### PR TITLE
Unify TF AWS provider configuration logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ kustomize-crds: output.init $(KUSTOMIZE) $(YQ)
 	@rm -fr $(OUTPUT_DIR)/package || $(FAIL)
 	@cp -R package $(OUTPUT_DIR) && \
 	cd $(OUTPUT_DIR)/package/crds && \
-	kustomize create --autodetect || $(FAIL)
+	$(KUSTOMIZE) create --autodetect || $(FAIL)
 	@export YQ=$(YQ) && \
 	XDG_CONFIG_HOME=$(PWD)/package $(KUSTOMIZE) build --enable-alpha-plugins $(OUTPUT_DIR)/package/kustomize -o $(OUTPUT_DIR)/package/crds.yaml || $(FAIL)
 	@$(OK) Kustomizing CRDs.

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -43,7 +43,7 @@ func main() {
 	if err != nil {
 		panic(fmt.Sprintf("cannot calculate the absolute path with %s", *repoRoot))
 	}
-	p, _, err := config.GetProvider(context.Background(), true)
+	p, err := config.GetProvider(context.Background(), true)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	dumpGeneratedResourceList(p, generatedResourceList)
 	dumpSkippedResourcesCSV(p, skippedResourcesCSV)

--- a/cmd/provider/accessanalyzer/zz_main.go
+++ b/cmd/provider/accessanalyzer/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/account/zz_main.go
+++ b/cmd/provider/account/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/acm/zz_main.go
+++ b/cmd/provider/acm/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/acmpca/zz_main.go
+++ b/cmd/provider/acmpca/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/amp/zz_main.go
+++ b/cmd/provider/amp/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/amplify/zz_main.go
+++ b/cmd/provider/amplify/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/apigateway/zz_main.go
+++ b/cmd/provider/apigateway/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/apigatewayv2/zz_main.go
+++ b/cmd/provider/apigatewayv2/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/appautoscaling/zz_main.go
+++ b/cmd/provider/appautoscaling/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/appconfig/zz_main.go
+++ b/cmd/provider/appconfig/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/appflow/zz_main.go
+++ b/cmd/provider/appflow/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/appintegrations/zz_main.go
+++ b/cmd/provider/appintegrations/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/applicationinsights/zz_main.go
+++ b/cmd/provider/applicationinsights/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/appmesh/zz_main.go
+++ b/cmd/provider/appmesh/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/apprunner/zz_main.go
+++ b/cmd/provider/apprunner/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/appstream/zz_main.go
+++ b/cmd/provider/appstream/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/appsync/zz_main.go
+++ b/cmd/provider/appsync/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/athena/zz_main.go
+++ b/cmd/provider/athena/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/autoscaling/zz_main.go
+++ b/cmd/provider/autoscaling/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/autoscalingplans/zz_main.go
+++ b/cmd/provider/autoscalingplans/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/backup/zz_main.go
+++ b/cmd/provider/backup/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/batch/zz_main.go
+++ b/cmd/provider/batch/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/budgets/zz_main.go
+++ b/cmd/provider/budgets/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/ce/zz_main.go
+++ b/cmd/provider/ce/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/chime/zz_main.go
+++ b/cmd/provider/chime/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/cloud9/zz_main.go
+++ b/cmd/provider/cloud9/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/cloudcontrol/zz_main.go
+++ b/cmd/provider/cloudcontrol/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/cloudformation/zz_main.go
+++ b/cmd/provider/cloudformation/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/cloudfront/zz_main.go
+++ b/cmd/provider/cloudfront/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/cloudsearch/zz_main.go
+++ b/cmd/provider/cloudsearch/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/cloudtrail/zz_main.go
+++ b/cmd/provider/cloudtrail/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/cloudwatch/zz_main.go
+++ b/cmd/provider/cloudwatch/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/cloudwatchevents/zz_main.go
+++ b/cmd/provider/cloudwatchevents/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/cloudwatchlogs/zz_main.go
+++ b/cmd/provider/cloudwatchlogs/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/codecommit/zz_main.go
+++ b/cmd/provider/codecommit/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/codepipeline/zz_main.go
+++ b/cmd/provider/codepipeline/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/codestarconnections/zz_main.go
+++ b/cmd/provider/codestarconnections/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/codestarnotifications/zz_main.go
+++ b/cmd/provider/codestarnotifications/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/cognitoidentity/zz_main.go
+++ b/cmd/provider/cognitoidentity/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/cognitoidp/zz_main.go
+++ b/cmd/provider/cognitoidp/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/config/zz_main.go
+++ b/cmd/provider/config/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/configservice/zz_main.go
+++ b/cmd/provider/configservice/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/connect/zz_main.go
+++ b/cmd/provider/connect/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/cur/zz_main.go
+++ b/cmd/provider/cur/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/dataexchange/zz_main.go
+++ b/cmd/provider/dataexchange/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/datapipeline/zz_main.go
+++ b/cmd/provider/datapipeline/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/datasync/zz_main.go
+++ b/cmd/provider/datasync/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/dax/zz_main.go
+++ b/cmd/provider/dax/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/deploy/zz_main.go
+++ b/cmd/provider/deploy/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/detective/zz_main.go
+++ b/cmd/provider/detective/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/devicefarm/zz_main.go
+++ b/cmd/provider/devicefarm/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/directconnect/zz_main.go
+++ b/cmd/provider/directconnect/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/dlm/zz_main.go
+++ b/cmd/provider/dlm/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/dms/zz_main.go
+++ b/cmd/provider/dms/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/docdb/zz_main.go
+++ b/cmd/provider/docdb/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/ds/zz_main.go
+++ b/cmd/provider/ds/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/dynamodb/zz_main.go
+++ b/cmd/provider/dynamodb/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/ec2/zz_main.go
+++ b/cmd/provider/ec2/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/ecr/zz_main.go
+++ b/cmd/provider/ecr/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/ecrpublic/zz_main.go
+++ b/cmd/provider/ecrpublic/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/ecs/zz_main.go
+++ b/cmd/provider/ecs/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/efs/zz_main.go
+++ b/cmd/provider/efs/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/eks/zz_main.go
+++ b/cmd/provider/eks/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/elasticache/zz_main.go
+++ b/cmd/provider/elasticache/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/elasticbeanstalk/zz_main.go
+++ b/cmd/provider/elasticbeanstalk/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/elasticsearch/zz_main.go
+++ b/cmd/provider/elasticsearch/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/elastictranscoder/zz_main.go
+++ b/cmd/provider/elastictranscoder/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/elb/zz_main.go
+++ b/cmd/provider/elb/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/elbv2/zz_main.go
+++ b/cmd/provider/elbv2/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/emr/zz_main.go
+++ b/cmd/provider/emr/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/emrserverless/zz_main.go
+++ b/cmd/provider/emrserverless/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/evidently/zz_main.go
+++ b/cmd/provider/evidently/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/firehose/zz_main.go
+++ b/cmd/provider/firehose/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/fis/zz_main.go
+++ b/cmd/provider/fis/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/fsx/zz_main.go
+++ b/cmd/provider/fsx/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/gamelift/zz_main.go
+++ b/cmd/provider/gamelift/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/glacier/zz_main.go
+++ b/cmd/provider/glacier/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/globalaccelerator/zz_main.go
+++ b/cmd/provider/globalaccelerator/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/glue/zz_main.go
+++ b/cmd/provider/glue/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/grafana/zz_main.go
+++ b/cmd/provider/grafana/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/guardduty/zz_main.go
+++ b/cmd/provider/guardduty/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/iam/zz_main.go
+++ b/cmd/provider/iam/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/identitystore/zz_main.go
+++ b/cmd/provider/identitystore/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/imagebuilder/zz_main.go
+++ b/cmd/provider/imagebuilder/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/inspector/zz_main.go
+++ b/cmd/provider/inspector/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/inspector2/zz_main.go
+++ b/cmd/provider/inspector2/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/iot/zz_main.go
+++ b/cmd/provider/iot/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/ivs/zz_main.go
+++ b/cmd/provider/ivs/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/kafka/zz_main.go
+++ b/cmd/provider/kafka/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/kendra/zz_main.go
+++ b/cmd/provider/kendra/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/keyspaces/zz_main.go
+++ b/cmd/provider/keyspaces/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/kinesis/zz_main.go
+++ b/cmd/provider/kinesis/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/kinesisanalytics/zz_main.go
+++ b/cmd/provider/kinesisanalytics/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/kinesisanalyticsv2/zz_main.go
+++ b/cmd/provider/kinesisanalyticsv2/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/kinesisvideo/zz_main.go
+++ b/cmd/provider/kinesisvideo/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/kms/zz_main.go
+++ b/cmd/provider/kms/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/lakeformation/zz_main.go
+++ b/cmd/provider/lakeformation/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/lambda/zz_main.go
+++ b/cmd/provider/lambda/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/lexmodels/zz_main.go
+++ b/cmd/provider/lexmodels/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/licensemanager/zz_main.go
+++ b/cmd/provider/licensemanager/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/lightsail/zz_main.go
+++ b/cmd/provider/lightsail/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/location/zz_main.go
+++ b/cmd/provider/location/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/macie2/zz_main.go
+++ b/cmd/provider/macie2/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/mediaconvert/zz_main.go
+++ b/cmd/provider/mediaconvert/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/medialive/zz_main.go
+++ b/cmd/provider/medialive/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/mediapackage/zz_main.go
+++ b/cmd/provider/mediapackage/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/mediastore/zz_main.go
+++ b/cmd/provider/mediastore/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/memorydb/zz_main.go
+++ b/cmd/provider/memorydb/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/monolith/zz_main.go
+++ b/cmd/provider/monolith/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/mq/zz_main.go
+++ b/cmd/provider/mq/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/neptune/zz_main.go
+++ b/cmd/provider/neptune/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/networkfirewall/zz_main.go
+++ b/cmd/provider/networkfirewall/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/networkmanager/zz_main.go
+++ b/cmd/provider/networkmanager/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/opensearch/zz_main.go
+++ b/cmd/provider/opensearch/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/opensearchserverless/zz_main.go
+++ b/cmd/provider/opensearchserverless/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/opsworks/zz_main.go
+++ b/cmd/provider/opsworks/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/organizations/zz_main.go
+++ b/cmd/provider/organizations/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/pinpoint/zz_main.go
+++ b/cmd/provider/pinpoint/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/qldb/zz_main.go
+++ b/cmd/provider/qldb/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/quicksight/zz_main.go
+++ b/cmd/provider/quicksight/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/ram/zz_main.go
+++ b/cmd/provider/ram/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/rds/zz_main.go
+++ b/cmd/provider/rds/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/redshift/zz_main.go
+++ b/cmd/provider/redshift/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/redshiftserverless/zz_main.go
+++ b/cmd/provider/redshiftserverless/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/resourcegroups/zz_main.go
+++ b/cmd/provider/resourcegroups/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/rolesanywhere/zz_main.go
+++ b/cmd/provider/rolesanywhere/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/route53/zz_main.go
+++ b/cmd/provider/route53/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/route53recoverycontrolconfig/zz_main.go
+++ b/cmd/provider/route53recoverycontrolconfig/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/route53recoveryreadiness/zz_main.go
+++ b/cmd/provider/route53recoveryreadiness/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/route53resolver/zz_main.go
+++ b/cmd/provider/route53resolver/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/rum/zz_main.go
+++ b/cmd/provider/rum/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/s3/zz_main.go
+++ b/cmd/provider/s3/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/s3control/zz_main.go
+++ b/cmd/provider/s3control/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/sagemaker/zz_main.go
+++ b/cmd/provider/sagemaker/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/scheduler/zz_main.go
+++ b/cmd/provider/scheduler/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/schemas/zz_main.go
+++ b/cmd/provider/schemas/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/secretsmanager/zz_main.go
+++ b/cmd/provider/secretsmanager/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/securityhub/zz_main.go
+++ b/cmd/provider/securityhub/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/serverlessrepo/zz_main.go
+++ b/cmd/provider/serverlessrepo/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/servicecatalog/zz_main.go
+++ b/cmd/provider/servicecatalog/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/servicediscovery/zz_main.go
+++ b/cmd/provider/servicediscovery/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/servicequotas/zz_main.go
+++ b/cmd/provider/servicequotas/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/ses/zz_main.go
+++ b/cmd/provider/ses/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/sesv2/zz_main.go
+++ b/cmd/provider/sesv2/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/sfn/zz_main.go
+++ b/cmd/provider/sfn/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/signer/zz_main.go
+++ b/cmd/provider/signer/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/simpledb/zz_main.go
+++ b/cmd/provider/simpledb/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/sns/zz_main.go
+++ b/cmd/provider/sns/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/sqs/zz_main.go
+++ b/cmd/provider/sqs/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/ssm/zz_main.go
+++ b/cmd/provider/ssm/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/ssoadmin/zz_main.go
+++ b/cmd/provider/ssoadmin/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/swf/zz_main.go
+++ b/cmd/provider/swf/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/timestreamwrite/zz_main.go
+++ b/cmd/provider/timestreamwrite/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/transcribe/zz_main.go
+++ b/cmd/provider/transcribe/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/transfer/zz_main.go
+++ b/cmd/provider/transfer/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/vpc/zz_main.go
+++ b/cmd/provider/vpc/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/waf/zz_main.go
+++ b/cmd/provider/waf/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/wafregional/zz_main.go
+++ b/cmd/provider/wafregional/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/wafv2/zz_main.go
+++ b/cmd/provider/wafv2/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/workspaces/zz_main.go
+++ b/cmd/provider/workspaces/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/cmd/provider/xray/zz_main.go
+++ b/cmd/provider/xray/zz_main.go
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/config/registry.go
+++ b/config/registry.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	// Note(ezgidemirel): we are importing this to embed provider schema document
 	_ "embed"
+
 	"github.com/crossplane/upjet/pkg/config"
 	"github.com/crossplane/upjet/pkg/registry/reference"
 	conversiontfjson "github.com/crossplane/upjet/pkg/types/conversion/tfjson"

--- a/config/registry.go
+++ b/config/registry.go
@@ -8,9 +8,6 @@ import (
 	"context"
 	// Note(ezgidemirel): we are importing this to embed provider schema document
 	_ "embed"
-	"reflect"
-	"unsafe"
-
 	"github.com/crossplane/upjet/pkg/config"
 	"github.com/crossplane/upjet/pkg/registry/reference"
 	conversiontfjson "github.com/crossplane/upjet/pkg/types/conversion/tfjson"
@@ -80,7 +77,7 @@ func getProviderSchema(s string) (*schema.Provider, error) {
 // configuration is being read for the code generation pipelines.
 // In that case, we will only use the JSON schema for generating
 // the CRDs.
-func GetProvider(ctx context.Context, generationProvider bool) (*config.Provider, *xpprovider.AWSClient, error) {
+func GetProvider(ctx context.Context, generationProvider bool) (*config.Provider, error) {
 	var p *schema.Provider
 	var fwProvider fwprovider.Provider
 	var err error
@@ -91,16 +88,7 @@ func GetProvider(ctx context.Context, generationProvider bool) (*config.Provider
 		fwProvider, p, err = xpprovider.GetProvider(ctx)
 	}
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "cannot get the Terraform provider schema with generation mode set to %t", generationProvider)
-	}
-	// we set schema.Provider's meta to nil because p.Configure modifies
-	// a singleton pointer. This further assumes that the
-	// schema.Provider.Configure calls do not modify the global state
-	// represented by the config.Provider.TerraformProvider.
-	var awsClient *xpprovider.AWSClient
-	if !generationProvider {
-		// #nosec G103
-		awsClient = (*xpprovider.AWSClient)(unsafe.Pointer(reflect.ValueOf(p.Meta()).Pointer()))
+		return nil, errors.Wrapf(err, "cannot get the Terraform provider schema with generation mode set to %t", generationProvider)
 	}
 
 	modulePath := "github.com/upbound/provider-aws"
@@ -131,7 +119,6 @@ func GetProvider(ctx context.Context, generationProvider bool) (*config.Provider
 			injectFieldRenamingConversionFunctions(),
 		),
 	)
-	p.SetMeta(nil)
 	pc.BasePackages.ControllerMap["internal/controller/eks/clusterauth"] = "eks"
 
 	for _, configure := range ProviderConfiguration {
@@ -139,7 +126,7 @@ func GetProvider(ctx context.Context, generationProvider bool) (*config.Provider
 	}
 
 	pc.ConfigureResources()
-	return pc, awsClient, nil
+	return pc, nil
 }
 
 // CLIReconciledResourceList returns the list of resources that have external

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.24.0
 	github.com/aws/aws-sdk-go-v2/config v1.26.1
 	github.com/aws/aws-sdk-go-v2/credentials v1.16.12
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.10
 	github.com/aws/aws-sdk-go-v2/service/eks v1.35.5
 	github.com/aws/aws-sdk-go-v2/service/sts v1.26.5
 	github.com/aws/smithy-go v1.19.0
@@ -41,7 +42,6 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.49.2 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.4 // indirect
-	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.15.7 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.9 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.9 // indirect

--- a/hack/main.go.tmpl
+++ b/hack/main.go.tmpl
@@ -143,10 +143,9 @@ func main() {
 	kingpin.FatalIfError(resolverapis.BuildScheme(apis.AddToSchemes), "Cannot register the AWS APIs with the API resolver's runtime scheme")
 
 	ctx := context.Background()
-	provider, awsClient, err := config.GetProvider(ctx, false)
+	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
 	setupConfig.TerraformProvider = provider.TerraformProvider
-	setupConfig.AWSClient = awsClient
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  log,

--- a/internal/clients/aws.go
+++ b/internal/clients/aws.go
@@ -28,7 +28,6 @@ const (
 
 type SetupConfig struct {
 	TerraformProvider *schema.Provider
-	AWSClient         *xpprovider.AWSClient
 }
 
 func SelectTerraformSetup(config *SetupConfig) terraform.SetupFn { // nolint:gocyclo
@@ -134,11 +133,10 @@ func configureNoForkAWSClient(ctx context.Context, ps *terraform.Setup, config *
 	}
 
 	// only used for retrieving the ServicePackages from the singleton provider instance
-	// sharedMeta := config.AWSClient.ServicePackages
-	// #nosec G103
+	p := config.TerraformProvider.Meta()
 	tfAwsConnsClient, diags := tfAwsConnsCfg.GetClient(ctx, &xpprovider.AWSClient{
-		ServicePackages: config.AWSClient.ServicePackages,
-		// ServicePackages: (*xpprovider.AWSClient)(unsafe.Pointer(reflect.ValueOf(sharedMeta).Pointer())).ServicePackages,
+		// #nosec G103
+		ServicePackages: (*xpprovider.AWSClient)(unsafe.Pointer(reflect.ValueOf(p).Pointer())).ServicePackages,
 	})
 	if diags.HasError() {
 		return errors.Errorf("cannot construct TF AWS Client from TF AWS Config, %v", diags)

--- a/internal/clients/aws.go
+++ b/internal/clients/aws.go
@@ -6,16 +6,14 @@ package clients
 
 import (
 	"context"
-	"os"
 	"reflect"
 	"unsafe"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/upjet/pkg/terraform"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	tfsdk "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/hashicorp/terraform-provider-aws/xpprovider"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -25,23 +23,7 @@ import (
 )
 
 const (
-	// Terraform provider configuration keys for AWS credentials.
-	keyRegion                    = "region"
-	keyAccountId                 = "account_id"
-	keySessionToken              = "token"
-	keyAccessKeyID               = "access_key"
-	keySecretAccessKey           = "secret_key"
-	keyAssumeRoleWithWebIdentity = "assume_role_with_web_identity"
-	keyRoleArn                   = "role_arn"
-	keySessionName               = "session_name"
-	keyWebIdentityTokenFile      = "web_identity_token_file"
-	keyWebIdentityToken          = "web_identity_token"
-	keySkipCredsValidation       = "skip_credentials_validation"
-	keyS3UsePathStyle            = "s3_use_path_style"
-	keySkipMetadataApiCheck      = "skip_metadata_api_check"
-	keySkipRegionValidation      = "skip_region_validation"
-	keySkipReqAccountId          = "skip_requesting_account_id"
-	keyEndpoints                 = "endpoints"
+	keyAccountId = "account_id"
 )
 
 type SetupConfig struct {
@@ -52,12 +34,16 @@ type SetupConfig struct {
 func SelectTerraformSetup(config *SetupConfig) terraform.SetupFn { // nolint:gocyclo
 	return func(ctx context.Context, c client.Client, mg resource.Managed) (terraform.Setup, error) {
 		pc := &v1beta1.ProviderConfig{}
-		var err error
-		if err = c.Get(ctx, types.NamespacedName{Name: mg.GetProviderConfigReference().Name}, pc); err != nil {
+		if err := c.Get(ctx, types.NamespacedName{Name: mg.GetProviderConfigReference().Name}, pc); err != nil {
 			return terraform.Setup{}, errors.Wrapf(err, "cannot get referenced Provider: %s", mg.GetProviderConfigReference().Name)
 		}
+		t := resource.NewProviderConfigUsageTracker(c, &v1beta1.ProviderConfigUsage{})
+		if err := t.Track(ctx, mg); err != nil {
+			return terraform.Setup{}, errors.Wrap(err, "cannot track ProviderConfig usage")
+		}
+
 		ps := terraform.Setup{}
-		awsCfg, err := getAWSConfig(ctx, c, mg)
+		awsCfg, err := GetAWSConfigWithDefaultRegion(ctx, c, mg, pc)
 		if err != nil {
 			return terraform.Setup{}, errors.Wrap(err, "cannot get aws config")
 		} else if awsCfg == nil {
@@ -67,6 +53,7 @@ func SelectTerraformSetup(config *SetupConfig) terraform.SetupFn { // nolint:goc
 		if err != nil {
 			return terraform.Setup{}, errors.Wrap(err, "failed to retrieve aws credentials from aws config")
 		}
+
 		account := "000000000"
 		if !pc.Spec.SkipCredsValidation {
 			account, err = getAccountId(ctx, awsCfg, creds)
@@ -74,135 +61,18 @@ func SelectTerraformSetup(config *SetupConfig) terraform.SetupFn { // nolint:goc
 				return terraform.Setup{}, errors.Wrap(err, "cannot get account id")
 			}
 		}
-
 		ps.ClientMetadata = map[string]string{
 			keyAccountId: account,
 		}
-
-		if len(pc.Spec.AssumeRoleChain) > 0 || pc.Spec.Endpoint != nil {
-			err = DefaultTerraformSetupBuilder(ctx, pc, &ps, awsCfg, creds)
-			if err != nil {
-				return terraform.Setup{}, errors.Wrap(err, "cannot build terraform configuration")
-			}
-		} else {
-			err = pushDownTerraformSetupBuilder(ctx, c, pc, &ps, awsCfg)
-			if err != nil {
-				return terraform.Setup{}, errors.Wrap(err, "cannot build terraform configuration")
-			}
-		}
-
 		if config.TerraformProvider == nil {
 			return terraform.Setup{}, errors.New("terraform provider cannot be nil")
 		}
-
-		return ps, errors.Wrap(configureNoForkAWSClient(ctx, &ps, config), "could not configure the no-fork AWS client")
+		return ps, errors.Wrap(configureNoForkAWSClient(ctx, &ps, config, awsCfg, creds, pc), "could not configure the no-fork AWS client")
 	}
 }
 
-func pushDownTerraformSetupBuilder(ctx context.Context, c client.Client, pc *v1beta1.ProviderConfig, ps *terraform.Setup, cfg *aws.Config) error { //nolint:gocyclo
-	if len(pc.Spec.AssumeRoleChain) > 0 || pc.Spec.Endpoint != nil {
-		return errors.New("shared scheduler cannot be used because the length of assume role chain array " +
-			"is more than 0 or endpoint configuration is not nil")
-	}
-
-	ps.Configuration = map[string]any{
-		keyRegion: cfg.Region,
-	}
-
-	switch s := pc.Spec.Credentials.Source; s { //nolint:exhaustive
-	case authKeyWebIdentity:
-		if pc.Spec.Credentials.WebIdentity == nil {
-			return errors.New(`spec.credentials.webIdentity of ProviderConfig cannot be nil when the credential source is "WebIdentity"`)
-		}
-		webIdentityConfig := map[string]any{
-			keyRoleArn: aws.ToString(pc.Spec.Credentials.WebIdentity.RoleARN),
-		}
-		if pc.Spec.Credentials.WebIdentity.TokenConfig != nil {
-			tokenSelector := xpv1.CommonCredentialSelectors{
-				Fs:        pc.Spec.Credentials.WebIdentity.TokenConfig.Fs,
-				SecretRef: pc.Spec.Credentials.WebIdentity.TokenConfig.SecretRef,
-			}
-			creds, err := resource.CommonCredentialExtractor(ctx, pc.Spec.Credentials.WebIdentity.TokenConfig.Source, c, tokenSelector)
-			if err != nil {
-				return errors.Wrap(err, "cannot extract token")
-			}
-			webIdentityConfig[keyWebIdentityToken] = string(creds)
-		} else {
-			// fallback to deprecated behavior with environment variables
-			webIdentityConfig[keyWebIdentityTokenFile] = os.Getenv(envWebIdentityTokenFile)
-		}
-		if pc.Spec.Credentials.WebIdentity.RoleSessionName != "" {
-			webIdentityConfig[keySessionName] = pc.Spec.Credentials.WebIdentity.RoleSessionName
-		}
-		ps.Configuration[keyAssumeRoleWithWebIdentity] = []any{
-			webIdentityConfig,
-		}
-	case authKeyUpbound:
-		if pc.Spec.Credentials.Upbound == nil || pc.Spec.Credentials.Upbound.WebIdentity == nil {
-			return errors.New(`spec.credentials.upbound.webIdentity of ProviderConfig cannot be nil when the credential source is "Upbound"`)
-		}
-		webIdentityConfig := map[string]any{
-			keyRoleArn:              aws.ToString(pc.Spec.Credentials.Upbound.WebIdentity.RoleARN),
-			keyWebIdentityTokenFile: upboundProviderIdentityTokenFile,
-		}
-		if pc.Spec.Credentials.Upbound.WebIdentity.RoleSessionName != "" {
-			webIdentityConfig[keySessionName] = pc.Spec.Credentials.Upbound.WebIdentity.RoleSessionName
-		}
-		ps.Configuration[keyAssumeRoleWithWebIdentity] = []any{
-			webIdentityConfig,
-		}
-	case authKeySecret:
-		data, err := resource.CommonCredentialExtractor(ctx, s, c, pc.Spec.Credentials.CommonCredentialSelectors)
-		if err != nil {
-			return errors.Wrap(err, "cannot get credentials")
-		}
-		cfg, err = UseProviderSecret(ctx, data, DefaultSection, cfg.Region)
-		if err != nil {
-			return errors.Wrap(err, errAWSConfig)
-		}
-		creds, err := cfg.Credentials.Retrieve(ctx)
-		if err != nil {
-			return errors.Wrap(err, "failed to retrieve aws credentials from aws config")
-		}
-		ps.Configuration = map[string]any{
-			keyRegion:          cfg.Region,
-			keyAccessKeyID:     creds.AccessKeyID,
-			keySecretAccessKey: creds.SecretAccessKey,
-			keySessionToken:    creds.SessionToken,
-		}
-	}
-	return nil
-}
-
-func DefaultTerraformSetupBuilder(_ context.Context, pc *v1beta1.ProviderConfig, ps *terraform.Setup, cfg *aws.Config, creds aws.Credentials) error {
-	ps.Configuration = map[string]any{
-		keyRegion:               cfg.Region,
-		keyAccessKeyID:          creds.AccessKeyID,
-		keySecretAccessKey:      creds.SecretAccessKey,
-		keySessionToken:         creds.SessionToken,
-		keySkipCredsValidation:  pc.Spec.SkipCredsValidation,
-		keyS3UsePathStyle:       pc.Spec.S3UsePathStyle,
-		keySkipRegionValidation: pc.Spec.SkipRegionValidation,
-		keySkipMetadataApiCheck: pc.Spec.SkipMetadataApiCheck,
-		keySkipReqAccountId:     pc.Spec.SkipReqAccountId,
-	}
-
-	if pc.Spec.Endpoint != nil {
-		if pc.Spec.Endpoint.URL.Static != nil {
-			if len(pc.Spec.Endpoint.Services) > 0 && *pc.Spec.Endpoint.URL.Static == "" {
-				return errors.New("endpoint.url.static cannot be empty")
-			} else {
-				endpoints := make(map[string]string)
-				for _, service := range pc.Spec.Endpoint.Services {
-					endpoints[service] = aws.ToString(pc.Spec.Endpoint.URL.Static)
-				}
-				ps.Configuration[keyEndpoints] = []any{endpoints}
-			}
-		}
-	}
-	return nil
-}
-
+// getAccountId retrieves the account ID associated with the given credentials.
+// Results are cached.
 func getAccountId(ctx context.Context, cfg *aws.Config, creds aws.Credentials) (string, error) {
 	identity, err := GlobalCallerIdentityCache.GetCallerIdentity(ctx, *cfg, creds)
 	if err != nil {
@@ -211,8 +81,8 @@ func getAccountId(ctx context.Context, cfg *aws.Config, creds aws.Credentials) (
 	return *identity.Account, nil
 }
 
-func getAWSConfig(ctx context.Context, c client.Client, mg resource.Managed) (*aws.Config, error) {
-	cfg, err := GetAWSConfig(ctx, c, mg)
+func GetAWSConfigWithDefaultRegion(ctx context.Context, c client.Client, mg resource.Managed, pc *v1beta1.ProviderConfig) (*aws.Config, error) {
+	cfg, err := GetAWSConfigViaProviderConfig(ctx, c, mg, pc)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot get AWS config")
 	}
@@ -230,18 +100,58 @@ func (m *metaOnlyPrimary) Meta() any {
 	return m.meta
 }
 
-func configureNoForkAWSClient(ctx context.Context, ps *terraform.Setup, config *SetupConfig) error { //nolint:gocyclo
-	p := *config.TerraformProvider
-	diag := p.Configure(context.WithoutCancel(ctx), &tfsdk.ResourceConfig{
-		Config: ps.Configuration,
-	})
-	if diag != nil && diag.HasError() {
-		return errors.Errorf("failed to configure the provider: %v", diag)
+// configureNoForkAWSClient populates the supplied *terraform.Setup with
+// Terraform Plugin SDK style AWS client (Meta) and Terraform Plugin Framework
+// style FrameworkProvider
+func configureNoForkAWSClient(ctx context.Context, ps *terraform.Setup, config *SetupConfig, awsCfg *aws.Config, creds aws.Credentials, pc *v1beta1.ProviderConfig) error { //nolint:gocyclo
+	tfAwsConnsCfg := xpprovider.AWSConfig{
+		AccessKey:                     creds.AccessKeyID,
+		EC2MetadataServiceEnableState: imds.ClientDefaultEnableState,
+		Endpoints:                     map[string]string{},
+		Region:                        awsCfg.Region,
+		S3UsePathStyle:                pc.Spec.S3UsePathStyle,
+		SecretKey:                     creds.SecretAccessKey,
+		SkipCredsValidation:           true, // disabled to prevent extra AWS STS call
+		SkipRegionValidation:          pc.Spec.SkipRegionValidation,
+		SkipRequestingAccountId:       true, // disabled to prevent extra AWS STS call
+		Token:                         creds.SessionToken,
 	}
-	ps.Meta = p.Meta()
+
+	if pc.Spec.SkipMetadataApiCheck {
+		tfAwsConnsCfg.EC2MetadataServiceEnableState = imds.ClientEnabled
+	}
+
+	if pc.Spec.Endpoint != nil {
+		if pc.Spec.Endpoint.URL.Static != nil {
+			if len(pc.Spec.Endpoint.Services) > 0 && *pc.Spec.Endpoint.URL.Static == "" {
+				return errors.New("endpoint.url.static cannot be empty")
+			} else {
+				for _, service := range pc.Spec.Endpoint.Services {
+					tfAwsConnsCfg.Endpoints[service] = aws.ToString(pc.Spec.Endpoint.URL.Static)
+				}
+			}
+		}
+	}
+
+	// only used for retrieving the ServicePackages from the singleton provider instance
+	// sharedMeta := config.AWSClient.ServicePackages
 	// #nosec G103
-	(*xpprovider.AWSClient)(unsafe.Pointer(reflect.ValueOf(ps.Meta).Pointer())).ServicePackages = (*xpprovider.AWSClient)(unsafe.Pointer(reflect.ValueOf(config.AWSClient).Pointer())).ServicePackages
-	fwProvider := xpprovider.GetFrameworkProviderWithMeta(&metaOnlyPrimary{meta: p.Meta()})
+	tfAwsConnsClient, diags := tfAwsConnsCfg.GetClient(ctx, &xpprovider.AWSClient{
+		ServicePackages: config.AWSClient.ServicePackages,
+		// ServicePackages: (*xpprovider.AWSClient)(unsafe.Pointer(reflect.ValueOf(sharedMeta).Pointer())).ServicePackages,
+	})
+	if diags.HasError() {
+		return errors.Errorf("cannot construct TF AWS Client from TF AWS Config, %v", diags)
+	}
+	// accountID is already calculated/retrieved from Caller ID cache while
+	// obtaining AWS config. The terraform config is explicitly constructed
+	// to skip requesting account ID to prevent the extra STS call. Therefore,
+	// the resulting TF AWS Client has empty account ID.
+	// Fill with previously calculated account ID.
+	// No need for nil check on ps.ClientMetadata per golang spec.
+	tfAwsConnsClient.AccountID = ps.ClientMetadata[keyAccountId]
+	ps.Meta = tfAwsConnsClient
+	fwProvider := xpprovider.GetFrameworkProviderWithMeta(&metaOnlyPrimary{meta: tfAwsConnsClient})
 	ps.FrameworkProvider = fwProvider
 	return nil
 }

--- a/internal/controller/eks/clusterauth/controller.go
+++ b/internal/controller/eks/clusterauth/controller.go
@@ -75,7 +75,7 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := clients.GetAWSConfig(ctx, c.kube, mg)
+	cfg, err := clients.GetAWSConfigWithProviderUsage(ctx, c.kube, mg)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/eks/clusterauth/controller.go
+++ b/internal/controller/eks/clusterauth/controller.go
@@ -75,7 +75,7 @@ type connector struct {
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
-	cfg, err := clients.GetAWSConfigWithProviderUsage(ctx, c.kube, mg)
+	cfg, err := clients.GetAWSConfigWithTracking(ctx, c.kube, mg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description of your changes

refactors AWS client configuration logic with a single path.

Previously, the AWS config was following various paths due to:
- Terraform Provider Configuration does not support AssumeRoleChain with lengths > 1
- Terraform CLI was using the shared scheduler, which required configuration push-down
- `eks.clusterAuth` resource has a manual controller implementation, since it is not terraform-based
To handle these paths, a native AWS configuration was being constructed along with the terraform configuration attributes.
These were causing in a non-unified configuration path, and duplicated AWS STS API calls due to configuration being processed by the native method and Terraform provider configure for no-fork.

Since the TF CLI is removed all relevant configuration paths can be removed to simplify.

This PR:
- removal of Terraform configuration block preparation for CLI
  - TerraformSetup.Configuration is no more present
  - no push-down configuration
- AWS configuration and credential resolution is solely handled by native AWS config.
  - All auth methods resolves down to the final AccessKey and Secret key (temporary) credentials
  - other configuration such as AssumeRoleChain and custom endpoints are also handled by the AWS config
- move away from native TF Provider's Configure() method
  - this method had a potential to introduce unintended side effects and bugs, due to its singleton nature.
  - instead, the native TF configuration object is directly filled using the already-obtained native AWS config & credentials.
  - This reduces the extra AWS STS calls for GetCallerIdentity and AssumeRole operations.

As a result this leads to 50% reduction in STS calls made per reconcile. Further improvement to STS calls will follow with a [cache implementation](https://github.com/crossplane-contrib/provider-upjet-aws/issues/997#issuecomment-1991658640). 

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested manually with following ProviderConfig specifications:
- Static creds from secret
- Static creds from secret with AssumeRoleChain
- WebIdentity
- WebIdentity with AssumeRoleChain 
- IRSA
- IRSA with AssumeRoleChain
- Upbound Auth  (thanks @turkenf for the test)
