### PR TITLE
Add needs:triage label to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Help us diagnose and fix bugs in Official AWS Provider
-labels: bug
+labels: bug,needs:triage
 title: "[Bug]: "
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature Request
 about: Help us make Official AWS Provider more useful
-labels: enhancement
+labels: enhancement,needs:triage
 title: 
 ---
 <!--


### PR DESCRIPTION
### Description of your changes

Adds `needs:triage` label to issue template.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

[contribution process]: https://git.io/fj2m9
