### PR TITLE
Generate license headers for setup.go files by consuming the latest commit of upjet

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/aws/smithy-go v1.19.0
 	github.com/crossplane/crossplane-runtime v1.16.0-rc.1.0.20240213134610-7fcb8c5cad6f
 	github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79
-	github.com/crossplane/upjet v1.3.0-rc.0.0.20240314111422-84abd051e678
+	github.com/crossplane/upjet v1.3.0-rc.0.0.20240314162745-2ef7077f6d16
 	github.com/go-ini/ini v1.46.0
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/terraform-json v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -266,8 +266,8 @@ github.com/crossplane/crossplane-runtime v1.16.0-rc.1.0.20240213134610-7fcb8c5ca
 github.com/crossplane/crossplane-runtime v1.16.0-rc.1.0.20240213134610-7fcb8c5cad6f/go.mod h1:kRcJjJQmBFrR2n/KhwL8wYS7xNfq3D8eK4JliEScOHI=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79 h1:HigXs5tEQxWz0fcj8hzbU2UAZgEM7wPe0XRFOsrtF8Y=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79/go.mod h1:+e4OaFlOcmr0JvINHl/yvEYBrZawzTgj6pQumOH1SS0=
-github.com/crossplane/upjet v1.3.0-rc.0.0.20240314111422-84abd051e678 h1:ilPa0mtKTydVhPFAea6wiGt/3tQF3qoeT9JPaPPUqAs=
-github.com/crossplane/upjet v1.3.0-rc.0.0.20240314111422-84abd051e678/go.mod h1:0bHLtnejZ9bDeyXuBb9MSOQLvKo3+aoTeUBO8N0dGSA=
+github.com/crossplane/upjet v1.3.0-rc.0.0.20240314162745-2ef7077f6d16 h1:rga2kPfuFXAeodP2+Ni8svo38BrfsdaaCv6yejn/+2M=
+github.com/crossplane/upjet v1.3.0-rc.0.0.20240314162745-2ef7077f6d16/go.mod h1:0bHLtnejZ9bDeyXuBb9MSOQLvKo3+aoTeUBO8N0dGSA=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/dave/jennifer v1.4.1 h1:XyqG6cn5RQsTj3qlWQTKlRGAyrTcsk1kUmWdZBzRjDw=

