### PR TITLE
feat(pc): add providerconfig example for aws eks pod identity feature

### DIFF
--- a/examples/providerconfig/v1beta1/pod-identity.yaml
+++ b/examples/providerconfig/v1beta1/pod-identity.yaml
@@ -23,7 +23,6 @@ metadata:
 spec:
   forProvider:
     clientIdList:
-    - sts.amazonaws.com
     - pods.eks.amazonaws.com
     thumbprintList:
     - 9e99a48a9960b14926bb7f3b02e22da2b0ab7280
@@ -33,19 +32,14 @@ apiVersion: iam.aws.upbound.io/v1beta1
 kind: Role
 metadata:
   name: pod-identity-role
+  labels:
+    testing.upbound.io/example-name: pod-identity
 spec:
   forProvider:
     assumeRolePolicy: |
       {
         "Version": "2012-10-17",
         "Statement": [
-          {
-            "Effect": "Allow",
-            "Principal": {
-              "Federated": "arn:aws:iam::<AWS-ACCOUNT-ID>:oidc-provider/oidc.eks.<REGION>.amazonaws.com/id/<UNIQUE_ID>"
-            },
-            "Action": "sts:AssumeRoleWithWebIdentity"
-          },
           {
             "Effect": "Allow",
             "Principal": {

--- a/examples/providerconfig/v1beta1/pod-identity.yaml
+++ b/examples/providerconfig/v1beta1/pod-identity.yaml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: pod-identity
+spec:
+  credentials:
+    source: WebIdentity
+    webIdentity:
+      roleARN: arn:aws:iam::123456789012:role/pod-identity-role
+      tokenConfig:
+        fs:
+          path: /var/run/secrets/pods.eks.amazonaws.com/serviceaccount/eks-pod-identity-token
+        source: Filesystem
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: OpenIDConnectProvider
+metadata:
+  name: pod-identity
+spec:
+  forProvider:
+    clientIdList:
+    - sts.amazonaws.com
+    - pods.eks.amazonaws.com
+    thumbprintList:
+    - 9e99a48a9960b14926bb7f3b02e22da2b0ab7280
+    url: oidc.eks.<REGION>.amazonaws.com/id/<UNIQUE_ID>
+---
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Role
+metadata:
+  name: pod-identity-role
+spec:
+  forProvider:
+    assumeRolePolicy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Federated": "arn:aws:iam::<AWS-ACCOUNT-ID>:oidc-provider/oidc.eks.<REGION>.amazonaws.com/id/<UNIQUE_ID>"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity"
+          },
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "pods.eks.amazonaws.com"
+            },
+            "Action": [
+              "sts:AssumeRole",
+              "sts:TagSession"
+            ]
+          }
+        ]
+      }


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes
add providerconfig example for aws eks pod identity feature (https://aws.amazon.com/blogs/containers/amazon-eks-pod-identity-a-new-way-for-applications-on-eks-to-obtain-iam-credentials/)  and additional hints for IAM Role and OpenIDConnectProvider
realted to this convo: https://github.com/crossplane-contrib/provider-upjet-aws/issues/1252

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1249 #1252

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
