### PR TITLE
Remove resource from externalnamenottested that is already implemented

### DIFF
--- a/config/externalnamenottested.go
+++ b/config/externalnamenottested.go
@@ -46,8 +46,6 @@ var ExternalNameNotTestedConfigs = map[string]config.ExternalName{
 
 	// cloudformation
 	//
-	// Cloudformation Stacks Instances imported using the StackSet name, target AWS account ID, and target AWS: example,123456789012,us-east-1
-	"aws_cloudformation_stack_set_instance": config.IdentifierFromProvider,
 	// aws_cloudformation_type can be imported with their type version Amazon Resource Name (ARN)
 	"aws_cloudformation_type": config.IdentifierFromProvider,
 


### PR DESCRIPTION
It looks like when cloudformation StackSetInstance got implemented, someone forgot to remove it from externalnamenottested.go. I'm cleaning that up.


<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes


I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
