### PR TITLE
fix(example): remove spec.forProvider.name for iam policy examples

### DIFF
--- a/examples/iam/v1beta1/user.yaml
+++ b/examples/iam/v1beta1/user.yaml
@@ -73,7 +73,6 @@ metadata:
     testing.upbound.io/example-name: user
 spec:
   forProvider:
-    name: user-policy-${Rand.RFC1123Subdomain}
     policy: |
       {
         "Version": "2012-10-17",


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes
remove spec.forProvider.name for iam policy examples

```
└─ CompositePostgreSQLInstance/my-db-aws-gb9qt      False    True    ReconcileError: ...nd=Policy): .spec.forProvider.name: field not declared in schema   
```

marketplace link: https://marketplace.upbound.io/providers/upbound/provider-aws-iam/v1.2.0/resources/iam.aws.upbound.io/Policy/v1beta1#doc:spec-forProvider
<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
