### PR TITLE
Add region parameter back to TF setup.Configuration

### DIFF
--- a/internal/clients/aws.go
+++ b/internal/clients/aws.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	keyAccountID = "account_id"
+	keyRegion    = "region"
 )
 
 type SetupConfig struct {
@@ -63,6 +64,10 @@ func SelectTerraformSetup(config *SetupConfig) terraform.SetupFn { // nolint:goc
 		}
 		ps.ClientMetadata = map[string]string{
 			keyAccountID: account,
+		}
+		// several external name configs depend on the setup.Configuration for templating region
+		ps.Configuration = map[string]any{
+			keyRegion: awsCfg.Region,
 		}
 		if config.TerraformProvider == nil {
 			return terraform.Setup{}, errors.New("terraform provider cannot be nil")


### PR DESCRIPTION
### Description of your changes
Fixes #1220 

#1204 removed obsolete TF-CLI related configuration codepath and switched to native TF SDK configuration.
As a result of native SDK configuration, `terraform.Setup.Configuration` was no longer needed to configure TF AWS client and we cease

However, several external name configurations which use external name templates, still rely on `terraform.Setup.Configuration` map to obtain `region` value. 

The change adds the `region` parameter back to `terraform.Setup.Configuration`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

With uptest, create resources that uses ` .setup.configuration` in their external name configs