### PR TITLE
Better detection of subpackages in apiVersion in uptest manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 PROVIDER_NAME := aws
 PROJECT_NAME := provider-$(PROVIDER_NAME)
 PROJECT_REPO := github.com/upbound/$(PROJECT_NAME)
+PROJECT_API_GROUP := $(PROVIDER_NAME).upbound.io
 
 export TERRAFORM_VERSION := 1.5.5
 export TERRAFORM_PROVIDER_VERSION := 5.31.0
@@ -227,11 +228,7 @@ family-e2e:
 	@(INSTALL_APIS=""; \
 	for m in $$(tr ',' ' ' <<< $${UPTEST_EXAMPLE_LIST}); do \
 	  	$(INFO) Processing the example manifest "$${m}"; \
-		for api in $$(sed -nE 's/^apiVersion: *(.+)/\1/p' "$${m}" | cut -d. -f1); do \
-		    if [[ $${api} == "v1" ]]; then \
-		        $(INFO) v1 is not a valid provider. Skipping...; \
-		        continue; \
-		    fi; \
+		for api in $$(sed -nE 's/^apiVersion: *([-a-z0-9]+)\.$(PROJECT_API_GROUP)\/(v\w+)/\1/p' "$${m}" ); do \
 			if [[ $${INSTALL_APIS} =~ " $${api} " ]]; then \
 				$(INFO) Resource provider $(PROJECT_NAME)-$${api} is already installed. Skipping...; \
 				continue; \

--- a/examples/iam/v1beta1/role-with-drc.yaml
+++ b/examples/iam/v1beta1/role-with-drc.yaml
@@ -1,0 +1,76 @@
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Role
+metadata:
+  annotations:
+    meta.upbound.io/example-id: iam/v1beta1/role
+  labels:
+    testing.upbound.io/example-name: role
+  name: sample-role
+spec:
+  forProvider:
+    assumeRolePolicy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "eks.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+          }
+        ]
+      }
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: RolePolicyAttachment
+metadata:
+  annotations:
+    meta.upbound.io/example-id: iam/v1beta1/role
+  labels:
+    testing.upbound.io/example-name: role
+  name: sample-policy-attachment
+spec:
+  forProvider:
+    policyArnSelector:
+      matchLabels:
+        testing.upbound.io/example-name: role
+    roleSelector:
+      matchLabels:
+        testing.upbound.io/example-name: role
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Policy
+metadata:
+  annotations:
+    meta.upbound.io/example-id: iam/v1beta1/role
+  labels:
+    testing.upbound.io/example-name: role
+  name: sample-user-policy
+spec:
+  forProvider:
+    policy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+              "Sid": "VisualEditor0",
+              "Effect": "Allow",
+              "Action": "elastic-inference:Connect",
+              "Resource": "*"
+          }
+        ]
+      }
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
+metadata:
+  name: placeholder
+  labels:
+    testing.upbound.io/example-name: role
+spec:
+  deploymentTemplate:
+    metadata:
+      annotations:
+        unused: empty
+


### PR DESCRIPTION


<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This allows resources in non-provider api groups to be specified if necessary.

I was trying to use a crossplane Usage resource in uptest, and it failed because the existing regex tried to figure out which provider-aws subpackage the crossplane api group was in, and failed. This change would remove one of the barriers to supporting more resource types in an uptest example, if that's necessary.
I have:

- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
It hasn't yet, that's why this is a draft.