### PR TITLE
Rename upbound provider ci repo

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -16,4 +16,4 @@ on:
 
 jobs:
   backport:
-    uses: upbound/uptest/.github/workflows/provider-backport.yml@standard-runners
+    uses: upbound/official-providers-ci/.github/workflows/provider-backport.yml@standard-runners

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   ci:
-    uses: upbound/uptest/.github/workflows/provider-ci.yml@standard-runners
+    uses: upbound/official-providers-ci/.github/workflows/provider-ci.yml@standard-runners
     with:
       go-version: "1.21"
       golangci-skip: true # we will run the linter via "make lint"

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -8,4 +8,4 @@ on: issue_comment
 
 jobs:
   comment-commands:
-    uses: upbound/uptest/.github/workflows/provider-commands.yml@standard-runners
+    uses: upbound/official-providers-ci/.github/workflows/provider-commands.yml@standard-runners

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   e2e:
-    uses: upbound/uptest/.github/workflows/pr-comment-trigger.yml@standard-runners
+    uses: upbound/official-providers-ci/.github/workflows/pr-comment-trigger.yml@standard-runners
     with:
       go-version: 1.21
       cleanup-disk: true

--- a/.github/workflows/native-provider-bump.yml
+++ b/.github/workflows/native-provider-bump.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   open-bump-pr:
-    uses: upbound/uptest/.github/workflows/native-provider-bump.yml@standard-runners
+    uses: upbound/official-providers-ci/.github/workflows/native-provider-bump.yml@standard-runners
     with:
       provider-source: hashicorp/aws
       go-version: 1.21

--- a/.github/workflows/publish-service-artifacts.yml
+++ b/.github/workflows/publish-service-artifacts.yml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   publish-service-artifacts:
-    uses: upbound/uptest/.github/workflows/provider-publish-service-artifacts.yml@standard-runners
+    uses: upbound/official-providers-ci/.github/workflows/provider-publish-service-artifacts.yml@standard-runners
     with:
       subpackages: ${{ github.event.inputs.subpackages }}
       size: ${{ github.event.inputs.size }}

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -44,7 +44,7 @@ jobs:
           echo "We are going to scan the last ${supported_releases_number} releases for: ${images}"
 
   scan:
-    uses: upbound/uptest/.github/workflows/scan.yml@standard-runners
+    uses: upbound/official-providers-ci/.github/workflows/scan.yml@standard-runners
     needs:
       - setup-vars
     with:

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   tag:
-    uses: upbound/uptest/.github/workflows/provider-tag.yml@standard-runners
+    uses: upbound/official-providers-ci/.github/workflows/provider-tag.yml@standard-runners
     with:
       version: ${{ github.event.inputs.version }}
       message: ${{ github.event.inputs.message }}

--- a/.github/workflows/updoc.yml
+++ b/.github/workflows/updoc.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish-docs:
-    uses: upbound/uptest/.github/workflows/provider-updoc.yml@standard-runners
+    uses: upbound/official-providers-ci/.github/workflows/provider-updoc.yml@standard-runners
     with:
       providers: "monolith config"
       go-version: 1.21


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

All the CI jobs have started failing. 

Github actions doesn't follow github repository redirects when resolving reusable workflows, as documented [here](https://docs.github.com/en/actions/using-workflows/reusing-workflows#access-to-reusable-workflows).

The `upbound/uptest` repo has been renamed to `upbound/official-providers-ci`.

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
