### PR TITLE
re-order columns for handwritten ClusterAuth.eks

### DIFF
--- a/apis/eks/v1beta1/clusterauth_types.go
+++ b/apis/eks/v1beta1/clusterauth_types.go
@@ -60,8 +60,8 @@ type ClusterAuthStatus struct {
 // +kubebuilder:object:root=true
 
 // ClusterAuth is used to retrieve Kubeconfig of given EKS cluster.
-// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
+// +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:subresource:status

--- a/package/crds/eks.aws.upbound.io_clusterauths.yaml
+++ b/package/crds/eks.aws.upbound.io_clusterauths.yaml
@@ -19,11 +19,11 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=='Ready')].status
-      name: READY
-      type: string
     - jsonPath: .status.conditions[?(@.type=='Synced')].status
       name: SYNCED
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: READY
       type: string
     - jsonPath: .metadata.annotations.crossplane\.io/external-name
       name: EXTERNAL-NAME


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes
There was a recent change in upjet that swapped the order of the Ready and Synced columns in the generated managed resource CRDs. That's already been merged and released in provider-upjet-aws. However, we forgot about ClusterAuth.eks, which is the only (I think?) CRD that's not generated by upjet. 

The result is that currently when listing managed resources, for all MR kinds other than ClusterAuth, Synced appears before Ready, but for ClusterAuth, Ready appears before synced.

This PR fixes that.
<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Using [uptest](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/9414897033) on this PR and manually:
```
NAME                                  SYNCED   READY   EXTERNAL-NAME   AGE
clusterauth.eks.aws.upbound.io/auth   True     True    auth            10m
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
