### PR TITLE
Fix update loop for Function.lambda resource 

### DIFF
--- a/apis/lambda/v1beta1/zz_function_terraformed.go
+++ b/apis/lambda/v1beta1/zz_function_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Function) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("SourceCodeHash"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/lambda/v1beta1/zz_function_types.go
+++ b/apis/lambda/v1beta1/zz_function_types.go
@@ -238,7 +238,7 @@ type FunctionInitParameters struct {
 	// Snap start settings block. Detailed below.
 	SnapStart []SnapStartInitParameters `json:"snapStart,omitempty" tf:"snap_start,omitempty"`
 
-	// Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either filename or s3_key. The usual way to set this is filebase64sha256("file.11.12 and later) or base64sha256(file("file.11.11 and earlier), where "file.zip" is the local filename of the lambda function source archive.
+	// Used to trigger updates. Must be set to a base64 encoded SHA256 hash of the package file specified with either filename or s3_key. If you have specified this field manually, it should be the actual (computed) hash of the underlying lambda function specified in the filename, image_uri, s3_bucket fields.
 	SourceCodeHash *string `json:"sourceCodeHash,omitempty" tf:"source_code_hash,omitempty"`
 
 	// Key-value map of resource tags.
@@ -355,7 +355,7 @@ type FunctionObservation struct {
 	// Snap start settings block. Detailed below.
 	SnapStart []SnapStartObservation `json:"snapStart,omitempty" tf:"snap_start,omitempty"`
 
-	// Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either filename or s3_key. The usual way to set this is filebase64sha256("file.11.12 and later) or base64sha256(file("file.11.11 and earlier), where "file.zip" is the local filename of the lambda function source archive.
+	// Used to trigger updates. Must be set to a base64 encoded SHA256 hash of the package file specified with either filename or s3_key. If you have specified this field manually, it should be the actual (computed) hash of the underlying lambda function specified in the filename, image_uri, s3_bucket fields.
 	SourceCodeHash *string `json:"sourceCodeHash,omitempty" tf:"source_code_hash,omitempty"`
 
 	// Size in bytes of the function .zip file.
@@ -528,7 +528,7 @@ type FunctionParameters struct {
 	// +kubebuilder:validation:Optional
 	SnapStart []SnapStartParameters `json:"snapStart,omitempty" tf:"snap_start,omitempty"`
 
-	// Used to trigger updates. Must be set to a base64-encoded SHA256 hash of the package file specified with either filename or s3_key. The usual way to set this is filebase64sha256("file.11.12 and later) or base64sha256(file("file.11.11 and earlier), where "file.zip" is the local filename of the lambda function source archive.
+	// Used to trigger updates. Must be set to a base64 encoded SHA256 hash of the package file specified with either filename or s3_key. If you have specified this field manually, it should be the actual (computed) hash of the underlying lambda function specified in the filename, image_uri, s3_bucket fields.
 	// +kubebuilder:validation:Optional
 	SourceCodeHash *string `json:"sourceCodeHash,omitempty" tf:"source_code_hash,omitempty"`
 

--- a/config/lambda/config.go
+++ b/config/lambda/config.go
@@ -6,6 +6,7 @@ package lambda
 
 import (
 	"github.com/crossplane/upjet/pkg/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/upbound/provider-aws/config/common"
 )
@@ -61,6 +62,14 @@ func Configure(p *config.Provider) {
 			SelectorFieldName: "SubnetIDSelector",
 		}
 		delete(r.TerraformResource.Schema, "filename")
+
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			if diff != nil && diff.Attributes != nil {
+				delete(diff.Attributes, "source_code_hash")
+				delete(diff.Attributes, "last_modified")
+			}
+			return diff, nil
+		}
 	})
 
 	p.AddResourceConfigurator("aws_lambda_function_event_invoke_config", func(r *config.Resource) {

--- a/config/lambda/config.go
+++ b/config/lambda/config.go
@@ -64,6 +64,10 @@ func Configure(p *config.Provider) {
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"source_code_hash"},
 		}
+		r.MetaResource.ArgumentDocs["source_code_hash"] = "Used to trigger updates. Must be set to " +
+			"a base64 encoded SHA256 hash of the package file specified with either filename or s3_key. " +
+			"If you have specified this field manually, it should be the actual (computed) hash of the " +
+			"underlying lambda function specified in the filename, image_uri, s3_bucket fields."
 	})
 
 	p.AddResourceConfigurator("aws_lambda_function_event_invoke_config", func(r *config.Resource) {

--- a/config/lambda/config.go
+++ b/config/lambda/config.go
@@ -6,7 +6,6 @@ package lambda
 
 import (
 	"github.com/crossplane/upjet/pkg/config"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/upbound/provider-aws/config/common"
 )
@@ -62,13 +61,8 @@ func Configure(p *config.Provider) {
 			SelectorFieldName: "SubnetIDSelector",
 		}
 		delete(r.TerraformResource.Schema, "filename")
-
-		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
-			if diff != nil && diff.Attributes != nil {
-				delete(diff.Attributes, "source_code_hash")
-				delete(diff.Attributes, "last_modified")
-			}
-			return diff, nil
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"source_code_hash"},
 		}
 	})
 

--- a/examples/lambda/v1beta1/function.yaml
+++ b/examples/lambda/v1beta1/function.yaml
@@ -13,7 +13,7 @@ metadata:
   name: example
 spec:
   forProvider:
