### PR TITLE
Cache AWS Config's CredentialsProvider to reduce STS calls

### DIFF
--- a/cmd/provider/accessanalyzer/zz_main.go
+++ b/cmd/provider/accessanalyzer/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/account/zz_main.go
+++ b/cmd/provider/account/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/acm/zz_main.go
+++ b/cmd/provider/acm/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/acmpca/zz_main.go
+++ b/cmd/provider/acmpca/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/amp/zz_main.go
+++ b/cmd/provider/amp/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/amplify/zz_main.go
+++ b/cmd/provider/amplify/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/apigateway/zz_main.go
+++ b/cmd/provider/apigateway/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/apigatewayv2/zz_main.go
+++ b/cmd/provider/apigatewayv2/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/appautoscaling/zz_main.go
+++ b/cmd/provider/appautoscaling/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/appconfig/zz_main.go
+++ b/cmd/provider/appconfig/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/appflow/zz_main.go
+++ b/cmd/provider/appflow/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/appintegrations/zz_main.go
+++ b/cmd/provider/appintegrations/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/applicationinsights/zz_main.go
+++ b/cmd/provider/applicationinsights/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/appmesh/zz_main.go
+++ b/cmd/provider/appmesh/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/apprunner/zz_main.go
+++ b/cmd/provider/apprunner/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/appstream/zz_main.go
+++ b/cmd/provider/appstream/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/appsync/zz_main.go
+++ b/cmd/provider/appsync/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/athena/zz_main.go
+++ b/cmd/provider/athena/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/autoscaling/zz_main.go
+++ b/cmd/provider/autoscaling/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/autoscalingplans/zz_main.go
+++ b/cmd/provider/autoscalingplans/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/backup/zz_main.go
+++ b/cmd/provider/backup/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/batch/zz_main.go
+++ b/cmd/provider/batch/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/budgets/zz_main.go
+++ b/cmd/provider/budgets/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/ce/zz_main.go
+++ b/cmd/provider/ce/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/chime/zz_main.go
+++ b/cmd/provider/chime/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/cloud9/zz_main.go
+++ b/cmd/provider/cloud9/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/cloudcontrol/zz_main.go
+++ b/cmd/provider/cloudcontrol/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/cloudformation/zz_main.go
+++ b/cmd/provider/cloudformation/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/cloudfront/zz_main.go
+++ b/cmd/provider/cloudfront/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/cloudsearch/zz_main.go
+++ b/cmd/provider/cloudsearch/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/cloudtrail/zz_main.go
+++ b/cmd/provider/cloudtrail/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/cloudwatch/zz_main.go
+++ b/cmd/provider/cloudwatch/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/cloudwatchevents/zz_main.go
+++ b/cmd/provider/cloudwatchevents/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/cloudwatchlogs/zz_main.go
+++ b/cmd/provider/cloudwatchlogs/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/codecommit/zz_main.go
+++ b/cmd/provider/codecommit/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/codepipeline/zz_main.go
+++ b/cmd/provider/codepipeline/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/codestarconnections/zz_main.go
+++ b/cmd/provider/codestarconnections/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/codestarnotifications/zz_main.go
+++ b/cmd/provider/codestarnotifications/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/cognitoidentity/zz_main.go
+++ b/cmd/provider/cognitoidentity/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/cognitoidp/zz_main.go
+++ b/cmd/provider/cognitoidp/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/config/zz_main.go
+++ b/cmd/provider/config/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/configservice/zz_main.go
+++ b/cmd/provider/configservice/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/connect/zz_main.go
+++ b/cmd/provider/connect/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/cur/zz_main.go
+++ b/cmd/provider/cur/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/dataexchange/zz_main.go
+++ b/cmd/provider/dataexchange/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/datapipeline/zz_main.go
+++ b/cmd/provider/datapipeline/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/datasync/zz_main.go
+++ b/cmd/provider/datasync/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/dax/zz_main.go
+++ b/cmd/provider/dax/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/deploy/zz_main.go
+++ b/cmd/provider/deploy/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/detective/zz_main.go
+++ b/cmd/provider/detective/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/devicefarm/zz_main.go
+++ b/cmd/provider/devicefarm/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/directconnect/zz_main.go
+++ b/cmd/provider/directconnect/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/dlm/zz_main.go
+++ b/cmd/provider/dlm/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/dms/zz_main.go
+++ b/cmd/provider/dms/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/docdb/zz_main.go
+++ b/cmd/provider/docdb/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/ds/zz_main.go
+++ b/cmd/provider/ds/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/dynamodb/zz_main.go
+++ b/cmd/provider/dynamodb/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/ec2/zz_main.go
+++ b/cmd/provider/ec2/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/ecr/zz_main.go
+++ b/cmd/provider/ecr/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/ecrpublic/zz_main.go
+++ b/cmd/provider/ecrpublic/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/ecs/zz_main.go
+++ b/cmd/provider/ecs/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/efs/zz_main.go
+++ b/cmd/provider/efs/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/eks/zz_main.go
+++ b/cmd/provider/eks/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/elasticache/zz_main.go
+++ b/cmd/provider/elasticache/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/elasticbeanstalk/zz_main.go
+++ b/cmd/provider/elasticbeanstalk/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/elasticsearch/zz_main.go
+++ b/cmd/provider/elasticsearch/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/elastictranscoder/zz_main.go
+++ b/cmd/provider/elastictranscoder/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/elb/zz_main.go
+++ b/cmd/provider/elb/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/elbv2/zz_main.go
+++ b/cmd/provider/elbv2/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/emr/zz_main.go
+++ b/cmd/provider/emr/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/emrserverless/zz_main.go
+++ b/cmd/provider/emrserverless/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/evidently/zz_main.go
+++ b/cmd/provider/evidently/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/firehose/zz_main.go
+++ b/cmd/provider/firehose/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/fis/zz_main.go
+++ b/cmd/provider/fis/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/fsx/zz_main.go
+++ b/cmd/provider/fsx/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/gamelift/zz_main.go
+++ b/cmd/provider/gamelift/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/glacier/zz_main.go
+++ b/cmd/provider/glacier/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/globalaccelerator/zz_main.go
+++ b/cmd/provider/globalaccelerator/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/glue/zz_main.go
+++ b/cmd/provider/glue/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/grafana/zz_main.go
+++ b/cmd/provider/grafana/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/guardduty/zz_main.go
+++ b/cmd/provider/guardduty/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/iam/zz_main.go
+++ b/cmd/provider/iam/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/identitystore/zz_main.go
+++ b/cmd/provider/identitystore/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/imagebuilder/zz_main.go
+++ b/cmd/provider/imagebuilder/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/inspector/zz_main.go
+++ b/cmd/provider/inspector/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/inspector2/zz_main.go
+++ b/cmd/provider/inspector2/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/iot/zz_main.go
+++ b/cmd/provider/iot/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/ivs/zz_main.go
+++ b/cmd/provider/ivs/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/kafka/zz_main.go
+++ b/cmd/provider/kafka/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/kendra/zz_main.go
+++ b/cmd/provider/kendra/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/keyspaces/zz_main.go
+++ b/cmd/provider/keyspaces/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/kinesis/zz_main.go
+++ b/cmd/provider/kinesis/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/kinesisanalytics/zz_main.go
+++ b/cmd/provider/kinesisanalytics/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/kinesisanalyticsv2/zz_main.go
+++ b/cmd/provider/kinesisanalyticsv2/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/kinesisvideo/zz_main.go
+++ b/cmd/provider/kinesisvideo/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/kms/zz_main.go
+++ b/cmd/provider/kms/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/lakeformation/zz_main.go
+++ b/cmd/provider/lakeformation/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/lambda/zz_main.go
+++ b/cmd/provider/lambda/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/lexmodels/zz_main.go
+++ b/cmd/provider/lexmodels/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/licensemanager/zz_main.go
+++ b/cmd/provider/licensemanager/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/lightsail/zz_main.go
+++ b/cmd/provider/lightsail/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/location/zz_main.go
+++ b/cmd/provider/location/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/macie2/zz_main.go
+++ b/cmd/provider/macie2/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/mediaconvert/zz_main.go
+++ b/cmd/provider/mediaconvert/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/medialive/zz_main.go
+++ b/cmd/provider/medialive/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/mediapackage/zz_main.go
+++ b/cmd/provider/mediapackage/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/mediastore/zz_main.go
+++ b/cmd/provider/mediastore/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/memorydb/zz_main.go
+++ b/cmd/provider/memorydb/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/monolith/zz_main.go
+++ b/cmd/provider/monolith/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -154,7 +153,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/mq/zz_main.go
+++ b/cmd/provider/mq/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/neptune/zz_main.go
+++ b/cmd/provider/neptune/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/networkfirewall/zz_main.go
+++ b/cmd/provider/networkfirewall/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/networkmanager/zz_main.go
+++ b/cmd/provider/networkmanager/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/opensearch/zz_main.go
+++ b/cmd/provider/opensearch/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/opensearchserverless/zz_main.go
+++ b/cmd/provider/opensearchserverless/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/opsworks/zz_main.go
+++ b/cmd/provider/opsworks/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/organizations/zz_main.go
+++ b/cmd/provider/organizations/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/pinpoint/zz_main.go
+++ b/cmd/provider/pinpoint/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/qldb/zz_main.go
+++ b/cmd/provider/qldb/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/quicksight/zz_main.go
+++ b/cmd/provider/quicksight/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/ram/zz_main.go
+++ b/cmd/provider/ram/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/rds/zz_main.go
+++ b/cmd/provider/rds/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/redshift/zz_main.go
+++ b/cmd/provider/redshift/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/redshiftserverless/zz_main.go
+++ b/cmd/provider/redshiftserverless/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/resourcegroups/zz_main.go
+++ b/cmd/provider/resourcegroups/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/rolesanywhere/zz_main.go
+++ b/cmd/provider/rolesanywhere/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/route53/zz_main.go
+++ b/cmd/provider/route53/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/route53recoverycontrolconfig/zz_main.go
+++ b/cmd/provider/route53recoverycontrolconfig/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/route53recoveryreadiness/zz_main.go
+++ b/cmd/provider/route53recoveryreadiness/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/route53resolver/zz_main.go
+++ b/cmd/provider/route53resolver/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/rum/zz_main.go
+++ b/cmd/provider/rum/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/s3/zz_main.go
+++ b/cmd/provider/s3/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/s3control/zz_main.go
+++ b/cmd/provider/s3control/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/sagemaker/zz_main.go
+++ b/cmd/provider/sagemaker/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/scheduler/zz_main.go
+++ b/cmd/provider/scheduler/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/schemas/zz_main.go
+++ b/cmd/provider/schemas/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/secretsmanager/zz_main.go
+++ b/cmd/provider/secretsmanager/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/securityhub/zz_main.go
+++ b/cmd/provider/securityhub/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/serverlessrepo/zz_main.go
+++ b/cmd/provider/serverlessrepo/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/servicecatalog/zz_main.go
+++ b/cmd/provider/servicecatalog/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/servicediscovery/zz_main.go
+++ b/cmd/provider/servicediscovery/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/servicequotas/zz_main.go
+++ b/cmd/provider/servicequotas/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/ses/zz_main.go
+++ b/cmd/provider/ses/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/sesv2/zz_main.go
+++ b/cmd/provider/sesv2/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/sfn/zz_main.go
+++ b/cmd/provider/sfn/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/signer/zz_main.go
+++ b/cmd/provider/signer/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/simpledb/zz_main.go
+++ b/cmd/provider/simpledb/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/sns/zz_main.go
+++ b/cmd/provider/sns/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/sqs/zz_main.go
+++ b/cmd/provider/sqs/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/ssm/zz_main.go
+++ b/cmd/provider/ssm/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/ssoadmin/zz_main.go
+++ b/cmd/provider/ssoadmin/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/swf/zz_main.go
+++ b/cmd/provider/swf/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/timestreamwrite/zz_main.go
+++ b/cmd/provider/timestreamwrite/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/transcribe/zz_main.go
+++ b/cmd/provider/transcribe/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/transfer/zz_main.go
+++ b/cmd/provider/transfer/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/vpc/zz_main.go
+++ b/cmd/provider/vpc/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/waf/zz_main.go
+++ b/cmd/provider/waf/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/wafregional/zz_main.go
+++ b/cmd/provider/wafregional/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/wafv2/zz_main.go
+++ b/cmd/provider/wafv2/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/workspaces/zz_main.go
+++ b/cmd/provider/workspaces/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/cmd/provider/xray/zz_main.go
+++ b/cmd/provider/xray/zz_main.go
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -149,7 +148,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/hack/main.go.tmpl
+++ b/hack/main.go.tmpl
@@ -84,7 +84,6 @@ func main() {
 		_ = app.Flag("terraform-native-provider-path", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform native provider path for shared execution.").Envar("TERRAFORM_NATIVE_PROVIDER_PATH").Hidden().Action(deprecationAction("terraform-native-provider-path")).String()
 		_ = app.Flag("terraform-provider-source", "[DEPRECATED: This option is no longer used and it will be removed in a future release.] Terraform provider source.").Envar("TERRAFORM_PROVIDER_SOURCE").Hidden().Action(deprecationAction("terraform-provider-source")).String()
 	)
-	setupConfig := &clients.SetupConfig{}
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 	log.Default().SetOutput(io.Discard)
 	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
@@ -154,7 +153,10 @@ func main() {
 	ctx := context.Background()
 	provider, err := config.GetProvider(ctx, false)
 	kingpin.FatalIfError(err, "Cannot initialize the provider configuration")
-	setupConfig.TerraformProvider = provider.TerraformProvider
+	setupConfig := &clients.SetupConfig{
+		Logger:            logr,
+		TerraformProvider: provider.TerraformProvider,
+	}
 	o := tjcontroller.Options{
 		Options: xpcontroller.Options{
 			Logger:                  logr,

--- a/internal/clients/aws.go
+++ b/internal/clients/aws.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/feature/ec2/imds"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	awsrequest "github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/smithy-go/middleware"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -27,8 +28,9 @@ import (
 )
 
 const (
-	keyAccountID = "account_id"
-	keyRegion    = "region"
+	keyAccountID        = "account_id"
+	keyRegion           = "region"
+	localstackAccountID = "000000000"
 )
 
 type SetupConfig struct {
@@ -56,28 +58,41 @@ func SelectTerraformSetup(config *SetupConfig) terraform.SetupFn { // nolint:goc
 			return terraform.Setup{}, errors.Wrap(err, "obtained aws config cannot be nil")
 		}
 
-		var creds aws.Credentials
-		if awsCredCache, ok := awsCfg.Credentials.(*aws.CredentialsCache); ok {
-			// only IRSA auth credentials are cached, other auth methods will skip
-			// the cache and call the downstream CredentialsCache.Retrieve()
-			creds, err = credsCache.RetrieveCredentials(ctx, pc, awsCfg.Region, awsCredCache)
-		} else {
-			config.Logger.Debug("Configured aws.CredentialProvider is not an aws.CredentialCache, skipping the provider credential cache...")
-			creds, err = awsCfg.Credentials.Retrieve(ctx)
-		}
+		// only IRSA auth credentials are currently cached, other auth methods
+		// will skip the cache and call the downstream
+		// CredentialsProvider.Retrieve().
+		credCache, err := credsCache.RetrieveCredentials(ctx, pc, awsCfg.Region, awsCfg.Credentials, func(ctx context.Context) (string, error) {
+			if pc.Spec.SkipCredsValidation {
+				// then we do not try to resolve the account ID and instead,
+				// return a constant value as before.
+				return localstackAccountID, nil
+			}
+			o, err := sts.NewFromConfig(*awsCfg).GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+			if err != nil {
+				return "", errors.Wrap(err, errGetCallerIdentityFailed)
+			}
+			return *o.Account, nil
+		})
 		if err != nil {
-			return terraform.Setup{}, errors.Wrap(err, "failed to retrieve aws credentials")
+			return terraform.Setup{}, errors.Wrap(err, "cache manager failure")
 		}
 
-		account := "000000000"
-		if !pc.Spec.SkipCredsValidation {
-			account, err = getAccountId(ctx, awsCfg, creds)
+		// if we are to retrieve the AWS account ID and if we have not already
+		// retrieved it via the credential cache, then we will utilize the
+		// identity cache.
+		// TODO: Replace the identity cache with the credential cache.
+		if !pc.Spec.SkipCredsValidation && credCache.accountID == "" {
+			credCache.accountID, err = getAccountId(ctx, awsCfg, credCache.creds)
 			if err != nil {
 				return terraform.Setup{}, errors.Wrap(err, "cannot get account id")
 			}
 		}
+		// just in case the localstack implementation relies on this...
+		if credCache.accountID == "" {
+			credCache.accountID = localstackAccountID
+		}
 		ps.ClientMetadata = map[string]string{
-			keyAccountID: account,
+			keyAccountID: credCache.accountID,
 		}
 		// several external name configs depend on the setup.Configuration for templating region
 		ps.Configuration = map[string]any{
@@ -86,7 +101,7 @@ func SelectTerraformSetup(config *SetupConfig) terraform.SetupFn { // nolint:goc
 		if config.TerraformProvider == nil {
 			return terraform.Setup{}, errors.New("terraform provider cannot be nil")
 		}
-		return ps, errors.Wrap(configureNoForkAWSClient(ctx, &ps, config, awsCfg.Region, creds, pc), "could not configure the no-fork AWS client")
+		return ps, errors.Wrap(configureNoForkAWSClient(ctx, &ps, config, awsCfg.Region, credCache.creds, pc), "could not configure the no-fork AWS client")
 	}
 }
 

--- a/internal/clients/aws.go
+++ b/internal/clients/aws.go
@@ -52,7 +52,10 @@ func SelectTerraformSetup(config *SetupConfig) terraform.SetupFn { // nolint:goc
 		} else if awsCfg == nil {
 			return terraform.Setup{}, errors.Wrap(err, "obtained aws config cannot be nil")
 		}
-		creds, err := awsCfg.Credentials.Retrieve(ctx)
+
+		// only IRSA auth credentials are cached, other auth methods will skip
+		// cache and call downstream Credentials.Retrieve() of given awsCfg
+		creds, err := GlobalAWSCredentialsProviderCache.RetrieveCredentials(ctx, pc, awsCfg)
 		if err != nil {
 			return terraform.Setup{}, errors.Wrap(err, "failed to retrieve aws credentials from aws config")
 		}

--- a/internal/clients/creds_cache.go
+++ b/internal/clients/creds_cache.go
@@ -18,25 +18,28 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/pkg/errors"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/upbound/provider-aws/apis/v1beta1"
 )
 
-// GlobalAWSCredentialsProviderCache is a global AWS CredentialsProvider cache to be used by all controllers.
+// GlobalAWSCredentialsProviderCache is a global AWS CredentialsProvider cache
+// to be used by all controllers.
 var GlobalAWSCredentialsProviderCache = NewAWSCredentialsProviderCache()
 
-// AWSCredentialsProviderCacheOption lets you configure *GlobalAWSCredentialsProviderCache.
+// AWSCredentialsProviderCacheOption lets you configure
+// a *GlobalAWSCredentialsProviderCache.
 type AWSCredentialsProviderCacheOption func(cache *AWSCredentialsProviderCache)
 
-// WithCacheMaxSize lets you override the default MaxSize for AWS CredentialsProvider cache.
+// WithCacheMaxSize lets you override the default MaxSize for
+// AWS CredentialsProvider cache.
 func WithCacheMaxSize(n int) AWSCredentialsProviderCacheOption {
 	return func(c *AWSCredentialsProviderCache) {
 		c.maxSize = n
 	}
 }
 
-// WithCacheStore lets you bootstrap AWS CredentialsProvider Cache with your own cache.
+// WithCacheStore lets you bootstrap AWS CredentialsProvider Cache with
+// your own cache.
 func WithCacheStore(cache map[string]*awsCredentialsProviderCacheEntry) AWSCredentialsProviderCacheOption {
 	return func(c *AWSCredentialsProviderCache) {
 		c.cache = cache
@@ -50,15 +53,14 @@ func WithCacheLogger(l logging.Logger) AWSCredentialsProviderCacheOption {
 	}
 }
 
-// NewAWSCredentialsProviderCache returns a new empty *AWSCredentialsProviderCache with the default GetAWSConfig method.
+// NewAWSCredentialsProviderCache returns a new empty
+// *AWSCredentialsProviderCache with the default GetAWSConfig method.
 func NewAWSCredentialsProviderCache(opts ...AWSCredentialsProviderCacheOption) *AWSCredentialsProviderCache {
-	// zl := zap.New(zap.UseDevMode(false))
-	logr := logging.NewLogrLogger(zap.New(zap.UseDevMode(false)).WithName("provider-aws-credentials-cache"))
 	c := &AWSCredentialsProviderCache{
 		cache:   map[string]*awsCredentialsProviderCacheEntry{},
 		maxSize: 100,
 		mu:      &sync.RWMutex{},
-		logger:  logr,
+		logger:  logging.NewNopLogger(),
 	}
 	for _, f := range opts {
 		f(c)
@@ -66,18 +68,21 @@ func NewAWSCredentialsProviderCache(opts ...AWSCredentialsProviderCacheOption) *
 	return c
 }
 
-// AWSCredentialsProviderCache holds aws.CredentialsProvider objects in memory so that
-// we don't need to make API calls to AWS in every reconciliation of every
-// resource. It has a maximum size that when it's reached, the entry that has
-// the oldest access time will be removed from the cache, i.e. FIFO on last access
-// time.
-// Note that there is no need to invalidate the values in the cache because they
-// never change, so we don't need concurrency-safety to prevent access to an
-// invalidated entry.
+// AWSCredentialsProviderCache holds aws.CredentialsProvider objects in memory
+// so that we don't need to make API calls to AWS in every reconciliation of
+//
+//	every resource. It has a maximum size that when it's reached, the entry
+//	that has the oldest access time will be removed from the cache,
+//	i.e. FIFO on last access time.
+//
+// Note that there is no need to invalidate the values in the cache because
+// they never change, so we don't need concurrency-safety to prevent access
+// to an invalidated entry.
 type AWSCredentialsProviderCache struct {
-	// cache holds the AWS Config with a unique cache key per provider configuration.
-	// key content includes the ProviderConfig's UUID and ResourceVersion and
-	// additional fields depending on the auth method
+	// cache holds the AWS Config with a unique cache key per
+	// provider configuration. Key content includes the ProviderConfig's UUID
+	// and ResourceVersion and additional fields depending on the auth method
+	// (currently only IRSA temporary credential caching is supported).
 	cache map[string]*awsCredentialsProviderCacheEntry
 
 	// maxSize is the maximum number of elements this cache can ever have.
@@ -86,84 +91,83 @@ type AWSCredentialsProviderCache struct {
 	// mu is used to make sure the cache map is concurrency-safe.
 	mu *sync.RWMutex
 
-	// logger is the logger for cache operations
+	// logger is the logger for cache operations.
 	logger logging.Logger
 }
 
 type awsCredentialsProviderCacheEntry struct {
-	*aws.Config
-	credProvider aws.CredentialsProvider
+	awsCredCache *aws.CredentialsCache
 	AccessedAt   time.Time
 }
 
-func (c *AWSCredentialsProviderCache) RetrieveCredentials(ctx context.Context, pc *v1beta1.ProviderConfig, awsCfg *aws.Config) (aws.Credentials, error) {
-	// cache key calculation tries to capture any parameter that could cause changes
-	// in the resulting AWS credentials, to ensure unique keys.
+func (c *AWSCredentialsProviderCache) RetrieveCredentials(ctx context.Context, pc *v1beta1.ProviderConfig, region string, awsCredCache *aws.CredentialsCache) (aws.Credentials, error) {
+	// Only IRSA authentication method credentials are cached currently
+	if pc.Spec.Credentials.Source != authKeyIRSA {
+		// skip cache for other/unimplemented credential types
+		return awsCredCache.Retrieve(ctx)
+	}
+	// cache key calculation tries to capture any parameter that
+	// could cause changes in the resulting AWS credentials,
+	// to ensure unique keys.
 	//
-	// Parameters that are directly available in the provider config, will generate
-	// unique cache keys through UUID and ResourceVersion of the ProviderConfig's
-	// k8s object, as they change when the provider config is modified.
+	// Parameters that are directly available in the provider config will
+	// generate unique cache keys through UUID and ResourceVersion of
+	// the ProviderConfig's k8s object, as they change when the provider
+	// config is modified.
 	//
-	// any other external parameter that have an effect on the resulting credentials
-	// and does not appear in the ProviderConfig directly (i.e. the same provider config
-	// content produces a different config), should be included in the cache key
+	// Any other external parameter that have an effect on the resulting
+	// credentials and does not appear in the ProviderConfig directly
+	// (i.e. the same provider config content produces a different config),
+	// should be included in the cache key.
 	cacheKeyParams := []string{
 		string(pc.UID),
 		pc.ResourceVersion,
-		awsCfg.Region,
+		region,
 		string(pc.Spec.Credentials.Source),
 	}
-
-	// Only IRSA authentication method credentials are cached currently
-	switch s := pc.Spec.Credentials.Source; s { //nolint:exhaustive
-	case authKeyIRSA:
-		tokenHash, err := hashTokenFile(os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE"))
-		if err != nil {
-			return aws.Credentials{}, errors.Wrap(err, "cannot calculate cache key for credentials")
-		}
-		cacheKeyParams = append(cacheKeyParams, authKeyIRSA, tokenHash, os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE"), os.Getenv("AWS_ROLE_ARN"))
-	default:
-		c.logger.Debug("skipping cache", "pc", pc.GroupVersionKind().String(), "authSource", s)
-		// skip cache for other/unimplemented credential types
-		return awsCfg.Credentials.Retrieve(ctx)
+	tokenHash, err := hashTokenFile(os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE"))
+	if err != nil {
+		return aws.Credentials{}, errors.Wrap(err, "cannot calculate the hash for the credentials file")
 	}
-
+	cacheKeyParams = append(cacheKeyParams, authKeyIRSA, tokenHash, os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE"), os.Getenv("AWS_ROLE_ARN"))
 	cacheKey := strings.Join(cacheKeyParams, ":")
-	c.logger.Debug("checking cache entry", "cacheKey", cacheKey, "pc", pc.GroupVersionKind().String())
+	c.logger.Debug("Checking cache entry", "cacheKey", cacheKey, "pc", pc.GroupVersionKind().String())
 	c.mu.RLock()
-	cacheEntry, ok := c.cache[cacheKey]
+	cacheEntry := c.cache[cacheKey]
+	lastAccess := cacheEntry.AccessedAt
 	c.mu.RUnlock()
 
 	// TODO: consider implementing a TTL even though the cached entry is valid
 	// cache hit
-	if ok {
-		c.logger.Debug("cache hit", "cacheKey", cacheKey, "pc", pc.GroupVersionKind().String())
+	if cacheEntry != nil {
+		c.logger.Debug("Cache hit", "cacheKey", cacheKey, "pc", pc.GroupVersionKind().String())
 		// since this is a hot-path in the execution, do not always update
 		// the last access times, it is fine to evict the LRU entry on a less
 		// granular precision.
-		if time.Since(cacheEntry.AccessedAt) > 10*time.Minute {
+		if time.Since(lastAccess) > 10*time.Minute {
 			c.mu.Lock()
 			cacheEntry.AccessedAt = time.Now()
 			c.mu.Unlock()
 		}
-		return cacheEntry.credProvider.Retrieve(ctx)
+		return cacheEntry.awsCredCache.Retrieve(ctx)
 	}
 
 	// cache miss
-	c.logger.Debug("cache miss", "cacheKey", cacheKey, "pc", pc.GroupVersionKind().String())
+	c.logger.Debug("Cache miss", "cacheKey", cacheKey, "pc", pc.GroupVersionKind().String())
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.makeRoom()
 	c.cache[cacheKey] = &awsCredentialsProviderCacheEntry{
-		credProvider: awsCfg.Credentials,
+		awsCredCache: awsCredCache,
 		AccessedAt:   time.Now(),
 	}
-	return awsCfg.Credentials.Retrieve(ctx)
+	c.mu.Unlock()
+	return awsCredCache.Retrieve(ctx)
 }
 
 // makeRoom ensures that there is at most maxSize-1 elements in the cache map
-// so that a new entry can be added. It deletes the object that was last accessed
-// before all others.
+// so that a new entry can be added. It deletes the object that
+// was last accessed before all others.
+// This implementation is not thread safe. Callers must properly synchronize.
 func (c *AWSCredentialsProviderCache) makeRoom() {
 	if 1+len(c.cache) <= c.maxSize {
 		return
@@ -172,6 +176,7 @@ func (c *AWSCredentialsProviderCache) makeRoom() {
 	for key, val := range c.cache {
 		if dustiest == "" {
 			dustiest = key
+			continue
 		}
 		if val.AccessedAt.Before(c.cache[dustiest].AccessedAt) {
 			dustiest = key

--- a/internal/clients/creds_cache.go
+++ b/internal/clients/creds_cache.go
@@ -22,10 +22,6 @@ import (
 	"github.com/upbound/provider-aws/apis/v1beta1"
 )
 
-// GlobalAWSCredentialsProviderCache is a global AWS CredentialsProvider cache
-// to be used by all controllers.
-var GlobalAWSCredentialsProviderCache = NewAWSCredentialsProviderCache()
-
 // AWSCredentialsProviderCacheOption lets you configure
 // a *GlobalAWSCredentialsProviderCache.
 type AWSCredentialsProviderCacheOption func(cache *AWSCredentialsProviderCache)

--- a/internal/clients/creds_cache.go
+++ b/internal/clients/creds_cache.go
@@ -125,7 +125,7 @@ func (c *AWSCredentialsProviderCache) RetrieveCredentials(ctx context.Context, p
 	if err != nil {
 		return aws.Credentials{}, errors.Wrap(err, "cannot calculate the hash for the credentials file")
 	}
-	cacheKeyParams = append(cacheKeyParams, authKeyIRSA, tokenHash, os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE"), os.Getenv("AWS_ROLE_ARN"))
+	cacheKeyParams = append(cacheKeyParams, tokenHash, os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE"), os.Getenv("AWS_ROLE_ARN"))
 	cacheKey := strings.Join(cacheKeyParams, ":")
 	c.logger.Debug("Checking cache entry", "cacheKey", cacheKey, "pc", pc.GroupVersionKind().String())
 	c.mu.RLock()

--- a/internal/clients/creds_cache.go
+++ b/internal/clients/creds_cache.go
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clients
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/crossplane/crossplane-runtime/pkg/logging"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/upbound/provider-aws/apis/v1beta1"
+)
+
+// GlobalAWSCredentialsProviderCache is a global AWS CredentialsProvider cache to be used by all controllers.
+var GlobalAWSCredentialsProviderCache = NewAWSCredentialsProviderCache()
+
+// AWSCredentialsProviderCacheOption lets you configure *GlobalAWSCredentialsProviderCache.
+type AWSCredentialsProviderCacheOption func(cache *AWSCredentialsProviderCache)
+
+// WithCacheMaxSize lets you override the default MaxSize for AWS CredentialsProvider cache.
+func WithCacheMaxSize(n int) AWSCredentialsProviderCacheOption {
+	return func(c *AWSCredentialsProviderCache) {
+		c.maxSize = n
+	}
+}
+
+// WithCacheStore lets you bootstrap AWS CredentialsProvider Cache with your own cache.
+func WithCacheStore(cache map[string]*awsCredentialsProviderCacheEntry) AWSCredentialsProviderCacheOption {
+	return func(c *AWSCredentialsProviderCache) {
+		c.cache = cache
+	}
+}
+
+// WithCacheLogger lets you configure the logger for the cache.
+func WithCacheLogger(l logging.Logger) AWSCredentialsProviderCacheOption {
+	return func(c *AWSCredentialsProviderCache) {
+		c.logger = l
+	}
+}
+
+// NewAWSCredentialsProviderCache returns a new empty *AWSCredentialsProviderCache with the default GetAWSConfig method.
+func NewAWSCredentialsProviderCache(opts ...AWSCredentialsProviderCacheOption) *AWSCredentialsProviderCache {
+	// zl := zap.New(zap.UseDevMode(false))
+	logr := logging.NewLogrLogger(zap.New(zap.UseDevMode(false)).WithName("provider-aws-credentials-cache"))
+	c := &AWSCredentialsProviderCache{
+		cache:   map[string]*awsCredentialsProviderCacheEntry{},
+		maxSize: 100,
+		mu:      &sync.RWMutex{},
+		logger:  logr,
+	}
+	for _, f := range opts {
+		f(c)
+	}
+	return c
+}
+
+// AWSCredentialsProviderCache holds aws.CredentialsProvider objects in memory so that
+// we don't need to make API calls to AWS in every reconciliation of every
+// resource. It has a maximum size that when it's reached, the entry that has
+// the oldest access time will be removed from the cache, i.e. FIFO on last access
+// time.
+// Note that there is no need to invalidate the values in the cache because they
+// never change, so we don't need concurrency-safety to prevent access to an
+// invalidated entry.
+type AWSCredentialsProviderCache struct {
+	// cache holds the AWS Config with a unique cache key per provider configuration.
+	// key content includes the ProviderConfig's UUID and ResourceVersion and
+	// additional fields depending on the auth method
+	cache map[string]*awsCredentialsProviderCacheEntry
+
+	// maxSize is the maximum number of elements this cache can ever have.
+	maxSize int
+
+	// mu is used to make sure the cache map is concurrency-safe.
+	mu *sync.RWMutex
+
+	// logger is the logger for cache operations
+	logger logging.Logger
+}
+
+type awsCredentialsProviderCacheEntry struct {
+	*aws.Config
+	credProvider aws.CredentialsProvider
+	AccessedAt   time.Time
+}
+
+func (c *AWSCredentialsProviderCache) RetrieveCredentials(ctx context.Context, pc *v1beta1.ProviderConfig, awsCfg *aws.Config) (aws.Credentials, error) {
+	// cache key calculation tries to capture any parameter that could cause changes
+	// in the resulting AWS credentials, to ensure unique keys.
+	//
+	// Parameters that are directly available in the provider config, will generate
+	// unique cache keys through UUID and ResourceVersion of the ProviderConfig's
+	// k8s object, as they change when the provider config is modified.
+	//
+	// any other external parameter that have an effect on the resulting credentials
+	// and does not appear in the ProviderConfig directly (i.e. the same provider config
+	// content produces a different config), should be included in the cache key
+	cacheKeyParams := []string{
+		string(pc.UID),
+		pc.ResourceVersion,
+		awsCfg.Region,
+		string(pc.Spec.Credentials.Source),
+	}
+
+	// Only IRSA authentication method credentials are cached currently
+	switch s := pc.Spec.Credentials.Source; s { //nolint:exhaustive
+	case authKeyIRSA:
+		tokenHash, err := hashTokenFile(os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE"))
+		if err != nil {
+			return aws.Credentials{}, errors.Wrap(err, "cannot calculate cache key for credentials")
+		}
+		cacheKeyParams = append(cacheKeyParams, authKeyIRSA, tokenHash, os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE"), os.Getenv("AWS_ROLE_ARN"))
+	default:
+		c.logger.Debug("skipping cache", "pc", pc.GroupVersionKind().String(), "authSource", s)
+		// skip cache for other/unimplemented credential types
+		return awsCfg.Credentials.Retrieve(ctx)
+	}
+
+	cacheKey := strings.Join(cacheKeyParams, ":")
+	c.logger.Debug("checking cache entry", "cacheKey", cacheKey, "pc", pc.GroupVersionKind().String())
+	c.mu.RLock()
+	cacheEntry, ok := c.cache[cacheKey]
+	c.mu.RUnlock()
+
+	// TODO: consider implementing a TTL even though the cached entry is valid
+	// cache hit
+	if ok {
+		c.logger.Debug("cache hit", "cacheKey", cacheKey, "pc", pc.GroupVersionKind().String())
+		// since this is a hot-path in the execution, do not always update
+		// the last access times, it is fine to evict the LRU entry on a less
+		// granular precision.
+		if time.Since(cacheEntry.AccessedAt) > 10*time.Minute {
+			c.mu.Lock()
+			cacheEntry.AccessedAt = time.Now()
+			c.mu.Unlock()
+		}
+		return cacheEntry.credProvider.Retrieve(ctx)
+	}
+
+	// cache miss
+	c.logger.Debug("cache miss", "cacheKey", cacheKey, "pc", pc.GroupVersionKind().String())
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.makeRoom()
+	c.cache[cacheKey] = &awsCredentialsProviderCacheEntry{
+		credProvider: awsCfg.Credentials,
+		AccessedAt:   time.Now(),
+	}
+	return awsCfg.Credentials.Retrieve(ctx)
+}
+
+// makeRoom ensures that there is at most maxSize-1 elements in the cache map
+// so that a new entry can be added. It deletes the object that was last accessed
+// before all others.
+func (c *AWSCredentialsProviderCache) makeRoom() {
+	if 1+len(c.cache) <= c.maxSize {
+		return
+	}
+	var dustiest string
+	for key, val := range c.cache {
+		if dustiest == "" {
+			dustiest = key
+		}
+		if val.AccessedAt.Before(c.cache[dustiest].AccessedAt) {
+			dustiest = key
+		}
+	}
+	delete(c.cache, dustiest)
+}
+
+// hashTokenFile calculates the sha256 checksum of the token file content at
+// the supplied file path
+func hashTokenFile(filename string) (string, error) {
+	if filename == "" {
+		return "", errors.New("token file name cannot be empty")
+	}
+	file, err := os.Open(filepath.Clean(filename))
+	if err != nil {
+		return "", err
+	}
+	defer file.Close() //nolint:errcheck
+
+	hash := sha256.New()
+	if _, err = io.Copy(hash, file); err != nil {
+		return "", err
+	}
+
+	checksum := hash.Sum(nil)
+	return fmt.Sprintf("%x", checksum), nil
+}


### PR DESCRIPTION
### Description of your changes

Fixes #997 
Introduces a global credential cache to reduce AWS STS calls.
Only IRSA credentials are cached.

The new provider cache is a two-layer hierarchical cache. L1 cache is an AWS SDK Go `aws.CredentialsCache` and the L2 cache is for caching the `aws.CredentialsCache`s. The cache key for the L2 cache is derived from the well known IRSA authentication parameters as well as the contents of the OIDC ID token file. The new cache also caches the AWS account ID for a given IRSA configuration and replaces the identity cache for IRSA configurations.

Background:

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Tested manually with provider configs with:
- IRSA auth configuration
- IRSA + RoleChain configuration
- WebIdentity + RoleChain configuration [no credential caching with this PR]
- @turkenf has also validated the provider package `index.docker.io/ulucinar/provider-aws-ec2:v1.3.0-0fbbf02b3656352c729396851646d12ef80a1496` for `Upbound` authentication on Upbound Cloud.
- A static (long term) credential configuration (with authentication type `Secret`) has succeeded here: https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/8468707015

Two experiments were done using 4 managed resources (MRs) with a plain IRSA configuration and an IRSA configuration with an assume role chain of length two with the following `ProviderConfig.aws`:
```yaml
apiVersion: aws.upbound.io/v1beta1
kind: ProviderConfig
metadata:
  name: default
spec:
  assumeRoleChain:
  - roleARN: arn:aws:iam::<account ID>:role/alper-rc-1
  - roleARN: arn:aws:iam::<account ID>:role/alper-rc-2
  credentials:
    source: IRSA
```

During these experiments, we forced frequent reconciliations of the MRs (every 3 seconds) in constant update loops and
we also observed the AWS CloudTrail event history for an extended period of time. Here are the relevant events from CloudTrail:
<img width="842" alt="image" src="https://github.com/crossplane-contrib/provider-upjet-aws/assets/9376684/007ee646-8bfd-4718-a01b-55b33212ef44">

As the logs show, for these 4 MRs, at most only one `sts.AssumeRoleWithWebIdentity` operation per an hour has been recorded, showing the effectiveness of the credential cache for IRSA authentication. Please note that the temporary credentials issued by the `sts.AssumeRoleWithWebIdentity` are valid for one hour. It's the L1 cache that discards these temporary credentials after one hour and renews them. During this extended period, because the L2 cache item is *not* discarded, only one `sts.GetCallerIdentity` operation has been observed.

I also did a test for the L2 cache by invaliding the cache entry prematurely. The following event logs show how this results in a premature call to `sts.AssumeRoleWithWebIdentity`:
<img width="895" alt="image" src="https://github.com/crossplane-contrib/provider-upjet-aws/assets/9376684/05ea2985-b172-440a-8cea-ce6a992f0ecd">

After the temporary credentials were fetched at `March 28, 2024, 16:36:47`, we would not expect them to be refreshed before an hour but causing the L2 cached entry go stale, there's been a premature call at `March 28, 2024, 16:46:22`.

Also tested the PR on top of @mergenci's [API Call Counters](https://github.com/crossplane-contrib/provider-upjet-aws/pull/1241) PR. Under an update loop, the reported API call counters for `sts.AssumeRoleWithWebIdentity` & `sts.GetCallerIdentity` are not increasing:
```
❯ curl -s http://localhost:8080/metrics | grep upjet | grep upjet_resource_external_api_calls_total
# HELP upjet_resource_external_api_calls_total The number of external API calls.
# TYPE upjet_resource_external_api_calls_total counter
upjet_resource_external_api_calls_total{operation="AssumeRole",service="STS"} 2
upjet_resource_external_api_calls_total{operation="AssumeRoleWithWebIdentity",service="STS"} 1
upjet_resource_external_api_calls_total{operation="CreateRole",service="IAM"} 1
upjet_resource_external_api_calls_total{operation="GetCallerIdentity",service="STS"} 1
upjet_resource_external_api_calls_total{operation="GetRole",service="IAM"} 26
upjet_resource_external_api_calls_total{operation="GetRolePolicy",service="IAM"} 25
upjet_resource_external_api_calls_total{operation="ListAttachedRolePolicies",service="IAM"} 25
upjet_resource_external_api_calls_total{operation="ListRolePolicies",service="IAM"} 25
upjet_resource_external_api_calls_total{operation="PutRolePolicy",service="IAM"} 1
❯ curl -s http://localhost:8080/metrics | grep upjet | grep upjet_resource_external_api_calls_total
# HELP upjet_resource_external_api_calls_total The number of external API calls.
# TYPE upjet_resource_external_api_calls_total counter
upjet_resource_external_api_calls_total{operation="AssumeRole",service="STS"} 2
upjet_resource_external_api_calls_total{operation="AssumeRoleWithWebIdentity",service="STS"} 1
upjet_resource_external_api_calls_total{operation="CreateRole",service="IAM"} 1
upjet_resource_external_api_calls_total{operation="GetCallerIdentity",service="STS"} 1
upjet_resource_external_api_calls_total{operation="GetRole",service="IAM"} 61
upjet_resource_external_api_calls_total{operation="GetRolePolicy",service="IAM"} 60
upjet_resource_external_api_calls_total{operation="ListAttachedRolePolicies",service="IAM"} 60
upjet_resource_external_api_calls_total{operation="ListRolePolicies",service="IAM"} 60
upjet_resource_external_api_calls_total{operation="PutRolePolicy",service="IAM"} 1
```

[contribution process]: https://git.io/fj2m9
