### PR TITLE
Add a "Disk Cleanup" step as the first step in the lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,16 @@ jobs:
     if: needs.detect-noop.outputs.noop != 'true'
 
     steps:
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          tool-cache: true
+          large-packages: false
+          swap-storage: false
+
       - name: Checkout
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
         with:
@@ -87,6 +97,6 @@ jobs:
       - name: Lint
         env:
           GOLANGCI_LINT_CACHE: ${{ steps.go_cache.outputs.analysis_cache }}
-          SKIP_LINTER_ANALYSIS: ${{ steps.cache-analysis.outputs.cache-hit }}
+          SKIP_LINTER_ANALYSIS: false
           RUN_BUILDTAGGER: true
         run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 run:
   timeout: 60m
   show-stats: true
+  concurrency: 3
 
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"

--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ build-lint-cache: $(GOLANGCILINT)
 	@# minimum.
 	@(BUILDTAGGER_DOWNLOAD_URL=$(BUILDTAGGER_DOWNLOAD_URL) ./scripts/tag.sh && \
 	(([[ "${SKIP_LINTER_ANALYSIS}" == "true" ]] && $(OK) "Skipping analysis cache build phase because it's already been populated") && \
-	[[ "${SKIP_LINTER_ANALYSIS}" == "true" ]] || $(GOLANGCILINT) run -v --build-tags account,configregistry,configprovider,linter_run -v --concurrency 3 --disable-all --exclude '.*')) || $(FAIL)
+	[[ "${SKIP_LINTER_ANALYSIS}" == "true" ]] || $(GOLANGCILINT) run -v --build-tags account,configregistry,configprovider,linter_run -v --disable-all --exclude '.*')) || $(FAIL)
 	@$(OK) Running golangci-lint with the analysis cache building phase.
 
 delete-build-tags:


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR adds a `Disk Cleanup` step as the first step in the `lint` CI job to allow for more virtual memory space during linting and limits the concurrency of both of the first analysis cache construction and the second full linting phases to 3. Previously, the second phase was run with the max available concurrency as we had observed no issues with the standard Github hosted runners (label `ubuntu-22.04`) but in a [test PR](https://github.com/crossplane-contrib/provider-upjet-aws/pull/1210), we had some mixed results with this phase. So we will try configuring the second phase by limiting its concurrency. Please see [this comment](https://github.com/crossplane-contrib/provider-upjet-aws/pull/1210#issuecomment-1994372493) for some further details.

Furthermore, the first phase is now always run. In the experiments we did with this PR, even there's an analysis cache hit and the cache is restored from a previous run, the second phase can run out of memory even with a concurrency of 1. With the experiment done [here](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/8270708479/job/22628864566?pr=1211), running the cache construction phase again, which employs the build constraints, on top of the restored analysis cache allows the full linting phase to complete successfully. Please note that the full linting phase does *not* employ the build constraints, more precisely it uses the `all` build constraint, which effectively lints the whole code base (except the two hot spots discussed in the previous PRs). Looks like even there's cache hit, it's imperative to run the first phase with a subset of the code base (partitioned with the build constraints) is imperative for decreasing the memory needs of the second (full linting) phase.

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
A successful run (with a concurrency of 1) has been observed [here](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/8270708479/job/22628864566?pr=1211) and another successful re-run (again with a concurrency of 1) is [here](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/8270708479/job/22631048387?pr=1211). [This run](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/8272654302/job/22634938723?pr=1211) uses a concurrency of 3 and decreases the linter runner time from ~45 min to 32 min at the expense of increased memory usage. We will continue with limiting the concurrency to 3 and we may revisit this if the linter starts failing due to high memory consumption.