### PR TITLE
Log a deprecation message when the monolithic provider is run

### DIFF
--- a/cmd/provider/monolith/zz_main.go
+++ b/cmd/provider/monolith/zz_main.go
@@ -98,6 +98,11 @@ func main() {
 		ctrl.SetLogger(zl)
 	}
 
+	logr.Info("warning: The monolithic package is deprecated in favor of the AWS family's resource packages " +
+		"and will no longer be maintained after 12 June 2024. Please consider switching to the family provider packages " +
+		"as we will no longer be publishing new versions of the monolithic package." +
+		"You can find more information about the provider families from the following link: https://docs.upbound.io/providers/provider-families/")
+
 	// currently, we configure the jitter to be the 5% of the poll interval
 	pollJitter := time.Duration(float64(*pollInterval) * 0.05)
 	logr.Debug("Starting", "sync-interval", syncInterval.String(),

--- a/hack/main.go.tmpl
+++ b/hack/main.go.tmpl
@@ -97,7 +97,12 @@ func main() {
 		// logger when we're running in debug mode.
 		ctrl.SetLogger(zl)
 	}
-
+{{ if eq .Group "monolith" }}
+	logr.Info("warning: The monolithic package is deprecated in favor of the AWS family's resource packages " +
+		"and will no longer be maintained after 12 June 2024. Please consider switching to the family provider packages " +
+		"as we will no longer be publishing new versions of the monolithic package." +
+		"You can find more information about the provider families from the following link: https://docs.upbound.io/providers/provider-families/")
+{{ end }}
 	// currently, we configure the jitter to be the 5% of the poll interval
 	pollJitter := time.Duration(float64(*pollInterval) * 0.05)
 	logr.Debug("Starting", "sync-interval", syncInterval.String(),

--- a/package/crossplane.yaml.tmpl
+++ b/package/crossplane.yaml.tmpl
@@ -13,6 +13,13 @@ metadata:
       Upbound's official Crossplane provider to manage Amazon Web Services (AWS)
       {{ .Service }} services in Kubernetes.
     meta.crossplane.io/readme: |
+      {{ if eq .Service "monolith" }}
+      ⚠️ **Deprecation Notice:** The monolithic package is deprecated in favor of the AWS family's
+      resource packages and will no longer be maintained after 12 June 2024. Please consider
+      switching to the [family provider packages](https://docs.upbound.io/providers/provider-families/)
+      as we will no longer be publishing new versions of the monolithic package.
+      \
+      {{ end }}
       Provider AWS is a Crossplane provider for [Amazon Web Services
       (AWS)](https://aws.amazon.com/) developed and supported by Upbound.
       Available resources and their fields can be found in the [Upbound


### PR DESCRIPTION
### Description of your changes

As we are approaching the end of support for the monolithic AWS package, this PR introduces:

- Info logs in the monolithic provider's output that communicate the deprecation and the next steps.
- A deprecation message in the monolithic packages marketplace listing.
- No deprecation message in a resource provider's marketplace listing.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