--- a/internal/controller/zz_accessanalyzer_setup.go
+++ b/internal/controller/zz_accessanalyzer_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_account_setup.go
+++ b/internal/controller/zz_account_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_acm_setup.go
+++ b/internal/controller/zz_acm_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_acmpca_setup.go
+++ b/internal/controller/zz_acmpca_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_amp_setup.go
+++ b/internal/controller/zz_amp_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_amplify_setup.go
+++ b/internal/controller/zz_amplify_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_apigateway_setup.go
+++ b/internal/controller/zz_apigateway_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_apigatewayv2_setup.go
+++ b/internal/controller/zz_apigatewayv2_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_appautoscaling_setup.go
+++ b/internal/controller/zz_appautoscaling_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_appconfig_setup.go
+++ b/internal/controller/zz_appconfig_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_appflow_setup.go
+++ b/internal/controller/zz_appflow_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_appintegrations_setup.go
+++ b/internal/controller/zz_appintegrations_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_applicationinsights_setup.go
+++ b/internal/controller/zz_applicationinsights_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_appmesh_setup.go
+++ b/internal/controller/zz_appmesh_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_apprunner_setup.go
+++ b/internal/controller/zz_apprunner_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_appstream_setup.go
+++ b/internal/controller/zz_appstream_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_appsync_setup.go
+++ b/internal/controller/zz_appsync_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_athena_setup.go
+++ b/internal/controller/zz_athena_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_autoscaling_setup.go
+++ b/internal/controller/zz_autoscaling_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_autoscalingplans_setup.go
+++ b/internal/controller/zz_autoscalingplans_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_backup_setup.go
+++ b/internal/controller/zz_backup_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_batch_setup.go
+++ b/internal/controller/zz_batch_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_budgets_setup.go
+++ b/internal/controller/zz_budgets_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_ce_setup.go
+++ b/internal/controller/zz_ce_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_chime_setup.go
+++ b/internal/controller/zz_chime_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloud9_setup.go
+++ b/internal/controller/zz_cloud9_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloudcontrol_setup.go
+++ b/internal/controller/zz_cloudcontrol_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloudformation_setup.go
+++ b/internal/controller/zz_cloudformation_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloudfront_setup.go
+++ b/internal/controller/zz_cloudfront_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloudsearch_setup.go
+++ b/internal/controller/zz_cloudsearch_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloudtrail_setup.go
+++ b/internal/controller/zz_cloudtrail_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloudwatch_setup.go
+++ b/internal/controller/zz_cloudwatch_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloudwatchevents_setup.go
+++ b/internal/controller/zz_cloudwatchevents_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cloudwatchlogs_setup.go
+++ b/internal/controller/zz_cloudwatchlogs_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_codecommit_setup.go
+++ b/internal/controller/zz_codecommit_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_codepipeline_setup.go
+++ b/internal/controller/zz_codepipeline_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_codestarconnections_setup.go
+++ b/internal/controller/zz_codestarconnections_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_codestarnotifications_setup.go
+++ b/internal/controller/zz_codestarnotifications_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cognitoidentity_setup.go
+++ b/internal/controller/zz_cognitoidentity_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cognitoidp_setup.go
+++ b/internal/controller/zz_cognitoidp_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_config_setup.go
+++ b/internal/controller/zz_config_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_configservice_setup.go
+++ b/internal/controller/zz_configservice_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_connect_setup.go
+++ b/internal/controller/zz_connect_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_cur_setup.go
+++ b/internal/controller/zz_cur_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_dataexchange_setup.go
+++ b/internal/controller/zz_dataexchange_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_datapipeline_setup.go
+++ b/internal/controller/zz_datapipeline_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_datasync_setup.go
+++ b/internal/controller/zz_datasync_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_dax_setup.go
+++ b/internal/controller/zz_dax_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_deploy_setup.go
+++ b/internal/controller/zz_deploy_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_detective_setup.go
+++ b/internal/controller/zz_detective_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_devicefarm_setup.go
+++ b/internal/controller/zz_devicefarm_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_directconnect_setup.go
+++ b/internal/controller/zz_directconnect_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_dlm_setup.go
+++ b/internal/controller/zz_dlm_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_dms_setup.go
+++ b/internal/controller/zz_dms_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_docdb_setup.go
+++ b/internal/controller/zz_docdb_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_ds_setup.go
+++ b/internal/controller/zz_ds_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_dynamodb_setup.go
+++ b/internal/controller/zz_dynamodb_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_ec2_setup.go
+++ b/internal/controller/zz_ec2_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_ecr_setup.go
+++ b/internal/controller/zz_ecr_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_ecrpublic_setup.go
+++ b/internal/controller/zz_ecrpublic_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_ecs_setup.go
+++ b/internal/controller/zz_ecs_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_efs_setup.go
+++ b/internal/controller/zz_efs_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_eks_setup.go
+++ b/internal/controller/zz_eks_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_elasticache_setup.go
+++ b/internal/controller/zz_elasticache_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_elasticbeanstalk_setup.go
+++ b/internal/controller/zz_elasticbeanstalk_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_elasticsearch_setup.go
+++ b/internal/controller/zz_elasticsearch_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_elastictranscoder_setup.go
+++ b/internal/controller/zz_elastictranscoder_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_elb_setup.go
+++ b/internal/controller/zz_elb_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_elbv2_setup.go
+++ b/internal/controller/zz_elbv2_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_emr_setup.go
+++ b/internal/controller/zz_emr_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_emrserverless_setup.go
+++ b/internal/controller/zz_emrserverless_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_evidently_setup.go
+++ b/internal/controller/zz_evidently_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_firehose_setup.go
+++ b/internal/controller/zz_firehose_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_fis_setup.go
+++ b/internal/controller/zz_fis_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_fsx_setup.go
+++ b/internal/controller/zz_fsx_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_gamelift_setup.go
+++ b/internal/controller/zz_gamelift_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_glacier_setup.go
+++ b/internal/controller/zz_glacier_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_globalaccelerator_setup.go
+++ b/internal/controller/zz_globalaccelerator_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_glue_setup.go
+++ b/internal/controller/zz_glue_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_grafana_setup.go
+++ b/internal/controller/zz_grafana_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_guardduty_setup.go
+++ b/internal/controller/zz_guardduty_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_iam_setup.go
+++ b/internal/controller/zz_iam_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_identitystore_setup.go
+++ b/internal/controller/zz_identitystore_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_imagebuilder_setup.go
+++ b/internal/controller/zz_imagebuilder_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_inspector2_setup.go
+++ b/internal/controller/zz_inspector2_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_inspector_setup.go
+++ b/internal/controller/zz_inspector_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_iot_setup.go
+++ b/internal/controller/zz_iot_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_ivs_setup.go
+++ b/internal/controller/zz_ivs_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_kafka_setup.go
+++ b/internal/controller/zz_kafka_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_kendra_setup.go
+++ b/internal/controller/zz_kendra_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_keyspaces_setup.go
+++ b/internal/controller/zz_keyspaces_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_kinesis_setup.go
+++ b/internal/controller/zz_kinesis_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_kinesisanalytics_setup.go
+++ b/internal/controller/zz_kinesisanalytics_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_kinesisanalyticsv2_setup.go
+++ b/internal/controller/zz_kinesisanalyticsv2_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_kinesisvideo_setup.go
+++ b/internal/controller/zz_kinesisvideo_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_kms_setup.go
+++ b/internal/controller/zz_kms_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_lakeformation_setup.go
+++ b/internal/controller/zz_lakeformation_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_lambda_setup.go
+++ b/internal/controller/zz_lambda_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_lexmodels_setup.go
+++ b/internal/controller/zz_lexmodels_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_licensemanager_setup.go
+++ b/internal/controller/zz_licensemanager_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_lightsail_setup.go
+++ b/internal/controller/zz_lightsail_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_location_setup.go
+++ b/internal/controller/zz_location_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_macie2_setup.go
+++ b/internal/controller/zz_macie2_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_mediaconvert_setup.go
+++ b/internal/controller/zz_mediaconvert_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_medialive_setup.go
+++ b/internal/controller/zz_medialive_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_mediapackage_setup.go
+++ b/internal/controller/zz_mediapackage_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_mediastore_setup.go
+++ b/internal/controller/zz_mediastore_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_memorydb_setup.go
+++ b/internal/controller/zz_memorydb_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_monolith_setup.go
+++ b/internal/controller/zz_monolith_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_mq_setup.go
+++ b/internal/controller/zz_mq_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_neptune_setup.go
+++ b/internal/controller/zz_neptune_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_networkfirewall_setup.go
+++ b/internal/controller/zz_networkfirewall_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_networkmanager_setup.go
+++ b/internal/controller/zz_networkmanager_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_opensearch_setup.go
+++ b/internal/controller/zz_opensearch_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_opensearchserverless_setup.go
+++ b/internal/controller/zz_opensearchserverless_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_opsworks_setup.go
+++ b/internal/controller/zz_opsworks_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_organizations_setup.go
+++ b/internal/controller/zz_organizations_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_pinpoint_setup.go
+++ b/internal/controller/zz_pinpoint_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_qldb_setup.go
+++ b/internal/controller/zz_qldb_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_quicksight_setup.go
+++ b/internal/controller/zz_quicksight_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_ram_setup.go
+++ b/internal/controller/zz_ram_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_rds_setup.go
+++ b/internal/controller/zz_rds_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_redshift_setup.go
+++ b/internal/controller/zz_redshift_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_redshiftserverless_setup.go
+++ b/internal/controller/zz_redshiftserverless_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_resourcegroups_setup.go
+++ b/internal/controller/zz_resourcegroups_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_rolesanywhere_setup.go
+++ b/internal/controller/zz_rolesanywhere_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_route53_setup.go
+++ b/internal/controller/zz_route53_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_route53recoverycontrolconfig_setup.go
+++ b/internal/controller/zz_route53recoverycontrolconfig_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_route53recoveryreadiness_setup.go
+++ b/internal/controller/zz_route53recoveryreadiness_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_route53resolver_setup.go
+++ b/internal/controller/zz_route53resolver_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_rum_setup.go
+++ b/internal/controller/zz_rum_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_s3_setup.go
+++ b/internal/controller/zz_s3_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_s3control_setup.go
+++ b/internal/controller/zz_s3control_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_sagemaker_setup.go
+++ b/internal/controller/zz_sagemaker_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_scheduler_setup.go
+++ b/internal/controller/zz_scheduler_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_schemas_setup.go
+++ b/internal/controller/zz_schemas_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_secretsmanager_setup.go
+++ b/internal/controller/zz_secretsmanager_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_securityhub_setup.go
+++ b/internal/controller/zz_securityhub_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_serverlessrepo_setup.go
+++ b/internal/controller/zz_serverlessrepo_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_servicecatalog_setup.go
+++ b/internal/controller/zz_servicecatalog_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_servicediscovery_setup.go
+++ b/internal/controller/zz_servicediscovery_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_servicequotas_setup.go
+++ b/internal/controller/zz_servicequotas_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_ses_setup.go
+++ b/internal/controller/zz_ses_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_sesv2_setup.go
+++ b/internal/controller/zz_sesv2_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_sfn_setup.go
+++ b/internal/controller/zz_sfn_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_signer_setup.go
+++ b/internal/controller/zz_signer_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_simpledb_setup.go
+++ b/internal/controller/zz_simpledb_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_sns_setup.go
+++ b/internal/controller/zz_sns_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_sqs_setup.go
+++ b/internal/controller/zz_sqs_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_ssm_setup.go
+++ b/internal/controller/zz_ssm_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_ssoadmin_setup.go
+++ b/internal/controller/zz_ssoadmin_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_swf_setup.go
+++ b/internal/controller/zz_swf_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_timestreamwrite_setup.go
+++ b/internal/controller/zz_timestreamwrite_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_transcribe_setup.go
+++ b/internal/controller/zz_transcribe_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_transfer_setup.go
+++ b/internal/controller/zz_transfer_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_vpc_setup.go
+++ b/internal/controller/zz_vpc_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_waf_setup.go
+++ b/internal/controller/zz_waf_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_wafregional_setup.go
+++ b/internal/controller/zz_wafregional_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_wafv2_setup.go
+++ b/internal/controller/zz_wafv2_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_workspaces_setup.go
+++ b/internal/controller/zz_workspaces_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (

--- a/internal/controller/zz_xray_setup.go
+++ b/internal/controller/zz_xray_setup.go
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package controller
 
 import (


### PR DESCRIPTION
### Description of your changes

This PR generates license headers for setup.go files by consuming the latest commit of upjet. More details please see https://github.com/crossplane/upjet/pull/376.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Uptest Run: https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/8293901983

[contribution process]: https://git.io/fj2m9
