### PR TITLE
Use Generation instead of ResourceVersion when computing the cache key

### DIFF
--- a/internal/clients/creds_cache.go
+++ b/internal/clients/creds_cache.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -82,7 +83,7 @@ func NewAWSCredentialsProviderCache(opts ...AWSCredentialsProviderCacheOption) *
 type AWSCredentialsProviderCache struct {
 	// cache holds the AWS Config with a unique cache key per
 	// provider configuration. Key content includes the ProviderConfig's UUID
-	// and ResourceVersion and additional fields depending on the auth method
+	// and Generation and additional fields depending on the auth method
 	// (currently only IRSA temporary credential caching is supported).
 	cache map[string]*awsCredentialsProviderCacheEntry
 
@@ -170,7 +171,7 @@ func (c *AWSCredentialsProviderCache) RetrieveCredentials(ctx context.Context, p
 	// to ensure unique keys.
 	//
 	// Parameters that are directly available in the provider config will
-	// generate unique cache keys through UUID and ResourceVersion of
+	// generate unique cache keys through UUID and Generation of
 	// the ProviderConfig's k8s object, as they change when the provider
 	// config is modified.
 	//
@@ -180,7 +181,7 @@ func (c *AWSCredentialsProviderCache) RetrieveCredentials(ctx context.Context, p
 	// should be included in the cache key.
 	cacheKeyParams := []string{
 		string(pc.UID),
-		pc.ResourceVersion,
+		strconv.FormatInt(pc.Generation, 10),
 		region,
 		string(pc.Spec.Credentials.Source),
 	}


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
The provider cache manager currently uses `ProviderConfig.ResourceVersion` when computing the cache keys. This PR changes it to `ProviderConfig.Generation` so that only ProviderConfig's `spec` updates will invalidate cache entries.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Validated the PR using the package `index.docker.io/ulucinar/provider-aws-iam:v1.3.0-8dbbc58fbd82da76ef5f8f50c34aa75494964bbd` and by modifying the `spec` of the `ProviderConfig`. Also via uptest here: https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/8470828375


[contribution process]: https://git.io/fj2m9