-    s3Bucket: upbound-provider-test-data
+    s3Bucket: official-provider-test-data
     s3Key: hello-python.zip
     handler: index.py
     packageType: Zip

--- a/package/crds/lambda.aws.upbound.io_functions.yaml
+++ b/package/crds/lambda.aws.upbound.io_functions.yaml
@@ -644,12 +644,11 @@ spec:
                       type: object
                     type: array
                   sourceCodeHash:
-                    description: Used to trigger updates. Must be set to a base64-encoded
-                      SHA256 hash of the package file specified with either filename
-                      or s3_key. The usual way to set this is filebase64sha256("file.11.12
-                      and later) or base64sha256(file("file.11.11 and earlier), where
-                      "file.zip" is the local filename of the lambda function source
-                      archive.
+                    description: Used to trigger updates. Must be set to a base64
+                      encoded SHA256 hash of the package file specified with either
+                      filename or s3_key. If you have specified this field manually,
+                      it should be the actual (computed) hash of the underlying lambda
+                      function specified in the filename, image_uri, s3_bucket fields.
                     type: string
                   tags:
                     additionalProperties:
@@ -1439,12 +1438,11 @@ spec:
                       type: object
                     type: array
                   sourceCodeHash:
-                    description: Used to trigger updates. Must be set to a base64-encoded
-                      SHA256 hash of the package file specified with either filename
-                      or s3_key. The usual way to set this is filebase64sha256("file.11.12
-                      and later) or base64sha256(file("file.11.11 and earlier), where
-                      "file.zip" is the local filename of the lambda function source
-                      archive.
+                    description: Used to trigger updates. Must be set to a base64
+                      encoded SHA256 hash of the package file specified with either
+                      filename or s3_key. If you have specified this field manually,
+                      it should be the actual (computed) hash of the underlying lambda
+                      function specified in the filename, image_uri, s3_bucket fields.
                     type: string
                   tags:
                     additionalProperties:
@@ -2047,12 +2045,11 @@ spec:
                       type: object
                     type: array
                   sourceCodeHash:
-                    description: Used to trigger updates. Must be set to a base64-encoded
-                      SHA256 hash of the package file specified with either filename
-                      or s3_key. The usual way to set this is filebase64sha256("file.11.12
-                      and later) or base64sha256(file("file.11.11 and earlier), where
-                      "file.zip" is the local filename of the lambda function source
-                      archive.
+                    description: Used to trigger updates. Must be set to a base64
+                      encoded SHA256 hash of the package file specified with either
+                      filename or s3_key. If you have specified this field manually,
+                      it should be the actual (computed) hash of the underlying lambda
+                      function specified in the filename, image_uri, s3_bucket fields.
                     type: string
                   sourceCodeSize:
                     description: Size in bytes of the function .zip file.


### PR DESCRIPTION
### Description of your changes

This PR fixes the update loop in the `Function.lambda` resource.

Fixes: https://github.com/crossplane-contrib/provider-upjet-aws/issues/1027

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Create a `Repository.ecr` resource by applying the following:
```
apiVersion: ecr.aws.upbound.io/v1beta1
kind: Repository
metadata:
  name: test-repo
spec:
  forProvider:
    region: us-east-1
    imageTagMutability: "IMMUTABLE"
```
- Push an image to the repository:
   - Retrieve an authentication token and authenticate your Docker client to your registry. Use the AWS CLI: `aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin <account_id>.dkr.ecr.us-east-1.amazonaws.com`
   - Build your Docker image using the following command. For information on building a Docker file from scratch see the instructions [here ](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/docker-basics.html). You can skip this step if your image is already built: `docker build -t test-repo .`
   - After the build completes, tag your image so you can push the image to this repository: `docker tag test-repo:latest <account_id>.dkr.ecr.us-east-1.amazonaws.com/test-repo:latest`
   - Run the following command to push this image to your newly created AWS repository: `docker push <account_id>.dkr.ecr.us-east-1.amazonaws.com/test-repo:latest`
- Create a `Function.lambda` resource by applying the following:
```
apiVersion: lambda.aws.upbound.io/v1beta1
kind: Function
metadata:
  name: example-ft-test
spec:
  forProvider:
    imageUri: <redacted>.dkr.ecr.us-east-1.amazonaws.com/ft-test-repo:latest
    packageType: Image
    region: us-east-1
    roleSelector:
      matchLabels:
        testing.upbound.io/example-name: role
    timeout: 60
``` 
- Once the resource has been created successfully, create and push a different image with a tag using the steps above.
- Change the `imageUri` in the `Function.lambda` resource with the new one.
```
2024-04-16T19:22:57+03:00	DEBUG	provider-aws	External resource is up to date	{"controller": "managed/lambda.aws.upbound.io/v1beta1, kind=function", "request": {"name":"example-ft-test"}, "uid": "786b127b-d342-423f-89b0-9e45c61b1d77", "version": "36662", "external-name": "example-ft-test", "requeue-after": "2024-04-16T19:33:03+03:00"}
```
```
  conditions:
  - lastTransitionTime: "2024-04-16T16:21:44Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2024-04-16T16:21:35Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  - lastTransitionTime: "2024-04-16T16:21:42Z"
    reason: Success
    status: "True"
    type: LastAsyncOperation
  - lastTransitionTime: "2024-04-16T16:22:57Z"
    reason: UpToDate
    status: "True"
    type: Test
```

[contribution process]: https://git.io/fj2m9
