### PR TITLE
Use config.Reference.TerraformName instead of config.Reference.Type

### DIFF
--- a/apis/acm/v1beta1/zz_certificatevalidation_types.go
+++ b/apis/acm/v1beta1/zz_certificatevalidation_types.go
@@ -16,14 +16,14 @@ import (
 type CertificateValidationInitParameters struct {
 
 	// ARN of the certificate that is being validated.
-	// +crossplane:generate:reference:type=Certificate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/acm/v1beta1.Certificate
 	CertificateArn *string `json:"certificateArn,omitempty" tf:"certificate_arn,omitempty"`
 
-	// Reference to a Certificate to populate certificateArn.
+	// Reference to a Certificate in acm to populate certificateArn.
 	// +kubebuilder:validation:Optional
 	CertificateArnRef *v1.Reference `json:"certificateArnRef,omitempty" tf:"-"`
 
-	// Selector for a Certificate to populate certificateArn.
+	// Selector for a Certificate in acm to populate certificateArn.
 	// +kubebuilder:validation:Optional
 	CertificateArnSelector *v1.Selector `json:"certificateArnSelector,omitempty" tf:"-"`
 
@@ -48,15 +48,15 @@ type CertificateValidationObservation struct {
 type CertificateValidationParameters struct {
 
 	// ARN of the certificate that is being validated.
-	// +crossplane:generate:reference:type=Certificate
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/acm/v1beta1.Certificate
 	// +kubebuilder:validation:Optional
 	CertificateArn *string `json:"certificateArn,omitempty" tf:"certificate_arn,omitempty"`
 
-	// Reference to a Certificate to populate certificateArn.
+	// Reference to a Certificate in acm to populate certificateArn.
 	// +kubebuilder:validation:Optional
 	CertificateArnRef *v1.Reference `json:"certificateArnRef,omitempty" tf:"-"`
 
-	// Selector for a Certificate to populate certificateArn.
+	// Selector for a Certificate in acm to populate certificateArn.
 	// +kubebuilder:validation:Optional
 	CertificateArnSelector *v1.Selector `json:"certificateArnSelector,omitempty" tf:"-"`
 

--- a/apis/acmpca/v1beta1/zz_certificate_types.go
+++ b/apis/acmpca/v1beta1/zz_certificate_types.go
@@ -19,14 +19,14 @@ type CertificateInitParameters struct {
 	APIPassthrough *string `json:"apiPassthrough,omitempty" tf:"api_passthrough,omitempty"`
 
 	// ARN of the certificate authority.
-	// +crossplane:generate:reference:type=CertificateAuthority
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/acmpca/v1beta1.CertificateAuthority
 	CertificateAuthorityArn *string `json:"certificateAuthorityArn,omitempty" tf:"certificate_authority_arn,omitempty"`
 
-	// Reference to a CertificateAuthority to populate certificateAuthorityArn.
+	// Reference to a CertificateAuthority in acmpca to populate certificateAuthorityArn.
 	// +kubebuilder:validation:Optional
 	CertificateAuthorityArnRef *v1.Reference `json:"certificateAuthorityArnRef,omitempty" tf:"-"`
 
-	// Selector for a CertificateAuthority to populate certificateAuthorityArn.
+	// Selector for a CertificateAuthority in acmpca to populate certificateAuthorityArn.
 	// +kubebuilder:validation:Optional
 	CertificateAuthorityArnSelector *v1.Selector `json:"certificateAuthorityArnSelector,omitempty" tf:"-"`
 
@@ -78,15 +78,15 @@ type CertificateParameters struct {
 	APIPassthrough *string `json:"apiPassthrough,omitempty" tf:"api_passthrough,omitempty"`
 
 	// ARN of the certificate authority.
-	// +crossplane:generate:reference:type=CertificateAuthority
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/acmpca/v1beta1.CertificateAuthority
 	// +kubebuilder:validation:Optional
 	CertificateAuthorityArn *string `json:"certificateAuthorityArn,omitempty" tf:"certificate_authority_arn,omitempty"`
 
-	// Reference to a CertificateAuthority to populate certificateAuthorityArn.
+	// Reference to a CertificateAuthority in acmpca to populate certificateAuthorityArn.
 	// +kubebuilder:validation:Optional
 	CertificateAuthorityArnRef *v1.Reference `json:"certificateAuthorityArnRef,omitempty" tf:"-"`
 
-	// Selector for a CertificateAuthority to populate certificateAuthorityArn.
+	// Selector for a CertificateAuthority in acmpca to populate certificateAuthorityArn.
 	// +kubebuilder:validation:Optional
 	CertificateAuthorityArnSelector *v1.Selector `json:"certificateAuthorityArnSelector,omitempty" tf:"-"`
 

--- a/apis/acmpca/v1beta1/zz_certificateauthoritycertificate_types.go
+++ b/apis/acmpca/v1beta1/zz_certificateauthoritycertificate_types.go
@@ -16,14 +16,14 @@ import (
 type CertificateAuthorityCertificateInitParameters struct {
 
 	// ARN of the Certificate Authority.
-	// +crossplane:generate:reference:type=CertificateAuthority
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/acmpca/v1beta1.CertificateAuthority
 	CertificateAuthorityArn *string `json:"certificateAuthorityArn,omitempty" tf:"certificate_authority_arn,omitempty"`
 
-	// Reference to a CertificateAuthority to populate certificateAuthorityArn.
+	// Reference to a CertificateAuthority in acmpca to populate certificateAuthorityArn.
 	// +kubebuilder:validation:Optional
 	CertificateAuthorityArnRef *v1.Reference `json:"certificateAuthorityArnRef,omitempty" tf:"-"`
 
-	// Selector for a CertificateAuthority to populate certificateAuthorityArn.
+	// Selector for a CertificateAuthority in acmpca to populate certificateAuthorityArn.
 	// +kubebuilder:validation:Optional
 	CertificateAuthorityArnSelector *v1.Selector `json:"certificateAuthorityArnSelector,omitempty" tf:"-"`
 }
@@ -39,15 +39,15 @@ type CertificateAuthorityCertificateObservation struct {
 type CertificateAuthorityCertificateParameters struct {
 
 	// ARN of the Certificate Authority.
-	// +crossplane:generate:reference:type=CertificateAuthority
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/acmpca/v1beta1.CertificateAuthority
 	// +kubebuilder:validation:Optional
 	CertificateAuthorityArn *string `json:"certificateAuthorityArn,omitempty" tf:"certificate_authority_arn,omitempty"`
 
-	// Reference to a CertificateAuthority to populate certificateAuthorityArn.
+	// Reference to a CertificateAuthority in acmpca to populate certificateAuthorityArn.
 	// +kubebuilder:validation:Optional
 	CertificateAuthorityArnRef *v1.Reference `json:"certificateAuthorityArnRef,omitempty" tf:"-"`
 
-	// Selector for a CertificateAuthority to populate certificateAuthorityArn.
+	// Selector for a CertificateAuthority in acmpca to populate certificateAuthorityArn.
 	// +kubebuilder:validation:Optional
 	CertificateAuthorityArnSelector *v1.Selector `json:"certificateAuthorityArnSelector,omitempty" tf:"-"`
 

--- a/apis/apigatewayv2/v1beta1/zz_apimapping_types.go
+++ b/apis/apigatewayv2/v1beta1/zz_apimapping_types.go
@@ -16,14 +16,14 @@ import (
 type APIMappingInitParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
@@ -31,27 +31,27 @@ type APIMappingInitParameters struct {
 	APIMappingKey *string `json:"apiMappingKey,omitempty" tf:"api_mapping_key,omitempty"`
 
 	// Domain name. Use the aws_apigatewayv2_domain_name resource to configure a domain name.
-	// +crossplane:generate:reference:type=DomainName
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.DomainName
 	DomainName *string `json:"domainName,omitempty" tf:"domain_name,omitempty"`
 
-	// Reference to a DomainName to populate domainName.
+	// Reference to a DomainName in apigatewayv2 to populate domainName.
 	// +kubebuilder:validation:Optional
 	DomainNameRef *v1.Reference `json:"domainNameRef,omitempty" tf:"-"`
 
-	// Selector for a DomainName to populate domainName.
+	// Selector for a DomainName in apigatewayv2 to populate domainName.
 	// +kubebuilder:validation:Optional
 	DomainNameSelector *v1.Selector `json:"domainNameSelector,omitempty" tf:"-"`
 
 	// API stage. Use the aws_apigatewayv2_stage resource to configure an API stage.
-	// +crossplane:generate:reference:type=Stage
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.Stage
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.TerraformID()
 	Stage *string `json:"stage,omitempty" tf:"stage,omitempty"`
 
-	// Reference to a Stage to populate stage.
+	// Reference to a Stage in apigatewayv2 to populate stage.
 	// +kubebuilder:validation:Optional
 	StageRef *v1.Reference `json:"stageRef,omitempty" tf:"-"`
 
-	// Selector for a Stage to populate stage.
+	// Selector for a Stage in apigatewayv2 to populate stage.
 	// +kubebuilder:validation:Optional
 	StageSelector *v1.Selector `json:"stageSelector,omitempty" tf:"-"`
 }
@@ -77,15 +77,15 @@ type APIMappingObservation struct {
 type APIMappingParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	// +kubebuilder:validation:Optional
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
@@ -94,15 +94,15 @@ type APIMappingParameters struct {
 	APIMappingKey *string `json:"apiMappingKey,omitempty" tf:"api_mapping_key,omitempty"`
 
 	// Domain name. Use the aws_apigatewayv2_domain_name resource to configure a domain name.
-	// +crossplane:generate:reference:type=DomainName
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.DomainName
 	// +kubebuilder:validation:Optional
 	DomainName *string `json:"domainName,omitempty" tf:"domain_name,omitempty"`
 
-	// Reference to a DomainName to populate domainName.
+	// Reference to a DomainName in apigatewayv2 to populate domainName.
 	// +kubebuilder:validation:Optional
 	DomainNameRef *v1.Reference `json:"domainNameRef,omitempty" tf:"-"`
 
-	// Selector for a DomainName to populate domainName.
+	// Selector for a DomainName in apigatewayv2 to populate domainName.
 	// +kubebuilder:validation:Optional
 	DomainNameSelector *v1.Selector `json:"domainNameSelector,omitempty" tf:"-"`
 
@@ -112,16 +112,16 @@ type APIMappingParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// API stage. Use the aws_apigatewayv2_stage resource to configure an API stage.
-	// +crossplane:generate:reference:type=Stage
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.Stage
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.TerraformID()
 	// +kubebuilder:validation:Optional
 	Stage *string `json:"stage,omitempty" tf:"stage,omitempty"`
 
-	// Reference to a Stage to populate stage.
+	// Reference to a Stage in apigatewayv2 to populate stage.
 	// +kubebuilder:validation:Optional
 	StageRef *v1.Reference `json:"stageRef,omitempty" tf:"-"`
 
-	// Selector for a Stage to populate stage.
+	// Selector for a Stage in apigatewayv2 to populate stage.
 	// +kubebuilder:validation:Optional
 	StageSelector *v1.Selector `json:"stageSelector,omitempty" tf:"-"`
 }

--- a/apis/apigatewayv2/v1beta1/zz_authorizer_types.go
+++ b/apis/apigatewayv2/v1beta1/zz_authorizer_types.go
@@ -16,14 +16,14 @@ import (
 type AuthorizerInitParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
@@ -130,15 +130,15 @@ type AuthorizerObservation struct {
 type AuthorizerParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	// +kubebuilder:validation:Optional
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 

--- a/apis/apigatewayv2/v1beta1/zz_deployment_types.go
+++ b/apis/apigatewayv2/v1beta1/zz_deployment_types.go
@@ -16,14 +16,14 @@ import (
 type DeploymentInitParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
@@ -49,15 +49,15 @@ type DeploymentObservation struct {
 type DeploymentParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	// +kubebuilder:validation:Optional
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 

--- a/apis/apigatewayv2/v1beta1/zz_integration_types.go
+++ b/apis/apigatewayv2/v1beta1/zz_integration_types.go
@@ -16,14 +16,14 @@ import (
 type IntegrationInitParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
@@ -193,15 +193,15 @@ type IntegrationObservation struct {
 type IntegrationParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	// +kubebuilder:validation:Optional
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 

--- a/apis/apigatewayv2/v1beta1/zz_integrationresponse_types.go
+++ b/apis/apigatewayv2/v1beta1/zz_integrationresponse_types.go
@@ -16,14 +16,14 @@ import (
 type IntegrationResponseInitParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
@@ -31,14 +31,14 @@ type IntegrationResponseInitParameters struct {
 	ContentHandlingStrategy *string `json:"contentHandlingStrategy,omitempty" tf:"content_handling_strategy,omitempty"`
 
 	// Identifier of the aws_apigatewayv2_integration.
-	// +crossplane:generate:reference:type=Integration
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.Integration
 	IntegrationID *string `json:"integrationId,omitempty" tf:"integration_id,omitempty"`
 
-	// Reference to a Integration to populate integrationId.
+	// Reference to a Integration in apigatewayv2 to populate integrationId.
 	// +kubebuilder:validation:Optional
 	IntegrationIDRef *v1.Reference `json:"integrationIdRef,omitempty" tf:"-"`
 
-	// Selector for a Integration to populate integrationId.
+	// Selector for a Integration in apigatewayv2 to populate integrationId.
 	// +kubebuilder:validation:Optional
 	IntegrationIDSelector *v1.Selector `json:"integrationIdSelector,omitempty" tf:"-"`
 
@@ -81,15 +81,15 @@ type IntegrationResponseObservation struct {
 type IntegrationResponseParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	// +kubebuilder:validation:Optional
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
@@ -98,15 +98,15 @@ type IntegrationResponseParameters struct {
 	ContentHandlingStrategy *string `json:"contentHandlingStrategy,omitempty" tf:"content_handling_strategy,omitempty"`
 
 	// Identifier of the aws_apigatewayv2_integration.
-	// +crossplane:generate:reference:type=Integration
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.Integration
 	// +kubebuilder:validation:Optional
 	IntegrationID *string `json:"integrationId,omitempty" tf:"integration_id,omitempty"`
 
-	// Reference to a Integration to populate integrationId.
+	// Reference to a Integration in apigatewayv2 to populate integrationId.
 	// +kubebuilder:validation:Optional
 	IntegrationIDRef *v1.Reference `json:"integrationIdRef,omitempty" tf:"-"`
 
-	// Selector for a Integration to populate integrationId.
+	// Selector for a Integration in apigatewayv2 to populate integrationId.
 	// +kubebuilder:validation:Optional
 	IntegrationIDSelector *v1.Selector `json:"integrationIdSelector,omitempty" tf:"-"`
 

--- a/apis/apigatewayv2/v1beta1/zz_model_types.go
+++ b/apis/apigatewayv2/v1beta1/zz_model_types.go
@@ -16,14 +16,14 @@ import (
 type ModelInitParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
@@ -64,15 +64,15 @@ type ModelObservation struct {
 type ModelParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	// +kubebuilder:validation:Optional
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 

--- a/apis/apigatewayv2/v1beta1/zz_route_types.go
+++ b/apis/apigatewayv2/v1beta1/zz_route_types.go
@@ -45,14 +45,14 @@ type RequestParameterParameters struct {
 type RouteInitParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
@@ -70,14 +70,14 @@ type RouteInitParameters struct {
 	AuthorizationType *string `json:"authorizationType,omitempty" tf:"authorization_type,omitempty"`
 
 	// Identifier of the aws_apigatewayv2_authorizer resource to be associated with this route.
-	// +crossplane:generate:reference:type=Authorizer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.Authorizer
 	AuthorizerID *string `json:"authorizerId,omitempty" tf:"authorizer_id,omitempty"`
 
-	// Reference to a Authorizer to populate authorizerId.
+	// Reference to a Authorizer in apigatewayv2 to populate authorizerId.
 	// +kubebuilder:validation:Optional
 	AuthorizerIDRef *v1.Reference `json:"authorizerIdRef,omitempty" tf:"-"`
 
-	// Selector for a Authorizer to populate authorizerId.
+	// Selector for a Authorizer in apigatewayv2 to populate authorizerId.
 	// +kubebuilder:validation:Optional
 	AuthorizerIDSelector *v1.Selector `json:"authorizerIdSelector,omitempty" tf:"-"`
 
@@ -164,15 +164,15 @@ type RouteObservation struct {
 type RouteParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	// +kubebuilder:validation:Optional
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
@@ -193,15 +193,15 @@ type RouteParameters struct {
 	AuthorizationType *string `json:"authorizationType,omitempty" tf:"authorization_type,omitempty"`
 
 	// Identifier of the aws_apigatewayv2_authorizer resource to be associated with this route.
-	// +crossplane:generate:reference:type=Authorizer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.Authorizer
 	// +kubebuilder:validation:Optional
 	AuthorizerID *string `json:"authorizerId,omitempty" tf:"authorizer_id,omitempty"`
 
-	// Reference to a Authorizer to populate authorizerId.
+	// Reference to a Authorizer in apigatewayv2 to populate authorizerId.
 	// +kubebuilder:validation:Optional
 	AuthorizerIDRef *v1.Reference `json:"authorizerIdRef,omitempty" tf:"-"`
 
-	// Selector for a Authorizer to populate authorizerId.
+	// Selector for a Authorizer in apigatewayv2 to populate authorizerId.
 	// +kubebuilder:validation:Optional
 	AuthorizerIDSelector *v1.Selector `json:"authorizerIdSelector,omitempty" tf:"-"`
 

--- a/apis/apigatewayv2/v1beta1/zz_routeresponse_types.go
+++ b/apis/apigatewayv2/v1beta1/zz_routeresponse_types.go
@@ -16,14 +16,14 @@ import (
 type RouteResponseInitParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
@@ -35,14 +35,14 @@ type RouteResponseInitParameters struct {
 	ResponseModels map[string]*string `json:"responseModels,omitempty" tf:"response_models,omitempty"`
 
 	// Identifier of the aws_apigatewayv2_route.
-	// +crossplane:generate:reference:type=Route
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.Route
 	RouteID *string `json:"routeId,omitempty" tf:"route_id,omitempty"`
 
-	// Reference to a Route to populate routeId.
+	// Reference to a Route in apigatewayv2 to populate routeId.
 	// +kubebuilder:validation:Optional
 	RouteIDRef *v1.Reference `json:"routeIdRef,omitempty" tf:"-"`
 
-	// Selector for a Route to populate routeId.
+	// Selector for a Route in apigatewayv2 to populate routeId.
 	// +kubebuilder:validation:Optional
 	RouteIDSelector *v1.Selector `json:"routeIdSelector,omitempty" tf:"-"`
 
@@ -75,15 +75,15 @@ type RouteResponseObservation struct {
 type RouteResponseParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	// +kubebuilder:validation:Optional
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
@@ -102,15 +102,15 @@ type RouteResponseParameters struct {
 	ResponseModels map[string]*string `json:"responseModels,omitempty" tf:"response_models,omitempty"`
 
 	// Identifier of the aws_apigatewayv2_route.
-	// +crossplane:generate:reference:type=Route
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.Route
 	// +kubebuilder:validation:Optional
 	RouteID *string `json:"routeId,omitempty" tf:"route_id,omitempty"`
 
-	// Reference to a Route to populate routeId.
+	// Reference to a Route in apigatewayv2 to populate routeId.
 	// +kubebuilder:validation:Optional
 	RouteIDRef *v1.Reference `json:"routeIdRef,omitempty" tf:"-"`
 
-	// Selector for a Route to populate routeId.
+	// Selector for a Route in apigatewayv2 to populate routeId.
 	// +kubebuilder:validation:Optional
 	RouteIDSelector *v1.Selector `json:"routeIdSelector,omitempty" tf:"-"`
 

--- a/apis/apigatewayv2/v1beta1/zz_stage_types.go
+++ b/apis/apigatewayv2/v1beta1/zz_stage_types.go
@@ -185,14 +185,14 @@ type RouteSettingsParameters struct {
 type StageInitParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
@@ -211,14 +211,14 @@ type StageInitParameters struct {
 	DefaultRouteSettings []DefaultRouteSettingsInitParameters `json:"defaultRouteSettings,omitempty" tf:"default_route_settings,omitempty"`
 
 	// Deployment identifier of the stage. Use the aws_apigatewayv2_deployment resource to configure a deployment.
-	// +crossplane:generate:reference:type=Deployment
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.Deployment
 	DeploymentID *string `json:"deploymentId,omitempty" tf:"deployment_id,omitempty"`
 
-	// Reference to a Deployment to populate deploymentId.
+	// Reference to a Deployment in apigatewayv2 to populate deploymentId.
 	// +kubebuilder:validation:Optional
 	DeploymentIDRef *v1.Reference `json:"deploymentIdRef,omitempty" tf:"-"`
 
-	// Selector for a Deployment to populate deploymentId.
+	// Selector for a Deployment in apigatewayv2 to populate deploymentId.
 	// +kubebuilder:validation:Optional
 	DeploymentIDSelector *v1.Selector `json:"deploymentIdSelector,omitempty" tf:"-"`
 
@@ -296,15 +296,15 @@ type StageObservation struct {
 type StageParameters struct {
 
 	// API identifier.
-	// +crossplane:generate:reference:type=API
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.API
 	// +kubebuilder:validation:Optional
 	APIID *string `json:"apiId,omitempty" tf:"api_id,omitempty"`
 
-	// Reference to a API to populate apiId.
+	// Reference to a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDRef *v1.Reference `json:"apiIdRef,omitempty" tf:"-"`
 
-	// Selector for a API to populate apiId.
+	// Selector for a API in apigatewayv2 to populate apiId.
 	// +kubebuilder:validation:Optional
 	APIIDSelector *v1.Selector `json:"apiIdSelector,omitempty" tf:"-"`
 
@@ -327,15 +327,15 @@ type StageParameters struct {
 	DefaultRouteSettings []DefaultRouteSettingsParameters `json:"defaultRouteSettings,omitempty" tf:"default_route_settings,omitempty"`
 
 	// Deployment identifier of the stage. Use the aws_apigatewayv2_deployment resource to configure a deployment.
-	// +crossplane:generate:reference:type=Deployment
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/apigatewayv2/v1beta1.Deployment
 	// +kubebuilder:validation:Optional
 	DeploymentID *string `json:"deploymentId,omitempty" tf:"deployment_id,omitempty"`
 
-	// Reference to a Deployment to populate deploymentId.
+	// Reference to a Deployment in apigatewayv2 to populate deploymentId.
 	// +kubebuilder:validation:Optional
 	DeploymentIDRef *v1.Reference `json:"deploymentIdRef,omitempty" tf:"-"`
 
-	// Selector for a Deployment to populate deploymentId.
+	// Selector for a Deployment in apigatewayv2 to populate deploymentId.
 	// +kubebuilder:validation:Optional
 	DeploymentIDSelector *v1.Selector `json:"deploymentIdSelector,omitempty" tf:"-"`
 

--- a/apis/autoscaling/v1beta1/zz_generated.resolvers.go
+++ b/apis/autoscaling/v1beta1/zz_generated.resolvers.go
@@ -502,7 +502,7 @@ func (mg *GroupTag) ResolveReferences(ctx context.Context, c client.Reader) erro
 	var rsp reference.ResolutionResponse
 	var err error
 	{
-		m, l, err = apisresolver.GetManagedResource("autoscaling.aws.upbound.io", "v1beta1", "AutoscalingGroup", "AutoscalingGroupList")
+		m, l, err = apisresolver.GetManagedResource("autoscaling.aws.upbound.io", "v1beta2", "AutoscalingGroup", "AutoscalingGroupList")
 		if err != nil {
 			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
 		}
@@ -521,7 +521,7 @@ func (mg *GroupTag) ResolveReferences(ctx context.Context, c client.Reader) erro
 	mg.Spec.ForProvider.AutoscalingGroupName = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.AutoscalingGroupNameRef = rsp.ResolvedReference
 	{
-		m, l, err = apisresolver.GetManagedResource("autoscaling.aws.upbound.io", "v1beta1", "AutoscalingGroup", "AutoscalingGroupList")
+		m, l, err = apisresolver.GetManagedResource("autoscaling.aws.upbound.io", "v1beta2", "AutoscalingGroup", "AutoscalingGroupList")
 		if err != nil {
 			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
 		}

--- a/apis/autoscaling/v1beta1/zz_grouptag_types.go
+++ b/apis/autoscaling/v1beta1/zz_grouptag_types.go
@@ -16,7 +16,7 @@ import (
 type GroupTagInitParameters struct {
 
 	// Name of the Autoscaling Group to apply the tag to.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/autoscaling/v1beta1.AutoscalingGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/autoscaling/v1beta2.AutoscalingGroup
 	AutoscalingGroupName *string `json:"autoscalingGroupName,omitempty" tf:"autoscaling_group_name,omitempty"`
 
 	// Reference to a AutoscalingGroup in autoscaling to populate autoscalingGroupName.
@@ -46,7 +46,7 @@ type GroupTagObservation struct {
 type GroupTagParameters struct {
 
 	// Name of the Autoscaling Group to apply the tag to.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/autoscaling/v1beta1.AutoscalingGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/autoscaling/v1beta2.AutoscalingGroup
 	// +kubebuilder:validation:Optional
 	AutoscalingGroupName *string `json:"autoscalingGroupName,omitempty" tf:"autoscaling_group_name,omitempty"`
 

--- a/apis/autoscaling/v1beta2/zz_attachment_types.go
+++ b/apis/autoscaling/v1beta2/zz_attachment_types.go
@@ -16,14 +16,14 @@ import (
 type AttachmentInitParameters struct {
 
 	// Name of ASG to associate with the ELB.
-	// +crossplane:generate:reference:type=AutoscalingGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/autoscaling/v1beta2.AutoscalingGroup
 	AutoscalingGroupName *string `json:"autoscalingGroupName,omitempty" tf:"autoscaling_group_name,omitempty"`
 
-	// Reference to a AutoscalingGroup to populate autoscalingGroupName.
+	// Reference to a AutoscalingGroup in autoscaling to populate autoscalingGroupName.
 	// +kubebuilder:validation:Optional
 	AutoscalingGroupNameRef *v1.Reference `json:"autoscalingGroupNameRef,omitempty" tf:"-"`
 
-	// Selector for a AutoscalingGroup to populate autoscalingGroupName.
+	// Selector for a AutoscalingGroup in autoscaling to populate autoscalingGroupName.
 	// +kubebuilder:validation:Optional
 	AutoscalingGroupNameSelector *v1.Selector `json:"autoscalingGroupNameSelector,omitempty" tf:"-"`
 
@@ -71,15 +71,15 @@ type AttachmentObservation struct {
 type AttachmentParameters struct {
 
 	// Name of ASG to associate with the ELB.
-	// +crossplane:generate:reference:type=AutoscalingGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/autoscaling/v1beta2.AutoscalingGroup
 	// +kubebuilder:validation:Optional
 	AutoscalingGroupName *string `json:"autoscalingGroupName,omitempty" tf:"autoscaling_group_name,omitempty"`
 
-	// Reference to a AutoscalingGroup to populate autoscalingGroupName.
+	// Reference to a AutoscalingGroup in autoscaling to populate autoscalingGroupName.
 	// +kubebuilder:validation:Optional
 	AutoscalingGroupNameRef *v1.Reference `json:"autoscalingGroupNameRef,omitempty" tf:"-"`
 
-	// Selector for a AutoscalingGroup to populate autoscalingGroupName.
+	// Selector for a AutoscalingGroup in autoscaling to populate autoscalingGroupName.
 	// +kubebuilder:validation:Optional
 	AutoscalingGroupNameSelector *v1.Selector `json:"autoscalingGroupNameSelector,omitempty" tf:"-"`
 

--- a/apis/backup/v1beta1/zz_selection_types.go
+++ b/apis/backup/v1beta1/zz_selection_types.go
@@ -74,14 +74,14 @@ type SelectionInitParameters struct {
 	NotResources []*string `json:"notResources,omitempty" tf:"not_resources,omitempty"`
 
 	// The backup plan ID to be associated with the selection of resources.
-	// +crossplane:generate:reference:type=Plan
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/backup/v1beta1.Plan
 	PlanID *string `json:"planId,omitempty" tf:"plan_id,omitempty"`
 
-	// Reference to a Plan to populate planId.
+	// Reference to a Plan in backup to populate planId.
 	// +kubebuilder:validation:Optional
 	PlanIDRef *v1.Reference `json:"planIdRef,omitempty" tf:"-"`
 
-	// Selector for a Plan to populate planId.
+	// Selector for a Plan in backup to populate planId.
 	// +kubebuilder:validation:Optional
 	PlanIDSelector *v1.Selector `json:"planIdSelector,omitempty" tf:"-"`
 
@@ -152,15 +152,15 @@ type SelectionParameters struct {
 	NotResources []*string `json:"notResources,omitempty" tf:"not_resources,omitempty"`
 
 	// The backup plan ID to be associated with the selection of resources.
-	// +crossplane:generate:reference:type=Plan
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/backup/v1beta1.Plan
 	// +kubebuilder:validation:Optional
 	PlanID *string `json:"planId,omitempty" tf:"plan_id,omitempty"`
 
-	// Reference to a Plan to populate planId.
+	// Reference to a Plan in backup to populate planId.
 	// +kubebuilder:validation:Optional
 	PlanIDRef *v1.Reference `json:"planIdRef,omitempty" tf:"-"`
 
-	// Selector for a Plan to populate planId.
+	// Selector for a Plan in backup to populate planId.
 	// +kubebuilder:validation:Optional
 	PlanIDSelector *v1.Selector `json:"planIdSelector,omitempty" tf:"-"`
 

--- a/apis/backup/v1beta1/zz_vaultlockconfiguration_types.go
+++ b/apis/backup/v1beta1/zz_vaultlockconfiguration_types.go
@@ -16,14 +16,14 @@ import (
 type VaultLockConfigurationInitParameters struct {
 
 	// Name of the backup vault to add a lock configuration for.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/backup/v1beta1.Vault
 	BackupVaultName *string `json:"backupVaultName,omitempty" tf:"backup_vault_name,omitempty"`
 
-	// Reference to a Vault to populate backupVaultName.
+	// Reference to a Vault in backup to populate backupVaultName.
 	// +kubebuilder:validation:Optional
 	BackupVaultNameRef *v1.Reference `json:"backupVaultNameRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate backupVaultName.
+	// Selector for a Vault in backup to populate backupVaultName.
 	// +kubebuilder:validation:Optional
 	BackupVaultNameSelector *v1.Selector `json:"backupVaultNameSelector,omitempty" tf:"-"`
 
@@ -60,15 +60,15 @@ type VaultLockConfigurationObservation struct {
 type VaultLockConfigurationParameters struct {
 
 	// Name of the backup vault to add a lock configuration for.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/backup/v1beta1.Vault
 	// +kubebuilder:validation:Optional
 	BackupVaultName *string `json:"backupVaultName,omitempty" tf:"backup_vault_name,omitempty"`
 
-	// Reference to a Vault to populate backupVaultName.
+	// Reference to a Vault in backup to populate backupVaultName.
 	// +kubebuilder:validation:Optional
 	BackupVaultNameRef *v1.Reference `json:"backupVaultNameRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate backupVaultName.
+	// Selector for a Vault in backup to populate backupVaultName.
 	// +kubebuilder:validation:Optional
 	BackupVaultNameSelector *v1.Selector `json:"backupVaultNameSelector,omitempty" tf:"-"`
 

--- a/apis/backup/v1beta1/zz_vaultnotifications_types.go
+++ b/apis/backup/v1beta1/zz_vaultnotifications_types.go
@@ -20,14 +20,14 @@ type VaultNotificationsInitParameters struct {
 	BackupVaultEvents []*string `json:"backupVaultEvents,omitempty" tf:"backup_vault_events,omitempty"`
 
 	// Name of the backup vault to add notifications for.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/backup/v1beta1.Vault
 	BackupVaultName *string `json:"backupVaultName,omitempty" tf:"backup_vault_name,omitempty"`
 
-	// Reference to a Vault to populate backupVaultName.
+	// Reference to a Vault in backup to populate backupVaultName.
 	// +kubebuilder:validation:Optional
 	BackupVaultNameRef *v1.Reference `json:"backupVaultNameRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate backupVaultName.
+	// Selector for a Vault in backup to populate backupVaultName.
 	// +kubebuilder:validation:Optional
 	BackupVaultNameSelector *v1.Selector `json:"backupVaultNameSelector,omitempty" tf:"-"`
 
@@ -72,15 +72,15 @@ type VaultNotificationsParameters struct {
 	BackupVaultEvents []*string `json:"backupVaultEvents,omitempty" tf:"backup_vault_events,omitempty"`
 
 	// Name of the backup vault to add notifications for.
-	// +crossplane:generate:reference:type=Vault
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/backup/v1beta1.Vault
 	// +kubebuilder:validation:Optional
 	BackupVaultName *string `json:"backupVaultName,omitempty" tf:"backup_vault_name,omitempty"`
 
-	// Reference to a Vault to populate backupVaultName.
+	// Reference to a Vault in backup to populate backupVaultName.
 	// +kubebuilder:validation:Optional
 	BackupVaultNameRef *v1.Reference `json:"backupVaultNameRef,omitempty" tf:"-"`
 
-	// Selector for a Vault to populate backupVaultName.
+	// Selector for a Vault in backup to populate backupVaultName.
 	// +kubebuilder:validation:Optional
 	BackupVaultNameSelector *v1.Selector `json:"backupVaultNameSelector,omitempty" tf:"-"`
 

--- a/apis/cloudfront/v1beta1/zz_keygroup_types.go
+++ b/apis/cloudfront/v1beta1/zz_keygroup_types.go
@@ -18,16 +18,16 @@ type KeyGroupInitParameters struct {
 	// A comment to describe the key group..
 	Comment *string `json:"comment,omitempty" tf:"comment,omitempty"`
 
-	// References to PublicKey to populate items.
+	// References to PublicKey in cloudfront to populate items.
 	// +kubebuilder:validation:Optional
 	ItemRefs []v1.Reference `json:"itemRefs,omitempty" tf:"-"`
 
-	// Selector for a list of PublicKey to populate items.
+	// Selector for a list of PublicKey in cloudfront to populate items.
 	// +kubebuilder:validation:Optional
 	ItemSelector *v1.Selector `json:"itemSelector,omitempty" tf:"-"`
 
 	// A list of the identifiers of the public keys in the key group.
-	// +crossplane:generate:reference:type=PublicKey
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cloudfront/v1beta1.PublicKey
 	// +crossplane:generate:reference:refFieldName=ItemRefs
 	// +crossplane:generate:reference:selectorFieldName=ItemSelector
 	// +listType=set
@@ -62,16 +62,16 @@ type KeyGroupParameters struct {
 	// +kubebuilder:validation:Optional
 	Comment *string `json:"comment,omitempty" tf:"comment,omitempty"`
 
-	// References to PublicKey to populate items.
+	// References to PublicKey in cloudfront to populate items.
 	// +kubebuilder:validation:Optional
 	ItemRefs []v1.Reference `json:"itemRefs,omitempty" tf:"-"`
 
-	// Selector for a list of PublicKey to populate items.
+	// Selector for a list of PublicKey in cloudfront to populate items.
 	// +kubebuilder:validation:Optional
 	ItemSelector *v1.Selector `json:"itemSelector,omitempty" tf:"-"`
 
 	// A list of the identifiers of the public keys in the key group.
-	// +crossplane:generate:reference:type=PublicKey
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cloudfront/v1beta1.PublicKey
 	// +crossplane:generate:reference:refFieldName=ItemRefs
 	// +crossplane:generate:reference:selectorFieldName=ItemSelector
 	// +kubebuilder:validation:Optional

--- a/apis/cloudwatchevents/v1beta1/zz_permission_types.go
+++ b/apis/cloudwatchevents/v1beta1/zz_permission_types.go
@@ -82,14 +82,14 @@ type PermissionInitParameters struct {
 
 	// The name of the event bus to set the permissions on.
 	// If you omit this, the permissions are set on the default event bus.
-	// +crossplane:generate:reference:type=Bus
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cloudwatchevents/v1beta1.Bus
 	EventBusName *string `json:"eventBusName,omitempty" tf:"event_bus_name,omitempty"`
 
-	// Reference to a Bus to populate eventBusName.
+	// Reference to a Bus in cloudwatchevents to populate eventBusName.
 	// +kubebuilder:validation:Optional
 	EventBusNameRef *v1.Reference `json:"eventBusNameRef,omitempty" tf:"-"`
 
-	// Selector for a Bus to populate eventBusName.
+	// Selector for a Bus in cloudwatchevents to populate eventBusName.
 	// +kubebuilder:validation:Optional
 	EventBusNameSelector *v1.Selector `json:"eventBusNameSelector,omitempty" tf:"-"`
 
@@ -134,15 +134,15 @@ type PermissionParameters struct {
 
 	// The name of the event bus to set the permissions on.
 	// If you omit this, the permissions are set on the default event bus.
-	// +crossplane:generate:reference:type=Bus
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cloudwatchevents/v1beta1.Bus
 	// +kubebuilder:validation:Optional
 	EventBusName *string `json:"eventBusName,omitempty" tf:"event_bus_name,omitempty"`
 
-	// Reference to a Bus to populate eventBusName.
+	// Reference to a Bus in cloudwatchevents to populate eventBusName.
 	// +kubebuilder:validation:Optional
 	EventBusNameRef *v1.Reference `json:"eventBusNameRef,omitempty" tf:"-"`
 
-	// Selector for a Bus to populate eventBusName.
+	// Selector for a Bus in cloudwatchevents to populate eventBusName.
 	// +kubebuilder:validation:Optional
 	EventBusNameSelector *v1.Selector `json:"eventBusNameSelector,omitempty" tf:"-"`
 

--- a/apis/cloudwatchevents/v1beta1/zz_rule_types.go
+++ b/apis/cloudwatchevents/v1beta1/zz_rule_types.go
@@ -20,14 +20,14 @@ type RuleInitParameters struct {
 
 	// The name or ARN of the event bus to associate with this rule.
 	// If you omit this, the default event bus is used.
-	// +crossplane:generate:reference:type=Bus
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cloudwatchevents/v1beta1.Bus
 	EventBusName *string `json:"eventBusName,omitempty" tf:"event_bus_name,omitempty"`
 
-	// Reference to a Bus to populate eventBusName.
+	// Reference to a Bus in cloudwatchevents to populate eventBusName.
 	// +kubebuilder:validation:Optional
 	EventBusNameRef *v1.Reference `json:"eventBusNameRef,omitempty" tf:"-"`
 
-	// Selector for a Bus to populate eventBusName.
+	// Selector for a Bus in cloudwatchevents to populate eventBusName.
 	// +kubebuilder:validation:Optional
 	EventBusNameSelector *v1.Selector `json:"eventBusNameSelector,omitempty" tf:"-"`
 
@@ -122,15 +122,15 @@ type RuleParameters struct {
 
 	// The name or ARN of the event bus to associate with this rule.
 	// If you omit this, the default event bus is used.
-	// +crossplane:generate:reference:type=Bus
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cloudwatchevents/v1beta1.Bus
 	// +kubebuilder:validation:Optional
 	EventBusName *string `json:"eventBusName,omitempty" tf:"event_bus_name,omitempty"`
 
-	// Reference to a Bus to populate eventBusName.
+	// Reference to a Bus in cloudwatchevents to populate eventBusName.
 	// +kubebuilder:validation:Optional
 	EventBusNameRef *v1.Reference `json:"eventBusNameRef,omitempty" tf:"-"`
 
-	// Selector for a Bus to populate eventBusName.
+	// Selector for a Bus in cloudwatchevents to populate eventBusName.
 	// +kubebuilder:validation:Optional
 	EventBusNameSelector *v1.Selector `json:"eventBusNameSelector,omitempty" tf:"-"`
 

--- a/apis/cloudwatchevents/v1beta1/zz_target_types.go
+++ b/apis/cloudwatchevents/v1beta1/zz_target_types.go
@@ -691,14 +691,14 @@ type TargetInitParameters struct {
 
 	// The name or ARN of the event bus to associate with the rule.
 	// If you omit this, the default event bus is used.
-	// +crossplane:generate:reference:type=Bus
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cloudwatchevents/v1beta1.Bus
 	EventBusName *string `json:"eventBusName,omitempty" tf:"event_bus_name,omitempty"`
 
-	// Reference to a Bus to populate eventBusName.
+	// Reference to a Bus in cloudwatchevents to populate eventBusName.
 	// +kubebuilder:validation:Optional
 	EventBusNameRef *v1.Reference `json:"eventBusNameRef,omitempty" tf:"-"`
 
-	// Selector for a Bus to populate eventBusName.
+	// Selector for a Bus in cloudwatchevents to populate eventBusName.
 	// +kubebuilder:validation:Optional
 	EventBusNameSelector *v1.Selector `json:"eventBusNameSelector,omitempty" tf:"-"`
 
@@ -841,15 +841,15 @@ type TargetParameters struct {
 
 	// The name or ARN of the event bus to associate with the rule.
 	// If you omit this, the default event bus is used.
-	// +crossplane:generate:reference:type=Bus
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cloudwatchevents/v1beta1.Bus
 	// +kubebuilder:validation:Optional
 	EventBusName *string `json:"eventBusName,omitempty" tf:"event_bus_name,omitempty"`
 
-	// Reference to a Bus to populate eventBusName.
+	// Reference to a Bus in cloudwatchevents to populate eventBusName.
 	// +kubebuilder:validation:Optional
 	EventBusNameRef *v1.Reference `json:"eventBusNameRef,omitempty" tf:"-"`
 
-	// Selector for a Bus to populate eventBusName.
+	// Selector for a Bus in cloudwatchevents to populate eventBusName.
 	// +kubebuilder:validation:Optional
 	EventBusNameSelector *v1.Selector `json:"eventBusNameSelector,omitempty" tf:"-"`
 

--- a/apis/cognitoidp/v1beta1/zz_identityprovider_types.go
+++ b/apis/cognitoidp/v1beta1/zz_identityprovider_types.go
@@ -33,14 +33,14 @@ type IdentityProviderInitParameters struct {
 	ProviderType *string `json:"providerType,omitempty" tf:"provider_type,omitempty"`
 
 	// The user pool id
-	// +crossplane:generate:reference:type=UserPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cognitoidp/v1beta1.UserPool
 	UserPoolID *string `json:"userPoolId,omitempty" tf:"user_pool_id,omitempty"`
 
-	// Reference to a UserPool to populate userPoolId.
+	// Reference to a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDRef *v1.Reference `json:"userPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a UserPool to populate userPoolId.
+	// Selector for a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDSelector *v1.Selector `json:"userPoolIdSelector,omitempty" tf:"-"`
 }
@@ -100,15 +100,15 @@ type IdentityProviderParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// The user pool id
-	// +crossplane:generate:reference:type=UserPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cognitoidp/v1beta1.UserPool
 	// +kubebuilder:validation:Optional
 	UserPoolID *string `json:"userPoolId,omitempty" tf:"user_pool_id,omitempty"`
 
-	// Reference to a UserPool to populate userPoolId.
+	// Reference to a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDRef *v1.Reference `json:"userPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a UserPool to populate userPoolId.
+	// Selector for a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDSelector *v1.Selector `json:"userPoolIdSelector,omitempty" tf:"-"`
 }

--- a/apis/cognitoidp/v1beta1/zz_resourceserver_types.go
+++ b/apis/cognitoidp/v1beta1/zz_resourceserver_types.go
@@ -24,14 +24,14 @@ type ResourceServerInitParameters struct {
 	// A list of Authorization Scope.
 	Scope []ScopeInitParameters `json:"scope,omitempty" tf:"scope,omitempty"`
 
-	// +crossplane:generate:reference:type=UserPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cognitoidp/v1beta1.UserPool
 	UserPoolID *string `json:"userPoolId,omitempty" tf:"user_pool_id,omitempty"`
 
-	// Reference to a UserPool to populate userPoolId.
+	// Reference to a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDRef *v1.Reference `json:"userPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a UserPool to populate userPoolId.
+	// Selector for a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDSelector *v1.Selector `json:"userPoolIdSelector,omitempty" tf:"-"`
 }
@@ -73,15 +73,15 @@ type ResourceServerParameters struct {
 	// +kubebuilder:validation:Optional
 	Scope []ScopeParameters `json:"scope,omitempty" tf:"scope,omitempty"`
 
-	// +crossplane:generate:reference:type=UserPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cognitoidp/v1beta1.UserPool
 	// +kubebuilder:validation:Optional
 	UserPoolID *string `json:"userPoolId,omitempty" tf:"user_pool_id,omitempty"`
 
-	// Reference to a UserPool to populate userPoolId.
+	// Reference to a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDRef *v1.Reference `json:"userPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a UserPool to populate userPoolId.
+	// Selector for a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDSelector *v1.Selector `json:"userPoolIdSelector,omitempty" tf:"-"`
 }

--- a/apis/cognitoidp/v1beta1/zz_usergroup_types.go
+++ b/apis/cognitoidp/v1beta1/zz_usergroup_types.go
@@ -38,14 +38,14 @@ type UserGroupInitParameters struct {
 	RoleArnSelector *v1.Selector `json:"roleArnSelector,omitempty" tf:"-"`
 
 	// The user pool ID.
-	// +crossplane:generate:reference:type=UserPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cognitoidp/v1beta1.UserPool
 	UserPoolID *string `json:"userPoolId,omitempty" tf:"user_pool_id,omitempty"`
 
-	// Reference to a UserPool to populate userPoolId.
+	// Reference to a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDRef *v1.Reference `json:"userPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a UserPool to populate userPoolId.
+	// Selector for a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDSelector *v1.Selector `json:"userPoolIdSelector,omitempty" tf:"-"`
 }
@@ -104,15 +104,15 @@ type UserGroupParameters struct {
 	RoleArnSelector *v1.Selector `json:"roleArnSelector,omitempty" tf:"-"`
 
 	// The user pool ID.
-	// +crossplane:generate:reference:type=UserPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cognitoidp/v1beta1.UserPool
 	// +kubebuilder:validation:Optional
 	UserPoolID *string `json:"userPoolId,omitempty" tf:"user_pool_id,omitempty"`
 
-	// Reference to a UserPool to populate userPoolId.
+	// Reference to a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDRef *v1.Reference `json:"userPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a UserPool to populate userPoolId.
+	// Selector for a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDSelector *v1.Selector `json:"userPoolIdSelector,omitempty" tf:"-"`
 }

--- a/apis/cognitoidp/v1beta1/zz_userpoolclient_types.go
+++ b/apis/cognitoidp/v1beta1/zz_userpoolclient_types.go
@@ -227,14 +227,14 @@ type UserPoolClientInitParameters struct {
 	TokenValidityUnits []TokenValidityUnitsInitParameters `json:"tokenValidityUnits,omitempty" tf:"token_validity_units,omitempty"`
 
 	// User pool the client belongs to.
-	// +crossplane:generate:reference:type=UserPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cognitoidp/v1beta1.UserPool
 	UserPoolID *string `json:"userPoolId,omitempty" tf:"user_pool_id,omitempty"`
 
-	// Reference to a UserPool to populate userPoolId.
+	// Reference to a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDRef *v1.Reference `json:"userPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a UserPool to populate userPoolId.
+	// Selector for a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDSelector *v1.Selector `json:"userPoolIdSelector,omitempty" tf:"-"`
 
@@ -430,15 +430,15 @@ type UserPoolClientParameters struct {
 	TokenValidityUnits []TokenValidityUnitsParameters `json:"tokenValidityUnits,omitempty" tf:"token_validity_units,omitempty"`
 
 	// User pool the client belongs to.
-	// +crossplane:generate:reference:type=UserPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cognitoidp/v1beta1.UserPool
 	// +kubebuilder:validation:Optional
 	UserPoolID *string `json:"userPoolId,omitempty" tf:"user_pool_id,omitempty"`
 
-	// Reference to a UserPool to populate userPoolId.
+	// Reference to a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDRef *v1.Reference `json:"userPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a UserPool to populate userPoolId.
+	// Selector for a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDSelector *v1.Selector `json:"userPoolIdSelector,omitempty" tf:"-"`
 

--- a/apis/cognitoidp/v1beta1/zz_userpooldomain_types.go
+++ b/apis/cognitoidp/v1beta1/zz_userpooldomain_types.go
@@ -32,14 +32,14 @@ type UserPoolDomainInitParameters struct {
 	Domain *string `json:"domain,omitempty" tf:"domain,omitempty"`
 
 	// The user pool ID.
-	// +crossplane:generate:reference:type=UserPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cognitoidp/v1beta1.UserPool
 	UserPoolID *string `json:"userPoolId,omitempty" tf:"user_pool_id,omitempty"`
 
-	// Reference to a UserPool to populate userPoolId.
+	// Reference to a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDRef *v1.Reference `json:"userPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a UserPool to populate userPoolId.
+	// Selector for a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDSelector *v1.Selector `json:"userPoolIdSelector,omitempty" tf:"-"`
 }
@@ -102,15 +102,15 @@ type UserPoolDomainParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// The user pool ID.
-	// +crossplane:generate:reference:type=UserPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cognitoidp/v1beta1.UserPool
 	// +kubebuilder:validation:Optional
 	UserPoolID *string `json:"userPoolId,omitempty" tf:"user_pool_id,omitempty"`
 
-	// Reference to a UserPool to populate userPoolId.
+	// Reference to a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDRef *v1.Reference `json:"userPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a UserPool to populate userPoolId.
+	// Selector for a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDSelector *v1.Selector `json:"userPoolIdSelector,omitempty" tf:"-"`
 }

--- a/apis/cognitoidp/v1beta1/zz_userpooluicustomization_types.go
+++ b/apis/cognitoidp/v1beta1/zz_userpooluicustomization_types.go
@@ -19,14 +19,14 @@ type UserPoolUICustomizationInitParameters struct {
 	CSS *string `json:"css,omitempty" tf:"css,omitempty"`
 
 	// The client ID for the client app. Defaults to ALL. If ALL is specified, the css and/or image_file settings will be used for every client that has no UI customization set previously.
-	// +crossplane:generate:reference:type=UserPoolClient
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cognitoidp/v1beta1.UserPoolClient
 	ClientID *string `json:"clientId,omitempty" tf:"client_id,omitempty"`
 
-	// Reference to a UserPoolClient to populate clientId.
+	// Reference to a UserPoolClient in cognitoidp to populate clientId.
 	// +kubebuilder:validation:Optional
 	ClientIDRef *v1.Reference `json:"clientIdRef,omitempty" tf:"-"`
 
-	// Selector for a UserPoolClient to populate clientId.
+	// Selector for a UserPoolClient in cognitoidp to populate clientId.
 	// +kubebuilder:validation:Optional
 	ClientIDSelector *v1.Selector `json:"clientIdSelector,omitempty" tf:"-"`
 
@@ -34,14 +34,14 @@ type UserPoolUICustomizationInitParameters struct {
 	ImageFile *string `json:"imageFile,omitempty" tf:"image_file,omitempty"`
 
 	// The user pool ID for the user pool.
-	// +crossplane:generate:reference:type=UserPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cognitoidp/v1beta1.UserPool
 	UserPoolID *string `json:"userPoolId,omitempty" tf:"user_pool_id,omitempty"`
 
-	// Reference to a UserPool to populate userPoolId.
+	// Reference to a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDRef *v1.Reference `json:"userPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a UserPool to populate userPoolId.
+	// Selector for a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDSelector *v1.Selector `json:"userPoolIdSelector,omitempty" tf:"-"`
 }
@@ -82,15 +82,15 @@ type UserPoolUICustomizationParameters struct {
 	CSS *string `json:"css,omitempty" tf:"css,omitempty"`
 
 	// The client ID for the client app. Defaults to ALL. If ALL is specified, the css and/or image_file settings will be used for every client that has no UI customization set previously.
-	// +crossplane:generate:reference:type=UserPoolClient
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cognitoidp/v1beta1.UserPoolClient
 	// +kubebuilder:validation:Optional
 	ClientID *string `json:"clientId,omitempty" tf:"client_id,omitempty"`
 
-	// Reference to a UserPoolClient to populate clientId.
+	// Reference to a UserPoolClient in cognitoidp to populate clientId.
 	// +kubebuilder:validation:Optional
 	ClientIDRef *v1.Reference `json:"clientIdRef,omitempty" tf:"-"`
 
-	// Selector for a UserPoolClient to populate clientId.
+	// Selector for a UserPoolClient in cognitoidp to populate clientId.
 	// +kubebuilder:validation:Optional
 	ClientIDSelector *v1.Selector `json:"clientIdSelector,omitempty" tf:"-"`
 
@@ -104,15 +104,15 @@ type UserPoolUICustomizationParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// The user pool ID for the user pool.
-	// +crossplane:generate:reference:type=UserPool
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/cognitoidp/v1beta1.UserPool
 	// +kubebuilder:validation:Optional
 	UserPoolID *string `json:"userPoolId,omitempty" tf:"user_pool_id,omitempty"`
 
-	// Reference to a UserPool to populate userPoolId.
+	// Reference to a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDRef *v1.Reference `json:"userPoolIdRef,omitempty" tf:"-"`
 
-	// Selector for a UserPool to populate userPoolId.
+	// Selector for a UserPool in cognitoidp to populate userPoolId.
 	// +kubebuilder:validation:Optional
 	UserPoolIDSelector *v1.Selector `json:"userPoolIdSelector,omitempty" tf:"-"`
 }

--- a/apis/datasync/v1beta1/zz_task_types.go
+++ b/apis/datasync/v1beta1/zz_task_types.go
@@ -353,14 +353,14 @@ type TaskInitParameters struct {
 	CloudwatchLogGroupArnSelector *v1.Selector `json:"cloudwatchLogGroupArnSelector,omitempty" tf:"-"`
 
 	// Amazon Resource Name (ARN) of destination DataSync Location.
-	// +crossplane:generate:reference:type=LocationS3
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/datasync/v1beta1.LocationS3
 	DestinationLocationArn *string `json:"destinationLocationArn,omitempty" tf:"destination_location_arn,omitempty"`
 
-	// Reference to a LocationS3 to populate destinationLocationArn.
+	// Reference to a LocationS3 in datasync to populate destinationLocationArn.
 	// +kubebuilder:validation:Optional
 	DestinationLocationArnRef *v1.Reference `json:"destinationLocationArnRef,omitempty" tf:"-"`
 
-	// Selector for a LocationS3 to populate destinationLocationArn.
+	// Selector for a LocationS3 in datasync to populate destinationLocationArn.
 	// +kubebuilder:validation:Optional
 	DestinationLocationArnSelector *v1.Selector `json:"destinationLocationArnSelector,omitempty" tf:"-"`
 
@@ -380,14 +380,14 @@ type TaskInitParameters struct {
 	Schedule []ScheduleInitParameters `json:"schedule,omitempty" tf:"schedule,omitempty"`
 
 	// Amazon Resource Name (ARN) of source DataSync Location.
-	// +crossplane:generate:reference:type=LocationS3
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/datasync/v1beta1.LocationS3
 	SourceLocationArn *string `json:"sourceLocationArn,omitempty" tf:"source_location_arn,omitempty"`
 
-	// Reference to a LocationS3 to populate sourceLocationArn.
+	// Reference to a LocationS3 in datasync to populate sourceLocationArn.
 	// +kubebuilder:validation:Optional
 	SourceLocationArnRef *v1.Reference `json:"sourceLocationArnRef,omitempty" tf:"-"`
 
-	// Selector for a LocationS3 to populate sourceLocationArn.
+	// Selector for a LocationS3 in datasync to populate sourceLocationArn.
 	// +kubebuilder:validation:Optional
 	SourceLocationArnSelector *v1.Selector `json:"sourceLocationArnSelector,omitempty" tf:"-"`
 
@@ -460,15 +460,15 @@ type TaskParameters struct {
 	CloudwatchLogGroupArnSelector *v1.Selector `json:"cloudwatchLogGroupArnSelector,omitempty" tf:"-"`
 
 	// Amazon Resource Name (ARN) of destination DataSync Location.
-	// +crossplane:generate:reference:type=LocationS3
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/datasync/v1beta1.LocationS3
 	// +kubebuilder:validation:Optional
 	DestinationLocationArn *string `json:"destinationLocationArn,omitempty" tf:"destination_location_arn,omitempty"`
 
-	// Reference to a LocationS3 to populate destinationLocationArn.
+	// Reference to a LocationS3 in datasync to populate destinationLocationArn.
 	// +kubebuilder:validation:Optional
 	DestinationLocationArnRef *v1.Reference `json:"destinationLocationArnRef,omitempty" tf:"-"`
 
-	// Selector for a LocationS3 to populate destinationLocationArn.
+	// Selector for a LocationS3 in datasync to populate destinationLocationArn.
 	// +kubebuilder:validation:Optional
 	DestinationLocationArnSelector *v1.Selector `json:"destinationLocationArnSelector,omitempty" tf:"-"`
 
@@ -498,15 +498,15 @@ type TaskParameters struct {
 	Schedule []ScheduleParameters `json:"schedule,omitempty" tf:"schedule,omitempty"`
 
 	// Amazon Resource Name (ARN) of source DataSync Location.
-	// +crossplane:generate:reference:type=LocationS3
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/datasync/v1beta1.LocationS3
 	// +kubebuilder:validation:Optional
 	SourceLocationArn *string `json:"sourceLocationArn,omitempty" tf:"source_location_arn,omitempty"`
 
-	// Reference to a LocationS3 to populate sourceLocationArn.
+	// Reference to a LocationS3 in datasync to populate sourceLocationArn.
 	// +kubebuilder:validation:Optional
 	SourceLocationArnRef *v1.Reference `json:"sourceLocationArnRef,omitempty" tf:"-"`
 
-	// Selector for a LocationS3 to populate sourceLocationArn.
+	// Selector for a LocationS3 in datasync to populate sourceLocationArn.
 	// +kubebuilder:validation:Optional
 	SourceLocationArnSelector *v1.Selector `json:"sourceLocationArnSelector,omitempty" tf:"-"`
 

--- a/apis/directconnect/v1beta1/zz_hostedprivatevirtualinterface_types.go
+++ b/apis/directconnect/v1beta1/zz_hostedprivatevirtualinterface_types.go
@@ -28,14 +28,14 @@ type HostedPrivateVirtualInterfaceInitParameters struct {
 	BGPAuthKey *string `json:"bgpAuthKey,omitempty" tf:"bgp_auth_key,omitempty"`
 
 	// The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
-	// +crossplane:generate:reference:type=Connection
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.Connection
 	ConnectionID *string `json:"connectionId,omitempty" tf:"connection_id,omitempty"`
 
-	// Reference to a Connection to populate connectionId.
+	// Reference to a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDRef *v1.Reference `json:"connectionIdRef,omitempty" tf:"-"`
 
-	// Selector for a Connection to populate connectionId.
+	// Selector for a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDSelector *v1.Selector `json:"connectionIdSelector,omitempty" tf:"-"`
 
@@ -121,15 +121,15 @@ type HostedPrivateVirtualInterfaceParameters struct {
 	BGPAuthKey *string `json:"bgpAuthKey,omitempty" tf:"bgp_auth_key,omitempty"`
 
 	// The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
-	// +crossplane:generate:reference:type=Connection
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.Connection
 	// +kubebuilder:validation:Optional
 	ConnectionID *string `json:"connectionId,omitempty" tf:"connection_id,omitempty"`
 
-	// Reference to a Connection to populate connectionId.
+	// Reference to a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDRef *v1.Reference `json:"connectionIdRef,omitempty" tf:"-"`
 
-	// Selector for a Connection to populate connectionId.
+	// Selector for a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDSelector *v1.Selector `json:"connectionIdSelector,omitempty" tf:"-"`
 

--- a/apis/directconnect/v1beta1/zz_hostedprivatevirtualinterfaceaccepter_types.go
+++ b/apis/directconnect/v1beta1/zz_hostedprivatevirtualinterfaceaccepter_types.go
@@ -36,14 +36,14 @@ type HostedPrivateVirtualInterfaceAccepterInitParameters struct {
 	VPNGatewayIDSelector *v1.Selector `json:"vpnGatewayIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Direct Connect virtual interface to accept.
-	// +crossplane:generate:reference:type=HostedPrivateVirtualInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.HostedPrivateVirtualInterface
 	VirtualInterfaceID *string `json:"virtualInterfaceId,omitempty" tf:"virtual_interface_id,omitempty"`
 
-	// Reference to a HostedPrivateVirtualInterface to populate virtualInterfaceId.
+	// Reference to a HostedPrivateVirtualInterface in directconnect to populate virtualInterfaceId.
 	// +kubebuilder:validation:Optional
 	VirtualInterfaceIDRef *v1.Reference `json:"virtualInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a HostedPrivateVirtualInterface to populate virtualInterfaceId.
+	// Selector for a HostedPrivateVirtualInterface in directconnect to populate virtualInterfaceId.
 	// +kubebuilder:validation:Optional
 	VirtualInterfaceIDSelector *v1.Selector `json:"virtualInterfaceIdSelector,omitempty" tf:"-"`
 }
@@ -105,15 +105,15 @@ type HostedPrivateVirtualInterfaceAccepterParameters struct {
 	VPNGatewayIDSelector *v1.Selector `json:"vpnGatewayIdSelector,omitempty" tf:"-"`
 
 	// The ID of the Direct Connect virtual interface to accept.
-	// +crossplane:generate:reference:type=HostedPrivateVirtualInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.HostedPrivateVirtualInterface
 	// +kubebuilder:validation:Optional
 	VirtualInterfaceID *string `json:"virtualInterfaceId,omitempty" tf:"virtual_interface_id,omitempty"`
 
-	// Reference to a HostedPrivateVirtualInterface to populate virtualInterfaceId.
+	// Reference to a HostedPrivateVirtualInterface in directconnect to populate virtualInterfaceId.
 	// +kubebuilder:validation:Optional
 	VirtualInterfaceIDRef *v1.Reference `json:"virtualInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a HostedPrivateVirtualInterface to populate virtualInterfaceId.
+	// Selector for a HostedPrivateVirtualInterface in directconnect to populate virtualInterfaceId.
 	// +kubebuilder:validation:Optional
 	VirtualInterfaceIDSelector *v1.Selector `json:"virtualInterfaceIdSelector,omitempty" tf:"-"`
 }

--- a/apis/directconnect/v1beta1/zz_hostedpublicvirtualinterface_types.go
+++ b/apis/directconnect/v1beta1/zz_hostedpublicvirtualinterface_types.go
@@ -28,14 +28,14 @@ type HostedPublicVirtualInterfaceInitParameters struct {
 	BGPAuthKey *string `json:"bgpAuthKey,omitempty" tf:"bgp_auth_key,omitempty"`
 
 	// The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
-	// +crossplane:generate:reference:type=Connection
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.Connection
 	ConnectionID *string `json:"connectionId,omitempty" tf:"connection_id,omitempty"`
 
-	// Reference to a Connection to populate connectionId.
+	// Reference to a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDRef *v1.Reference `json:"connectionIdRef,omitempty" tf:"-"`
 
-	// Selector for a Connection to populate connectionId.
+	// Selector for a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDSelector *v1.Selector `json:"connectionIdSelector,omitempty" tf:"-"`
 
@@ -120,15 +120,15 @@ type HostedPublicVirtualInterfaceParameters struct {
 	BGPAuthKey *string `json:"bgpAuthKey,omitempty" tf:"bgp_auth_key,omitempty"`
 
 	// The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
-	// +crossplane:generate:reference:type=Connection
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.Connection
 	// +kubebuilder:validation:Optional
 	ConnectionID *string `json:"connectionId,omitempty" tf:"connection_id,omitempty"`
 
-	// Reference to a Connection to populate connectionId.
+	// Reference to a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDRef *v1.Reference `json:"connectionIdRef,omitempty" tf:"-"`
 
-	// Selector for a Connection to populate connectionId.
+	// Selector for a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDSelector *v1.Selector `json:"connectionIdSelector,omitempty" tf:"-"`
 

--- a/apis/directconnect/v1beta1/zz_hostedpublicvirtualinterfaceaccepter_types.go
+++ b/apis/directconnect/v1beta1/zz_hostedpublicvirtualinterfaceaccepter_types.go
@@ -20,14 +20,14 @@ type HostedPublicVirtualInterfaceAccepterInitParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// The ID of the Direct Connect virtual interface to accept.
-	// +crossplane:generate:reference:type=HostedPublicVirtualInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.HostedPublicVirtualInterface
 	VirtualInterfaceID *string `json:"virtualInterfaceId,omitempty" tf:"virtual_interface_id,omitempty"`
 
-	// Reference to a HostedPublicVirtualInterface to populate virtualInterfaceId.
+	// Reference to a HostedPublicVirtualInterface in directconnect to populate virtualInterfaceId.
 	// +kubebuilder:validation:Optional
 	VirtualInterfaceIDRef *v1.Reference `json:"virtualInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a HostedPublicVirtualInterface to populate virtualInterfaceId.
+	// Selector for a HostedPublicVirtualInterface in directconnect to populate virtualInterfaceId.
 	// +kubebuilder:validation:Optional
 	VirtualInterfaceIDSelector *v1.Selector `json:"virtualInterfaceIdSelector,omitempty" tf:"-"`
 }
@@ -65,15 +65,15 @@ type HostedPublicVirtualInterfaceAccepterParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// The ID of the Direct Connect virtual interface to accept.
-	// +crossplane:generate:reference:type=HostedPublicVirtualInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.HostedPublicVirtualInterface
 	// +kubebuilder:validation:Optional
 	VirtualInterfaceID *string `json:"virtualInterfaceId,omitempty" tf:"virtual_interface_id,omitempty"`
 
-	// Reference to a HostedPublicVirtualInterface to populate virtualInterfaceId.
+	// Reference to a HostedPublicVirtualInterface in directconnect to populate virtualInterfaceId.
 	// +kubebuilder:validation:Optional
 	VirtualInterfaceIDRef *v1.Reference `json:"virtualInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a HostedPublicVirtualInterface to populate virtualInterfaceId.
+	// Selector for a HostedPublicVirtualInterface in directconnect to populate virtualInterfaceId.
 	// +kubebuilder:validation:Optional
 	VirtualInterfaceIDSelector *v1.Selector `json:"virtualInterfaceIdSelector,omitempty" tf:"-"`
 }

--- a/apis/directconnect/v1beta1/zz_hostedtransitvirtualinterface_types.go
+++ b/apis/directconnect/v1beta1/zz_hostedtransitvirtualinterface_types.go
@@ -28,14 +28,14 @@ type HostedTransitVirtualInterfaceInitParameters struct {
 	BGPAuthKey *string `json:"bgpAuthKey,omitempty" tf:"bgp_auth_key,omitempty"`
 
 	// The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
-	// +crossplane:generate:reference:type=Connection
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.Connection
 	ConnectionID *string `json:"connectionId,omitempty" tf:"connection_id,omitempty"`
 
-	// Reference to a Connection to populate connectionId.
+	// Reference to a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDRef *v1.Reference `json:"connectionIdRef,omitempty" tf:"-"`
 
-	// Selector for a Connection to populate connectionId.
+	// Selector for a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDSelector *v1.Selector `json:"connectionIdSelector,omitempty" tf:"-"`
 
@@ -121,15 +121,15 @@ type HostedTransitVirtualInterfaceParameters struct {
 	BGPAuthKey *string `json:"bgpAuthKey,omitempty" tf:"bgp_auth_key,omitempty"`
 
 	// The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
-	// +crossplane:generate:reference:type=Connection
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.Connection
 	// +kubebuilder:validation:Optional
 	ConnectionID *string `json:"connectionId,omitempty" tf:"connection_id,omitempty"`
 
-	// Reference to a Connection to populate connectionId.
+	// Reference to a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDRef *v1.Reference `json:"connectionIdRef,omitempty" tf:"-"`
 
-	// Selector for a Connection to populate connectionId.
+	// Selector for a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDSelector *v1.Selector `json:"connectionIdSelector,omitempty" tf:"-"`
 

--- a/apis/directconnect/v1beta1/zz_hostedtransitvirtualinterfaceaccepter_types.go
+++ b/apis/directconnect/v1beta1/zz_hostedtransitvirtualinterfaceaccepter_types.go
@@ -33,14 +33,14 @@ type HostedTransitVirtualInterfaceAccepterInitParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// The ID of the Direct Connect virtual interface to accept.
-	// +crossplane:generate:reference:type=HostedTransitVirtualInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.HostedTransitVirtualInterface
 	VirtualInterfaceID *string `json:"virtualInterfaceId,omitempty" tf:"virtual_interface_id,omitempty"`
 
-	// Reference to a HostedTransitVirtualInterface to populate virtualInterfaceId.
+	// Reference to a HostedTransitVirtualInterface in directconnect to populate virtualInterfaceId.
 	// +kubebuilder:validation:Optional
 	VirtualInterfaceIDRef *v1.Reference `json:"virtualInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a HostedTransitVirtualInterface to populate virtualInterfaceId.
+	// Selector for a HostedTransitVirtualInterface in directconnect to populate virtualInterfaceId.
 	// +kubebuilder:validation:Optional
 	VirtualInterfaceIDSelector *v1.Selector `json:"virtualInterfaceIdSelector,omitempty" tf:"-"`
 }
@@ -95,15 +95,15 @@ type HostedTransitVirtualInterfaceAccepterParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// The ID of the Direct Connect virtual interface to accept.
-	// +crossplane:generate:reference:type=HostedTransitVirtualInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.HostedTransitVirtualInterface
 	// +kubebuilder:validation:Optional
 	VirtualInterfaceID *string `json:"virtualInterfaceId,omitempty" tf:"virtual_interface_id,omitempty"`
 
-	// Reference to a HostedTransitVirtualInterface to populate virtualInterfaceId.
+	// Reference to a HostedTransitVirtualInterface in directconnect to populate virtualInterfaceId.
 	// +kubebuilder:validation:Optional
 	VirtualInterfaceIDRef *v1.Reference `json:"virtualInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a HostedTransitVirtualInterface to populate virtualInterfaceId.
+	// Selector for a HostedTransitVirtualInterface in directconnect to populate virtualInterfaceId.
 	// +kubebuilder:validation:Optional
 	VirtualInterfaceIDSelector *v1.Selector `json:"virtualInterfaceIdSelector,omitempty" tf:"-"`
 }

--- a/apis/directconnect/v1beta1/zz_privatevirtualinterface_types.go
+++ b/apis/directconnect/v1beta1/zz_privatevirtualinterface_types.go
@@ -28,14 +28,14 @@ type PrivateVirtualInterfaceInitParameters struct {
 	BGPAuthKey *string `json:"bgpAuthKey,omitempty" tf:"bgp_auth_key,omitempty"`
 
 	// The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
-	// +crossplane:generate:reference:type=Connection
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.Connection
 	ConnectionID *string `json:"connectionId,omitempty" tf:"connection_id,omitempty"`
 
-	// Reference to a Connection to populate connectionId.
+	// Reference to a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDRef *v1.Reference `json:"connectionIdRef,omitempty" tf:"-"`
 
-	// Selector for a Connection to populate connectionId.
+	// Selector for a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDSelector *v1.Selector `json:"connectionIdSelector,omitempty" tf:"-"`
 
@@ -156,15 +156,15 @@ type PrivateVirtualInterfaceParameters struct {
 	BGPAuthKey *string `json:"bgpAuthKey,omitempty" tf:"bgp_auth_key,omitempty"`
 
 	// The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
-	// +crossplane:generate:reference:type=Connection
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.Connection
 	// +kubebuilder:validation:Optional
 	ConnectionID *string `json:"connectionId,omitempty" tf:"connection_id,omitempty"`
 
-	// Reference to a Connection to populate connectionId.
+	// Reference to a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDRef *v1.Reference `json:"connectionIdRef,omitempty" tf:"-"`
 
-	// Selector for a Connection to populate connectionId.
+	// Selector for a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDSelector *v1.Selector `json:"connectionIdSelector,omitempty" tf:"-"`
 

--- a/apis/directconnect/v1beta1/zz_publicvirtualinterface_types.go
+++ b/apis/directconnect/v1beta1/zz_publicvirtualinterface_types.go
@@ -28,14 +28,14 @@ type PublicVirtualInterfaceInitParameters struct {
 	BGPAuthKey *string `json:"bgpAuthKey,omitempty" tf:"bgp_auth_key,omitempty"`
 
 	// The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
-	// +crossplane:generate:reference:type=Connection
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.Connection
 	ConnectionID *string `json:"connectionId,omitempty" tf:"connection_id,omitempty"`
 
-	// Reference to a Connection to populate connectionId.
+	// Reference to a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDRef *v1.Reference `json:"connectionIdRef,omitempty" tf:"-"`
 
-	// Selector for a Connection to populate connectionId.
+	// Selector for a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDSelector *v1.Selector `json:"connectionIdSelector,omitempty" tf:"-"`
 
@@ -126,15 +126,15 @@ type PublicVirtualInterfaceParameters struct {
 	BGPAuthKey *string `json:"bgpAuthKey,omitempty" tf:"bgp_auth_key,omitempty"`
 
 	// The ID of the Direct Connect connection (or LAG) on which to create the virtual interface.
-	// +crossplane:generate:reference:type=Connection
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/directconnect/v1beta1.Connection
 	// +kubebuilder:validation:Optional
 	ConnectionID *string `json:"connectionId,omitempty" tf:"connection_id,omitempty"`
 
-	// Reference to a Connection to populate connectionId.
+	// Reference to a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDRef *v1.Reference `json:"connectionIdRef,omitempty" tf:"-"`
 
-	// Selector for a Connection to populate connectionId.
+	// Selector for a Connection in directconnect to populate connectionId.
 	// +kubebuilder:validation:Optional
 	ConnectionIDSelector *v1.Selector `json:"connectionIdSelector,omitempty" tf:"-"`
 

--- a/apis/docdb/v1beta1/zz_clusterinstance_types.go
+++ b/apis/docdb/v1beta1/zz_clusterinstance_types.go
@@ -29,14 +29,14 @@ type ClusterInstanceInitParameters struct {
 	CACertIdentifier *string `json:"caCertIdentifier,omitempty" tf:"ca_cert_identifier,omitempty"`
 
 	// The identifier of the aws_docdb_cluster in which to launch this instance.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/docdb/v1beta1.Cluster
 	ClusterIdentifier *string `json:"clusterIdentifier,omitempty" tf:"cluster_identifier,omitempty"`
 
-	// Reference to a Cluster to populate clusterIdentifier.
+	// Reference to a Cluster in docdb to populate clusterIdentifier.
 	// +kubebuilder:validation:Optional
 	ClusterIdentifierRef *v1.Reference `json:"clusterIdentifierRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate clusterIdentifier.
+	// Selector for a Cluster in docdb to populate clusterIdentifier.
 	// +kubebuilder:validation:Optional
 	ClusterIdentifierSelector *v1.Selector `json:"clusterIdentifierSelector,omitempty" tf:"-"`
 
@@ -174,15 +174,15 @@ type ClusterInstanceParameters struct {
 	CACertIdentifier *string `json:"caCertIdentifier,omitempty" tf:"ca_cert_identifier,omitempty"`
 
 	// The identifier of the aws_docdb_cluster in which to launch this instance.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/docdb/v1beta1.Cluster
 	// +kubebuilder:validation:Optional
 	ClusterIdentifier *string `json:"clusterIdentifier,omitempty" tf:"cluster_identifier,omitempty"`
 
-	// Reference to a Cluster to populate clusterIdentifier.
+	// Reference to a Cluster in docdb to populate clusterIdentifier.
 	// +kubebuilder:validation:Optional
 	ClusterIdentifierRef *v1.Reference `json:"clusterIdentifierRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate clusterIdentifier.
+	// Selector for a Cluster in docdb to populate clusterIdentifier.
 	// +kubebuilder:validation:Optional
 	ClusterIdentifierSelector *v1.Selector `json:"clusterIdentifierSelector,omitempty" tf:"-"`
 

--- a/apis/dynamodb/v1beta1/zz_contributorinsights_types.go
+++ b/apis/dynamodb/v1beta1/zz_contributorinsights_types.go
@@ -19,14 +19,14 @@ type ContributorInsightsInitParameters struct {
 	IndexName *string `json:"indexName,omitempty" tf:"index_name,omitempty"`
 
 	// The name of the table to enable contributor insights
-	// +crossplane:generate:reference:type=Table
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/dynamodb/v1beta1.Table
 	TableName *string `json:"tableName,omitempty" tf:"table_name,omitempty"`
 
-	// Reference to a Table to populate tableName.
+	// Reference to a Table in dynamodb to populate tableName.
 	// +kubebuilder:validation:Optional
 	TableNameRef *v1.Reference `json:"tableNameRef,omitempty" tf:"-"`
 
-	// Selector for a Table to populate tableName.
+	// Selector for a Table in dynamodb to populate tableName.
 	// +kubebuilder:validation:Optional
 	TableNameSelector *v1.Selector `json:"tableNameSelector,omitempty" tf:"-"`
 }
@@ -53,15 +53,15 @@ type ContributorInsightsParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// The name of the table to enable contributor insights
-	// +crossplane:generate:reference:type=Table
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/dynamodb/v1beta1.Table
 	// +kubebuilder:validation:Optional
 	TableName *string `json:"tableName,omitempty" tf:"table_name,omitempty"`
 
-	// Reference to a Table to populate tableName.
+	// Reference to a Table in dynamodb to populate tableName.
 	// +kubebuilder:validation:Optional
 	TableNameRef *v1.Reference `json:"tableNameRef,omitempty" tf:"-"`
 
-	// Selector for a Table to populate tableName.
+	// Selector for a Table in dynamodb to populate tableName.
 	// +kubebuilder:validation:Optional
 	TableNameSelector *v1.Selector `json:"tableNameSelector,omitempty" tf:"-"`
 }

--- a/apis/dynamodb/v1beta1/zz_kinesisstreamingdestination_types.go
+++ b/apis/dynamodb/v1beta1/zz_kinesisstreamingdestination_types.go
@@ -30,14 +30,14 @@ type KinesisStreamingDestinationInitParameters struct {
 
 	// The name of the DynamoDB table. There
 	// can only be one Kinesis streaming destination for a given DynamoDB table.
-	// +crossplane:generate:reference:type=Table
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/dynamodb/v1beta1.Table
 	TableName *string `json:"tableName,omitempty" tf:"table_name,omitempty"`
 
-	// Reference to a Table to populate tableName.
+	// Reference to a Table in dynamodb to populate tableName.
 	// +kubebuilder:validation:Optional
 	TableNameRef *v1.Reference `json:"tableNameRef,omitempty" tf:"-"`
 
-	// Selector for a Table to populate tableName.
+	// Selector for a Table in dynamodb to populate tableName.
 	// +kubebuilder:validation:Optional
 	TableNameSelector *v1.Selector `json:"tableNameSelector,omitempty" tf:"-"`
 }
@@ -78,15 +78,15 @@ type KinesisStreamingDestinationParameters struct {
 
 	// The name of the DynamoDB table. There
 	// can only be one Kinesis streaming destination for a given DynamoDB table.
-	// +crossplane:generate:reference:type=Table
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/dynamodb/v1beta1.Table
 	// +kubebuilder:validation:Optional
 	TableName *string `json:"tableName,omitempty" tf:"table_name,omitempty"`
 
-	// Reference to a Table to populate tableName.
+	// Reference to a Table in dynamodb to populate tableName.
 	// +kubebuilder:validation:Optional
 	TableNameRef *v1.Reference `json:"tableNameRef,omitempty" tf:"-"`
 
-	// Selector for a Table to populate tableName.
+	// Selector for a Table in dynamodb to populate tableName.
 	// +kubebuilder:validation:Optional
 	TableNameSelector *v1.Selector `json:"tableNameSelector,omitempty" tf:"-"`
 }

--- a/apis/dynamodb/v1beta1/zz_tableitem_types.go
+++ b/apis/dynamodb/v1beta1/zz_tableitem_types.go
@@ -25,14 +25,14 @@ type TableItemInitParameters struct {
 	RangeKey *string `json:"rangeKey,omitempty" tf:"range_key,omitempty"`
 
 	// Name of the table to contain the item.
-	// +crossplane:generate:reference:type=Table
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/dynamodb/v1beta1.Table
 	TableName *string `json:"tableName,omitempty" tf:"table_name,omitempty"`
 
-	// Reference to a Table to populate tableName.
+	// Reference to a Table in dynamodb to populate tableName.
 	// +kubebuilder:validation:Optional
 	TableNameRef *v1.Reference `json:"tableNameRef,omitempty" tf:"-"`
 
-	// Selector for a Table to populate tableName.
+	// Selector for a Table in dynamodb to populate tableName.
 	// +kubebuilder:validation:Optional
 	TableNameSelector *v1.Selector `json:"tableNameSelector,omitempty" tf:"-"`
 }
@@ -74,15 +74,15 @@ type TableItemParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// Name of the table to contain the item.
-	// +crossplane:generate:reference:type=Table
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/dynamodb/v1beta1.Table
 	// +kubebuilder:validation:Optional
 	TableName *string `json:"tableName,omitempty" tf:"table_name,omitempty"`
 
-	// Reference to a Table to populate tableName.
+	// Reference to a Table in dynamodb to populate tableName.
 	// +kubebuilder:validation:Optional
 	TableNameRef *v1.Reference `json:"tableNameRef,omitempty" tf:"-"`
 
-	// Selector for a Table to populate tableName.
+	// Selector for a Table in dynamodb to populate tableName.
 	// +kubebuilder:validation:Optional
 	TableNameSelector *v1.Selector `json:"tableNameSelector,omitempty" tf:"-"`
 }

--- a/apis/ec2/v1beta1/zz_ami_types.go
+++ b/apis/ec2/v1beta1/zz_ami_types.go
@@ -285,14 +285,14 @@ type EBSBlockDeviceInitParameters struct {
 	// ID of an EBS snapshot that will be used to initialize the created
 	// EBS volumes. If set, the volume_size attribute must be at least as large as the referenced
 	// snapshot.
-	// +crossplane:generate:reference:type=EBSSnapshot
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.EBSSnapshot
 	SnapshotID *string `json:"snapshotId,omitempty" tf:"snapshot_id,omitempty"`
 
-	// Reference to a EBSSnapshot to populate snapshotId.
+	// Reference to a EBSSnapshot in ec2 to populate snapshotId.
 	// +kubebuilder:validation:Optional
 	SnapshotIDRef *v1.Reference `json:"snapshotIdRef,omitempty" tf:"-"`
 
-	// Selector for a EBSSnapshot to populate snapshotId.
+	// Selector for a EBSSnapshot in ec2 to populate snapshotId.
 	// +kubebuilder:validation:Optional
 	SnapshotIDSelector *v1.Selector `json:"snapshotIdSelector,omitempty" tf:"-"`
 
@@ -371,15 +371,15 @@ type EBSBlockDeviceParameters struct {
 	// ID of an EBS snapshot that will be used to initialize the created
 	// EBS volumes. If set, the volume_size attribute must be at least as large as the referenced
 	// snapshot.
-	// +crossplane:generate:reference:type=EBSSnapshot
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.EBSSnapshot
 	// +kubebuilder:validation:Optional
 	SnapshotID *string `json:"snapshotId,omitempty" tf:"snapshot_id,omitempty"`
 
-	// Reference to a EBSSnapshot to populate snapshotId.
+	// Reference to a EBSSnapshot in ec2 to populate snapshotId.
 	// +kubebuilder:validation:Optional
 	SnapshotIDRef *v1.Reference `json:"snapshotIdRef,omitempty" tf:"-"`
 
-	// Selector for a EBSSnapshot to populate snapshotId.
+	// Selector for a EBSSnapshot in ec2 to populate snapshotId.
 	// +kubebuilder:validation:Optional
 	SnapshotIDSelector *v1.Selector `json:"snapshotIdSelector,omitempty" tf:"-"`
 

--- a/apis/ec2/v1beta1/zz_amicopy_types.go
+++ b/apis/ec2/v1beta1/zz_amicopy_types.go
@@ -91,14 +91,14 @@ type AMICopyInitParameters struct {
 
 	// Id of the AMI to copy. This id must be valid in the region
 	// given by source_ami_region.
-	// +crossplane:generate:reference:type=AMI
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.AMI
 	SourceAMIID *string `json:"sourceAmiId,omitempty" tf:"source_ami_id,omitempty"`
 
-	// Reference to a AMI to populate sourceAmiId.
+	// Reference to a AMI in ec2 to populate sourceAmiId.
 	// +kubebuilder:validation:Optional
 	SourceAMIIDRef *v1.Reference `json:"sourceAmiIdRef,omitempty" tf:"-"`
 
-	// Selector for a AMI to populate sourceAmiId.
+	// Selector for a AMI in ec2 to populate sourceAmiId.
 	// +kubebuilder:validation:Optional
 	SourceAMIIDSelector *v1.Selector `json:"sourceAmiIdSelector,omitempty" tf:"-"`
 
@@ -249,15 +249,15 @@ type AMICopyParameters struct {
 
 	// Id of the AMI to copy. This id must be valid in the region
 	// given by source_ami_region.
-	// +crossplane:generate:reference:type=AMI
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.AMI
 	// +kubebuilder:validation:Optional
 	SourceAMIID *string `json:"sourceAmiId,omitempty" tf:"source_ami_id,omitempty"`
 
-	// Reference to a AMI to populate sourceAmiId.
+	// Reference to a AMI in ec2 to populate sourceAmiId.
 	// +kubebuilder:validation:Optional
 	SourceAMIIDRef *v1.Reference `json:"sourceAmiIdRef,omitempty" tf:"-"`
 
-	// Selector for a AMI to populate sourceAmiId.
+	// Selector for a AMI in ec2 to populate sourceAmiId.
 	// +kubebuilder:validation:Optional
 	SourceAMIIDSelector *v1.Selector `json:"sourceAmiIdSelector,omitempty" tf:"-"`
 

--- a/apis/ec2/v1beta1/zz_amilaunchpermission_types.go
+++ b/apis/ec2/v1beta1/zz_amilaunchpermission_types.go
@@ -22,14 +22,14 @@ type AMILaunchPermissionInitParameters struct {
 	Group *string `json:"group,omitempty" tf:"group,omitempty"`
 
 	// ID of the AMI.
-	// +crossplane:generate:reference:type=AMI
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.AMI
 	ImageID *string `json:"imageId,omitempty" tf:"image_id,omitempty"`
 
-	// Reference to a AMI to populate imageId.
+	// Reference to a AMI in ec2 to populate imageId.
 	// +kubebuilder:validation:Optional
 	ImageIDRef *v1.Reference `json:"imageIdRef,omitempty" tf:"-"`
 
-	// Selector for a AMI to populate imageId.
+	// Selector for a AMI in ec2 to populate imageId.
 	// +kubebuilder:validation:Optional
 	ImageIDSelector *v1.Selector `json:"imageIdSelector,omitempty" tf:"-"`
 
@@ -72,15 +72,15 @@ type AMILaunchPermissionParameters struct {
 	Group *string `json:"group,omitempty" tf:"group,omitempty"`
 
 	// ID of the AMI.
-	// +crossplane:generate:reference:type=AMI
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.AMI
 	// +kubebuilder:validation:Optional
 	ImageID *string `json:"imageId,omitempty" tf:"image_id,omitempty"`
 
-	// Reference to a AMI to populate imageId.
+	// Reference to a AMI in ec2 to populate imageId.
 	// +kubebuilder:validation:Optional
 	ImageIDRef *v1.Reference `json:"imageIdRef,omitempty" tf:"-"`
 
-	// Selector for a AMI to populate imageId.
+	// Selector for a AMI in ec2 to populate imageId.
 	// +kubebuilder:validation:Optional
 	ImageIDSelector *v1.Selector `json:"imageIdSelector,omitempty" tf:"-"`
 

--- a/apis/ec2/v1beta1/zz_eip_types.go
+++ b/apis/ec2/v1beta1/zz_eip_types.go
@@ -28,14 +28,14 @@ type EIPInitParameters struct {
 	Domain *string `json:"domain,omitempty" tf:"domain,omitempty"`
 
 	// EC2 instance ID.
-	// +crossplane:generate:reference:type=Instance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.Instance
 	Instance *string `json:"instance,omitempty" tf:"instance,omitempty"`
 
-	// Reference to a Instance to populate instance.
+	// Reference to a Instance in ec2 to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceRef *v1.Reference `json:"instanceRef,omitempty" tf:"-"`
 
-	// Selector for a Instance to populate instance.
+	// Selector for a Instance in ec2 to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceSelector *v1.Selector `json:"instanceSelector,omitempty" tf:"-"`
 
@@ -43,14 +43,14 @@ type EIPInitParameters struct {
 	NetworkBorderGroup *string `json:"networkBorderGroup,omitempty" tf:"network_border_group,omitempty"`
 
 	// Network interface ID to associate with.
-	// +crossplane:generate:reference:type=NetworkInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.NetworkInterface
 	NetworkInterface *string `json:"networkInterface,omitempty" tf:"network_interface,omitempty"`
 
-	// Reference to a NetworkInterface to populate networkInterface.
+	// Reference to a NetworkInterface in ec2 to populate networkInterface.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceRef *v1.Reference `json:"networkInterfaceRef,omitempty" tf:"-"`
 
-	// Selector for a NetworkInterface to populate networkInterface.
+	// Selector for a NetworkInterface in ec2 to populate networkInterface.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceSelector *v1.Selector `json:"networkInterfaceSelector,omitempty" tf:"-"`
 
@@ -153,15 +153,15 @@ type EIPParameters struct {
 	Domain *string `json:"domain,omitempty" tf:"domain,omitempty"`
 
 	// EC2 instance ID.
-	// +crossplane:generate:reference:type=Instance
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.Instance
 	// +kubebuilder:validation:Optional
 	Instance *string `json:"instance,omitempty" tf:"instance,omitempty"`
 
-	// Reference to a Instance to populate instance.
+	// Reference to a Instance in ec2 to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceRef *v1.Reference `json:"instanceRef,omitempty" tf:"-"`
 
-	// Selector for a Instance to populate instance.
+	// Selector for a Instance in ec2 to populate instance.
 	// +kubebuilder:validation:Optional
 	InstanceSelector *v1.Selector `json:"instanceSelector,omitempty" tf:"-"`
 
@@ -170,15 +170,15 @@ type EIPParameters struct {
 	NetworkBorderGroup *string `json:"networkBorderGroup,omitempty" tf:"network_border_group,omitempty"`
 
 	// Network interface ID to associate with.
-	// +crossplane:generate:reference:type=NetworkInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.NetworkInterface
 	// +kubebuilder:validation:Optional
 	NetworkInterface *string `json:"networkInterface,omitempty" tf:"network_interface,omitempty"`
 
-	// Reference to a NetworkInterface to populate networkInterface.
+	// Reference to a NetworkInterface in ec2 to populate networkInterface.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceRef *v1.Reference `json:"networkInterfaceRef,omitempty" tf:"-"`
 
-	// Selector for a NetworkInterface to populate networkInterface.
+	// Selector for a NetworkInterface in ec2 to populate networkInterface.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceSelector *v1.Selector `json:"networkInterfaceSelector,omitempty" tf:"-"`
 

--- a/apis/ec2/v1beta1/zz_instance_types.go
+++ b/apis/ec2/v1beta1/zz_instance_types.go
@@ -435,14 +435,14 @@ type InstanceInitParameters struct {
 	SourceDestCheck *bool `json:"sourceDestCheck,omitempty" tf:"source_dest_check,omitempty"`
 
 	// VPC Subnet ID to launch in.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 
@@ -462,16 +462,16 @@ type InstanceInitParameters struct {
 	// When used in combination with user_data or user_data_base64 will trigger a destroy and recreate when set to true. Defaults to false if not set.
 	UserDataReplaceOnChange *bool `json:"userDataReplaceOnChange,omitempty" tf:"user_data_replace_on_change,omitempty"`
 
-	// References to SecurityGroup to populate vpcSecurityGroupIds.
+	// References to SecurityGroup in ec2 to populate vpcSecurityGroupIds.
 	// +kubebuilder:validation:Optional
 	VPCSecurityGroupIDRefs []v1.Reference `json:"vpcSecurityGroupIdRefs,omitempty" tf:"-"`
 
-	// Selector for a list of SecurityGroup to populate vpcSecurityGroupIds.
+	// Selector for a list of SecurityGroup in ec2 to populate vpcSecurityGroupIds.
 	// +kubebuilder:validation:Optional
 	VPCSecurityGroupIDSelector *v1.Selector `json:"vpcSecurityGroupIdSelector,omitempty" tf:"-"`
 
 	// List of security group IDs to associate with.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup
 	// +crossplane:generate:reference:refFieldName=VPCSecurityGroupIDRefs
 	// +crossplane:generate:reference:selectorFieldName=VPCSecurityGroupIDSelector
 	// +listType=set
@@ -523,14 +523,14 @@ type InstanceNetworkInterfaceInitParameters struct {
 	NetworkCardIndex *float64 `json:"networkCardIndex,omitempty" tf:"network_card_index,omitempty"`
 
 	// ID of the network interface to attach.
-	// +crossplane:generate:reference:type=NetworkInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.NetworkInterface
 	NetworkInterfaceID *string `json:"networkInterfaceId,omitempty" tf:"network_interface_id,omitempty"`
 
-	// Reference to a NetworkInterface to populate networkInterfaceId.
+	// Reference to a NetworkInterface in ec2 to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDRef *v1.Reference `json:"networkInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a NetworkInterface to populate networkInterfaceId.
+	// Selector for a NetworkInterface in ec2 to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDSelector *v1.Selector `json:"networkInterfaceIdSelector,omitempty" tf:"-"`
 }
@@ -565,15 +565,15 @@ type InstanceNetworkInterfaceParameters struct {
 	NetworkCardIndex *float64 `json:"networkCardIndex,omitempty" tf:"network_card_index,omitempty"`
 
 	// ID of the network interface to attach.
-	// +crossplane:generate:reference:type=NetworkInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.NetworkInterface
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceID *string `json:"networkInterfaceId,omitempty" tf:"network_interface_id,omitempty"`
 
-	// Reference to a NetworkInterface to populate networkInterfaceId.
+	// Reference to a NetworkInterface in ec2 to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDRef *v1.Reference `json:"networkInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a NetworkInterface to populate networkInterfaceId.
+	// Selector for a NetworkInterface in ec2 to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDSelector *v1.Selector `json:"networkInterfaceIdSelector,omitempty" tf:"-"`
 }
@@ -918,15 +918,15 @@ type InstanceParameters struct {
 	SourceDestCheck *bool `json:"sourceDestCheck,omitempty" tf:"source_dest_check,omitempty"`
 
 	// VPC Subnet ID to launch in.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 
@@ -951,16 +951,16 @@ type InstanceParameters struct {
 	// +kubebuilder:validation:Optional
 	UserDataReplaceOnChange *bool `json:"userDataReplaceOnChange,omitempty" tf:"user_data_replace_on_change,omitempty"`
 
-	// References to SecurityGroup to populate vpcSecurityGroupIds.
+	// References to SecurityGroup in ec2 to populate vpcSecurityGroupIds.
 	// +kubebuilder:validation:Optional
 	VPCSecurityGroupIDRefs []v1.Reference `json:"vpcSecurityGroupIdRefs,omitempty" tf:"-"`
 
-	// Selector for a list of SecurityGroup to populate vpcSecurityGroupIds.
+	// Selector for a list of SecurityGroup in ec2 to populate vpcSecurityGroupIds.
 	// +kubebuilder:validation:Optional
 	VPCSecurityGroupIDSelector *v1.Selector `json:"vpcSecurityGroupIdSelector,omitempty" tf:"-"`
 
 	// List of security group IDs to associate with.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup
 	// +crossplane:generate:reference:refFieldName=VPCSecurityGroupIDRefs
 	// +crossplane:generate:reference:selectorFieldName=VPCSecurityGroupIDSelector
 	// +kubebuilder:validation:Optional

--- a/apis/ec2/v1beta1/zz_launchtemplate_types.go
+++ b/apis/ec2/v1beta1/zz_launchtemplate_types.go
@@ -978,17 +978,17 @@ type LaunchTemplateInitParameters_2 struct {
 	// The ID of the RAM disk.
 	RAMDiskID *string `json:"ramDiskId,omitempty" tf:"ram_disk_id,omitempty"`
 
-	// References to SecurityGroup to populate securityGroupNames.
+	// References to SecurityGroup in ec2 to populate securityGroupNames.
 	// +kubebuilder:validation:Optional
 	SecurityGroupNameRefs []v1.Reference `json:"securityGroupNameRefs,omitempty" tf:"-"`
 
-	// Selector for a list of SecurityGroup to populate securityGroupNames.
+	// Selector for a list of SecurityGroup in ec2 to populate securityGroupNames.
 	// +kubebuilder:validation:Optional
 	SecurityGroupNameSelector *v1.Selector `json:"securityGroupNameSelector,omitempty" tf:"-"`
 
 	// A list of security group names to associate with. If you are creating Instances in a VPC, use
 	// vpc_security_group_ids instead.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup
 	// +crossplane:generate:reference:refFieldName=SecurityGroupNameRefs
 	// +crossplane:generate:reference:selectorFieldName=SecurityGroupNameSelector
 	// +listType=set
@@ -1401,17 +1401,17 @@ type LaunchTemplateParameters_2 struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// References to SecurityGroup to populate securityGroupNames.
+	// References to SecurityGroup in ec2 to populate securityGroupNames.
 	// +kubebuilder:validation:Optional
 	SecurityGroupNameRefs []v1.Reference `json:"securityGroupNameRefs,omitempty" tf:"-"`
 
-	// Selector for a list of SecurityGroup to populate securityGroupNames.
+	// Selector for a list of SecurityGroup in ec2 to populate securityGroupNames.
 	// +kubebuilder:validation:Optional
 	SecurityGroupNameSelector *v1.Selector `json:"securityGroupNameSelector,omitempty" tf:"-"`
 
 	// A list of security group names to associate with. If you are creating Instances in a VPC, use
 	// vpc_security_group_ids instead.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup
 	// +crossplane:generate:reference:refFieldName=SecurityGroupNameRefs
 	// +crossplane:generate:reference:selectorFieldName=SecurityGroupNameSelector
 	// +kubebuilder:validation:Optional
@@ -1700,44 +1700,44 @@ type NetworkInterfacesInitParameters struct {
 	NetworkCardIndex *float64 `json:"networkCardIndex,omitempty" tf:"network_card_index,omitempty"`
 
 	// The ID of the network interface to attach.
-	// +crossplane:generate:reference:type=NetworkInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.NetworkInterface
 	NetworkInterfaceID *string `json:"networkInterfaceId,omitempty" tf:"network_interface_id,omitempty"`
 
-	// Reference to a NetworkInterface to populate networkInterfaceId.
+	// Reference to a NetworkInterface in ec2 to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDRef *v1.Reference `json:"networkInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a NetworkInterface to populate networkInterfaceId.
+	// Selector for a NetworkInterface in ec2 to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDSelector *v1.Selector `json:"networkInterfaceIdSelector,omitempty" tf:"-"`
 
 	// The primary private IPv4 address.
 	PrivateIPAddress *string `json:"privateIpAddress,omitempty" tf:"private_ip_address,omitempty"`
 
-	// References to SecurityGroup to populate securityGroups.
+	// References to SecurityGroup in ec2 to populate securityGroups.
 	// +kubebuilder:validation:Optional
 	SecurityGroupRefs []v1.Reference `json:"securityGroupRefs,omitempty" tf:"-"`
 
-	// Selector for a list of SecurityGroup to populate securityGroups.
+	// Selector for a list of SecurityGroup in ec2 to populate securityGroups.
 	// +kubebuilder:validation:Optional
 	SecurityGroupSelector *v1.Selector `json:"securityGroupSelector,omitempty" tf:"-"`
 
 	// A list of security group IDs to associate.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup
 	// +crossplane:generate:reference:refFieldName=SecurityGroupRefs
 	// +crossplane:generate:reference:selectorFieldName=SecurityGroupSelector
 	// +listType=set
 	SecurityGroups []*string `json:"securityGroups,omitempty" tf:"security_groups,omitempty"`
 
 	// The VPC Subnet ID to associate.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }
@@ -1880,15 +1880,15 @@ type NetworkInterfacesParameters struct {
 	NetworkCardIndex *float64 `json:"networkCardIndex,omitempty" tf:"network_card_index,omitempty"`
 
 	// The ID of the network interface to attach.
-	// +crossplane:generate:reference:type=NetworkInterface
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.NetworkInterface
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceID *string `json:"networkInterfaceId,omitempty" tf:"network_interface_id,omitempty"`
 
-	// Reference to a NetworkInterface to populate networkInterfaceId.
+	// Reference to a NetworkInterface in ec2 to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDRef *v1.Reference `json:"networkInterfaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a NetworkInterface to populate networkInterfaceId.
+	// Selector for a NetworkInterface in ec2 to populate networkInterfaceId.
 	// +kubebuilder:validation:Optional
 	NetworkInterfaceIDSelector *v1.Selector `json:"networkInterfaceIdSelector,omitempty" tf:"-"`
 
@@ -1896,16 +1896,16 @@ type NetworkInterfacesParameters struct {
 	// +kubebuilder:validation:Optional
 	PrivateIPAddress *string `json:"privateIpAddress,omitempty" tf:"private_ip_address,omitempty"`
 
-	// References to SecurityGroup to populate securityGroups.
+	// References to SecurityGroup in ec2 to populate securityGroups.
 	// +kubebuilder:validation:Optional
 	SecurityGroupRefs []v1.Reference `json:"securityGroupRefs,omitempty" tf:"-"`
 
-	// Selector for a list of SecurityGroup to populate securityGroups.
+	// Selector for a list of SecurityGroup in ec2 to populate securityGroups.
 	// +kubebuilder:validation:Optional
 	SecurityGroupSelector *v1.Selector `json:"securityGroupSelector,omitempty" tf:"-"`
 
 	// A list of security group IDs to associate.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup
 	// +crossplane:generate:reference:refFieldName=SecurityGroupRefs
 	// +crossplane:generate:reference:selectorFieldName=SecurityGroupSelector
 	// +kubebuilder:validation:Optional
@@ -1913,15 +1913,15 @@ type NetworkInterfacesParameters struct {
 	SecurityGroups []*string `json:"securityGroups,omitempty" tf:"security_groups,omitempty"`
 
 	// The VPC Subnet ID to associate.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }

--- a/apis/ec2/v1beta1/zz_mainroutetableassociation_types.go
+++ b/apis/ec2/v1beta1/zz_mainroutetableassociation_types.go
@@ -17,14 +17,14 @@ type MainRouteTableAssociationInitParameters struct {
 
 	// The ID of the Route Table to set as the new
 	// main route table for the target VPC
-	// +crossplane:generate:reference:type=RouteTable
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.RouteTable
 	RouteTableID *string `json:"routeTableId,omitempty" tf:"route_table_id,omitempty"`
 
-	// Reference to a RouteTable to populate routeTableId.
+	// Reference to a RouteTable in ec2 to populate routeTableId.
 	// +kubebuilder:validation:Optional
 	RouteTableIDRef *v1.Reference `json:"routeTableIdRef,omitempty" tf:"-"`
 
-	// Selector for a RouteTable to populate routeTableId.
+	// Selector for a RouteTable in ec2 to populate routeTableId.
 	// +kubebuilder:validation:Optional
 	RouteTableIDSelector *v1.Selector `json:"routeTableIdSelector,omitempty" tf:"-"`
 
@@ -66,15 +66,15 @@ type MainRouteTableAssociationParameters struct {
 
 	// The ID of the Route Table to set as the new
 	// main route table for the target VPC
-	// +crossplane:generate:reference:type=RouteTable
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.RouteTable
 	// +kubebuilder:validation:Optional
 	RouteTableID *string `json:"routeTableId,omitempty" tf:"route_table_id,omitempty"`
 
-	// Reference to a RouteTable to populate routeTableId.
+	// Reference to a RouteTable in ec2 to populate routeTableId.
 	// +kubebuilder:validation:Optional
 	RouteTableIDRef *v1.Reference `json:"routeTableIdRef,omitempty" tf:"-"`
 
-	// Selector for a RouteTable to populate routeTableId.
+	// Selector for a RouteTable in ec2 to populate routeTableId.
 	// +kubebuilder:validation:Optional
 	RouteTableIDSelector *v1.Selector `json:"routeTableIdSelector,omitempty" tf:"-"`
 

--- a/apis/ec2/v1beta1/zz_natgateway_types.go
+++ b/apis/ec2/v1beta1/zz_natgateway_types.go
@@ -46,14 +46,14 @@ type NATGatewayInitParameters_2 struct {
 	SecondaryPrivateIPAddresses []*string `json:"secondaryPrivateIpAddresses,omitempty" tf:"secondary_private_ip_addresses,omitempty"`
 
 	// The Subnet ID of the subnet in which to place the NAT Gateway.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 
@@ -152,15 +152,15 @@ type NATGatewayParameters_2 struct {
 	SecondaryPrivateIPAddresses []*string `json:"secondaryPrivateIpAddresses,omitempty" tf:"secondary_private_ip_addresses,omitempty"`
 
 	// The Subnet ID of the subnet in which to place the NAT Gateway.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 

--- a/apis/ec2/v1beta1/zz_networkinterface_types.go
+++ b/apis/ec2/v1beta1/zz_networkinterface_types.go
@@ -81,16 +81,16 @@ type NetworkInterfaceInitParameters_2 struct {
 	// Number of secondary private IPs to assign to the ENI. The total number of private IPs will be 1 + private_ips_count, as a primary private IP will be assiged to an ENI by default.
 	PrivateIpsCount *float64 `json:"privateIpsCount,omitempty" tf:"private_ips_count,omitempty"`
 
-	// References to SecurityGroup to populate securityGroups.
+	// References to SecurityGroup in ec2 to populate securityGroups.
 	// +kubebuilder:validation:Optional
 	SecurityGroupRefs []v1.Reference `json:"securityGroupRefs,omitempty" tf:"-"`
 
-	// Selector for a list of SecurityGroup to populate securityGroups.
+	// Selector for a list of SecurityGroup in ec2 to populate securityGroups.
 	// +kubebuilder:validation:Optional
 	SecurityGroupSelector *v1.Selector `json:"securityGroupSelector,omitempty" tf:"-"`
 
 	// List of security group IDs to assign to the ENI.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup
 	// +crossplane:generate:reference:refFieldName=SecurityGroupRefs
 	// +crossplane:generate:reference:selectorFieldName=SecurityGroupSelector
 	// +listType=set
@@ -100,14 +100,14 @@ type NetworkInterfaceInitParameters_2 struct {
 	SourceDestCheck *bool `json:"sourceDestCheck,omitempty" tf:"source_dest_check,omitempty"`
 
 	// Subnet ID to create the ENI in.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 
@@ -276,16 +276,16 @@ type NetworkInterfaceParameters_2 struct {
 	// +kubebuilder:validation:Required
 	Region *string `json:"region" tf:"-"`
 
-	// References to SecurityGroup to populate securityGroups.
+	// References to SecurityGroup in ec2 to populate securityGroups.
 	// +kubebuilder:validation:Optional
 	SecurityGroupRefs []v1.Reference `json:"securityGroupRefs,omitempty" tf:"-"`
 
-	// Selector for a list of SecurityGroup to populate securityGroups.
+	// Selector for a list of SecurityGroup in ec2 to populate securityGroups.
 	// +kubebuilder:validation:Optional
 	SecurityGroupSelector *v1.Selector `json:"securityGroupSelector,omitempty" tf:"-"`
 
 	// List of security group IDs to assign to the ENI.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup
 	// +crossplane:generate:reference:refFieldName=SecurityGroupRefs
 	// +crossplane:generate:reference:selectorFieldName=SecurityGroupSelector
 	// +kubebuilder:validation:Optional
@@ -297,15 +297,15 @@ type NetworkInterfaceParameters_2 struct {
 	SourceDestCheck *bool `json:"sourceDestCheck,omitempty" tf:"source_dest_check,omitempty"`
 
 	// Subnet ID to create the ENI in.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 

--- a/apis/ec2/v1beta1/zz_routetableassociation_types.go
+++ b/apis/ec2/v1beta1/zz_routetableassociation_types.go
@@ -29,26 +29,26 @@ type RouteTableAssociationInitParameters struct {
 	GatewayIDSelector *v1.Selector `json:"gatewayIdSelector,omitempty" tf:"-"`
 
 	// The ID of the routing table to associate with.
-	// +crossplane:generate:reference:type=RouteTable
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.RouteTable
 	RouteTableID *string `json:"routeTableId,omitempty" tf:"route_table_id,omitempty"`
 
-	// Reference to a RouteTable to populate routeTableId.
+	// Reference to a RouteTable in ec2 to populate routeTableId.
 	// +kubebuilder:validation:Optional
 	RouteTableIDRef *v1.Reference `json:"routeTableIdRef,omitempty" tf:"-"`
 
-	// Selector for a RouteTable to populate routeTableId.
+	// Selector for a RouteTable in ec2 to populate routeTableId.
 	// +kubebuilder:validation:Optional
 	RouteTableIDSelector *v1.Selector `json:"routeTableIdSelector,omitempty" tf:"-"`
 
 	// The subnet ID to create an association. Conflicts with gateway_id.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }
@@ -90,28 +90,28 @@ type RouteTableAssociationParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// The ID of the routing table to associate with.
-	// +crossplane:generate:reference:type=RouteTable
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.RouteTable
 	// +kubebuilder:validation:Optional
 	RouteTableID *string `json:"routeTableId,omitempty" tf:"route_table_id,omitempty"`
 
-	// Reference to a RouteTable to populate routeTableId.
+	// Reference to a RouteTable in ec2 to populate routeTableId.
 	// +kubebuilder:validation:Optional
 	RouteTableIDRef *v1.Reference `json:"routeTableIdRef,omitempty" tf:"-"`
 
-	// Selector for a RouteTable to populate routeTableId.
+	// Selector for a RouteTable in ec2 to populate routeTableId.
 	// +kubebuilder:validation:Optional
 	RouteTableIDSelector *v1.Selector `json:"routeTableIdSelector,omitempty" tf:"-"`
 
 	// The subnet ID to create an association. Conflicts with gateway_id.
-	// +crossplane:generate:reference:type=Subnet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet
 	// +kubebuilder:validation:Optional
 	SubnetID *string `json:"subnetId,omitempty" tf:"subnet_id,omitempty"`
 
-	// Reference to a Subnet to populate subnetId.
+	// Reference to a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDRef *v1.Reference `json:"subnetIdRef,omitempty" tf:"-"`
 
-	// Selector for a Subnet to populate subnetId.
+	// Selector for a Subnet in ec2 to populate subnetId.
 	// +kubebuilder:validation:Optional
 	SubnetIDSelector *v1.Selector `json:"subnetIdSelector,omitempty" tf:"-"`
 }

--- a/apis/ec2/v1beta1/zz_securitygrouprule_types.go
+++ b/apis/ec2/v1beta1/zz_securitygrouprule_types.go
@@ -45,14 +45,14 @@ type SecurityGroupRuleInitParameters_2 struct {
 	Protocol *string `json:"protocol,omitempty" tf:"protocol,omitempty"`
 
 	// Security group to apply this rule to.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup
 	SecurityGroupID *string `json:"securityGroupId,omitempty" tf:"security_group_id,omitempty"`
 
-	// Reference to a SecurityGroup to populate securityGroupId.
+	// Reference to a SecurityGroup in ec2 to populate securityGroupId.
 	// +kubebuilder:validation:Optional
 	SecurityGroupIDRef *v1.Reference `json:"securityGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a SecurityGroup to populate securityGroupId.
+	// Selector for a SecurityGroup in ec2 to populate securityGroupId.
 	// +kubebuilder:validation:Optional
 	SecurityGroupIDSelector *v1.Selector `json:"securityGroupIdSelector,omitempty" tf:"-"`
 
@@ -60,14 +60,14 @@ type SecurityGroupRuleInitParameters_2 struct {
 	Self *bool `json:"self,omitempty" tf:"self,omitempty"`
 
 	// Security group id to allow access to/from, depending on the type. Cannot be specified with cidr_blocks, ipv6_cidr_blocks, or self.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup
 	SourceSecurityGroupID *string `json:"sourceSecurityGroupId,omitempty" tf:"source_security_group_id,omitempty"`
 
-	// Reference to a SecurityGroup to populate sourceSecurityGroupId.
+	// Reference to a SecurityGroup in ec2 to populate sourceSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	SourceSecurityGroupIDRef *v1.Reference `json:"sourceSecurityGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a SecurityGroup to populate sourceSecurityGroupId.
+	// Selector for a SecurityGroup in ec2 to populate sourceSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	SourceSecurityGroupIDSelector *v1.Selector `json:"sourceSecurityGroupIdSelector,omitempty" tf:"-"`
 
@@ -165,15 +165,15 @@ type SecurityGroupRuleParameters_2 struct {
 	Region *string `json:"region" tf:"-"`
 
 	// Security group to apply this rule to.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup
 	// +kubebuilder:validation:Optional
 	SecurityGroupID *string `json:"securityGroupId,omitempty" tf:"security_group_id,omitempty"`
 
-	// Reference to a SecurityGroup to populate securityGroupId.
+	// Reference to a SecurityGroup in ec2 to populate securityGroupId.
 	// +kubebuilder:validation:Optional
 	SecurityGroupIDRef *v1.Reference `json:"securityGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a SecurityGroup to populate securityGroupId.
+	// Selector for a SecurityGroup in ec2 to populate securityGroupId.
 	// +kubebuilder:validation:Optional
 	SecurityGroupIDSelector *v1.Selector `json:"securityGroupIdSelector,omitempty" tf:"-"`
 
@@ -182,15 +182,15 @@ type SecurityGroupRuleParameters_2 struct {
 	Self *bool `json:"self,omitempty" tf:"self,omitempty"`
 
 	// Security group id to allow access to/from, depending on the type. Cannot be specified with cidr_blocks, ipv6_cidr_blocks, or self.
-	// +crossplane:generate:reference:type=SecurityGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup
 	// +kubebuilder:validation:Optional
 	SourceSecurityGroupID *string `json:"sourceSecurityGroupId,omitempty" tf:"source_security_group_id,omitempty"`
 
-	// Reference to a SecurityGroup to populate sourceSecurityGroupId.
+	// Reference to a SecurityGroup in ec2 to populate sourceSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	SourceSecurityGroupIDRef *v1.Reference `json:"sourceSecurityGroupIdRef,omitempty" tf:"-"`
 
-	// Selector for a SecurityGroup to populate sourceSecurityGroupId.
+	// Selector for a SecurityGroup in ec2 to populate sourceSecurityGroupId.
 	// +kubebuilder:validation:Optional
 	SourceSecurityGroupIDSelector *v1.Selector `json:"sourceSecurityGroupIdSelector,omitempty" tf:"-"`
 

--- a/apis/ec2/v1beta1/zz_transitgatewaymulticastdomain_types.go
+++ b/apis/ec2/v1beta1/zz_transitgatewaymulticastdomain_types.go
@@ -29,14 +29,14 @@ type TransitGatewayMulticastDomainInitParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// EC2 Transit Gateway identifier. The EC2 Transit Gateway must have multicast_support enabled.
-	// +crossplane:generate:reference:type=TransitGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGateway
 	TransitGatewayID *string `json:"transitGatewayId,omitempty" tf:"transit_gateway_id,omitempty"`
 
-	// Reference to a TransitGateway to populate transitGatewayId.
+	// Reference to a TransitGateway in ec2 to populate transitGatewayId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayIDRef *v1.Reference `json:"transitGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGateway to populate transitGatewayId.
+	// Selector for a TransitGateway in ec2 to populate transitGatewayId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayIDSelector *v1.Selector `json:"transitGatewayIdSelector,omitempty" tf:"-"`
 }
@@ -98,15 +98,15 @@ type TransitGatewayMulticastDomainParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// EC2 Transit Gateway identifier. The EC2 Transit Gateway must have multicast_support enabled.
-	// +crossplane:generate:reference:type=TransitGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGateway
 	// +kubebuilder:validation:Optional
 	TransitGatewayID *string `json:"transitGatewayId,omitempty" tf:"transit_gateway_id,omitempty"`
 
-	// Reference to a TransitGateway to populate transitGatewayId.
+	// Reference to a TransitGateway in ec2 to populate transitGatewayId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayIDRef *v1.Reference `json:"transitGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGateway to populate transitGatewayId.
+	// Selector for a TransitGateway in ec2 to populate transitGatewayId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayIDSelector *v1.Selector `json:"transitGatewayIdSelector,omitempty" tf:"-"`
 }

--- a/apis/ec2/v1beta1/zz_transitgatewayroute_types.go
+++ b/apis/ec2/v1beta1/zz_transitgatewayroute_types.go
@@ -22,26 +22,26 @@ type TransitGatewayRouteInitParameters struct {
 	DestinationCidrBlock *string `json:"destinationCidrBlock,omitempty" tf:"destination_cidr_block,omitempty"`
 
 	// Identifier of EC2 Transit Gateway Attachment .
-	// +crossplane:generate:reference:type=TransitGatewayVPCAttachment
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGatewayVPCAttachment
 	TransitGatewayAttachmentID *string `json:"transitGatewayAttachmentId,omitempty" tf:"transit_gateway_attachment_id,omitempty"`
 
-	// Reference to a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Reference to a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDRef *v1.Reference `json:"transitGatewayAttachmentIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Selector for a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDSelector *v1.Selector `json:"transitGatewayAttachmentIdSelector,omitempty" tf:"-"`
 
 	// Identifier of EC2 Transit Gateway Route Table.
-	// +crossplane:generate:reference:type=TransitGatewayRouteTable
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGatewayRouteTable
 	TransitGatewayRouteTableID *string `json:"transitGatewayRouteTableId,omitempty" tf:"transit_gateway_route_table_id,omitempty"`
 
-	// Reference to a TransitGatewayRouteTable to populate transitGatewayRouteTableId.
+	// Reference to a TransitGatewayRouteTable in ec2 to populate transitGatewayRouteTableId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableIDRef *v1.Reference `json:"transitGatewayRouteTableIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGatewayRouteTable to populate transitGatewayRouteTableId.
+	// Selector for a TransitGatewayRouteTable in ec2 to populate transitGatewayRouteTableId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableIDSelector *v1.Selector `json:"transitGatewayRouteTableIdSelector,omitempty" tf:"-"`
 }
@@ -80,28 +80,28 @@ type TransitGatewayRouteParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// Identifier of EC2 Transit Gateway Attachment .
-	// +crossplane:generate:reference:type=TransitGatewayVPCAttachment
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGatewayVPCAttachment
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentID *string `json:"transitGatewayAttachmentId,omitempty" tf:"transit_gateway_attachment_id,omitempty"`
 
-	// Reference to a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Reference to a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDRef *v1.Reference `json:"transitGatewayAttachmentIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Selector for a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDSelector *v1.Selector `json:"transitGatewayAttachmentIdSelector,omitempty" tf:"-"`
 
 	// Identifier of EC2 Transit Gateway Route Table.
-	// +crossplane:generate:reference:type=TransitGatewayRouteTable
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGatewayRouteTable
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableID *string `json:"transitGatewayRouteTableId,omitempty" tf:"transit_gateway_route_table_id,omitempty"`
 
-	// Reference to a TransitGatewayRouteTable to populate transitGatewayRouteTableId.
+	// Reference to a TransitGatewayRouteTable in ec2 to populate transitGatewayRouteTableId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableIDRef *v1.Reference `json:"transitGatewayRouteTableIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGatewayRouteTable to populate transitGatewayRouteTableId.
+	// Selector for a TransitGatewayRouteTable in ec2 to populate transitGatewayRouteTableId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableIDSelector *v1.Selector `json:"transitGatewayRouteTableIdSelector,omitempty" tf:"-"`
 }

--- a/apis/ec2/v1beta1/zz_transitgatewayroutetable_types.go
+++ b/apis/ec2/v1beta1/zz_transitgatewayroutetable_types.go
@@ -20,14 +20,14 @@ type TransitGatewayRouteTableInitParameters_2 struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Identifier of EC2 Transit Gateway.
-	// +crossplane:generate:reference:type=TransitGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGateway
 	TransitGatewayID *string `json:"transitGatewayId,omitempty" tf:"transit_gateway_id,omitempty"`
 
-	// Reference to a TransitGateway to populate transitGatewayId.
+	// Reference to a TransitGateway in ec2 to populate transitGatewayId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayIDRef *v1.Reference `json:"transitGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGateway to populate transitGatewayId.
+	// Selector for a TransitGateway in ec2 to populate transitGatewayId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayIDSelector *v1.Selector `json:"transitGatewayIdSelector,omitempty" tf:"-"`
 }
@@ -71,15 +71,15 @@ type TransitGatewayRouteTableParameters_2 struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Identifier of EC2 Transit Gateway.
-	// +crossplane:generate:reference:type=TransitGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGateway
 	// +kubebuilder:validation:Optional
 	TransitGatewayID *string `json:"transitGatewayId,omitempty" tf:"transit_gateway_id,omitempty"`
 
-	// Reference to a TransitGateway to populate transitGatewayId.
+	// Reference to a TransitGateway in ec2 to populate transitGatewayId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayIDRef *v1.Reference `json:"transitGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGateway to populate transitGatewayId.
+	// Selector for a TransitGateway in ec2 to populate transitGatewayId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayIDSelector *v1.Selector `json:"transitGatewayIdSelector,omitempty" tf:"-"`
 }

--- a/apis/ec2/v1beta1/zz_transitgatewayroutetableassociation_types.go
+++ b/apis/ec2/v1beta1/zz_transitgatewayroutetableassociation_types.go
@@ -19,26 +19,26 @@ type TransitGatewayRouteTableAssociationInitParameters struct {
 	ReplaceExistingAssociation *bool `json:"replaceExistingAssociation,omitempty" tf:"replace_existing_association,omitempty"`
 
 	// Identifier of EC2 Transit Gateway Attachment.
-	// +crossplane:generate:reference:type=TransitGatewayVPCAttachment
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGatewayVPCAttachment
 	TransitGatewayAttachmentID *string `json:"transitGatewayAttachmentId,omitempty" tf:"transit_gateway_attachment_id,omitempty"`
 
-	// Reference to a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Reference to a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDRef *v1.Reference `json:"transitGatewayAttachmentIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Selector for a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDSelector *v1.Selector `json:"transitGatewayAttachmentIdSelector,omitempty" tf:"-"`
 
 	// Identifier of EC2 Transit Gateway Route Table.
-	// +crossplane:generate:reference:type=TransitGatewayRouteTable
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGatewayRouteTable
 	TransitGatewayRouteTableID *string `json:"transitGatewayRouteTableId,omitempty" tf:"transit_gateway_route_table_id,omitempty"`
 
-	// Reference to a TransitGatewayRouteTable to populate transitGatewayRouteTableId.
+	// Reference to a TransitGatewayRouteTable in ec2 to populate transitGatewayRouteTableId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableIDRef *v1.Reference `json:"transitGatewayRouteTableIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGatewayRouteTable to populate transitGatewayRouteTableId.
+	// Selector for a TransitGatewayRouteTable in ec2 to populate transitGatewayRouteTableId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableIDSelector *v1.Selector `json:"transitGatewayRouteTableIdSelector,omitempty" tf:"-"`
 }
@@ -76,28 +76,28 @@ type TransitGatewayRouteTableAssociationParameters struct {
 	ReplaceExistingAssociation *bool `json:"replaceExistingAssociation,omitempty" tf:"replace_existing_association,omitempty"`
 
 	// Identifier of EC2 Transit Gateway Attachment.
-	// +crossplane:generate:reference:type=TransitGatewayVPCAttachment
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGatewayVPCAttachment
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentID *string `json:"transitGatewayAttachmentId,omitempty" tf:"transit_gateway_attachment_id,omitempty"`
 
-	// Reference to a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Reference to a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDRef *v1.Reference `json:"transitGatewayAttachmentIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Selector for a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDSelector *v1.Selector `json:"transitGatewayAttachmentIdSelector,omitempty" tf:"-"`
 
 	// Identifier of EC2 Transit Gateway Route Table.
-	// +crossplane:generate:reference:type=TransitGatewayRouteTable
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGatewayRouteTable
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableID *string `json:"transitGatewayRouteTableId,omitempty" tf:"transit_gateway_route_table_id,omitempty"`
 
-	// Reference to a TransitGatewayRouteTable to populate transitGatewayRouteTableId.
+	// Reference to a TransitGatewayRouteTable in ec2 to populate transitGatewayRouteTableId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableIDRef *v1.Reference `json:"transitGatewayRouteTableIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGatewayRouteTable to populate transitGatewayRouteTableId.
+	// Selector for a TransitGatewayRouteTable in ec2 to populate transitGatewayRouteTableId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableIDSelector *v1.Selector `json:"transitGatewayRouteTableIdSelector,omitempty" tf:"-"`
 }

--- a/apis/ec2/v1beta1/zz_transitgatewayroutetablepropagation_types.go
+++ b/apis/ec2/v1beta1/zz_transitgatewayroutetablepropagation_types.go
@@ -16,26 +16,26 @@ import (
 type TransitGatewayRouteTablePropagationInitParameters struct {
 
 	// Identifier of EC2 Transit Gateway Attachment.
-	// +crossplane:generate:reference:type=TransitGatewayVPCAttachment
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGatewayVPCAttachment
 	TransitGatewayAttachmentID *string `json:"transitGatewayAttachmentId,omitempty" tf:"transit_gateway_attachment_id,omitempty"`
 
-	// Reference to a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Reference to a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDRef *v1.Reference `json:"transitGatewayAttachmentIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Selector for a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDSelector *v1.Selector `json:"transitGatewayAttachmentIdSelector,omitempty" tf:"-"`
 
 	// Identifier of EC2 Transit Gateway Route Table.
-	// +crossplane:generate:reference:type=TransitGatewayRouteTable
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGatewayRouteTable
 	TransitGatewayRouteTableID *string `json:"transitGatewayRouteTableId,omitempty" tf:"transit_gateway_route_table_id,omitempty"`
 
-	// Reference to a TransitGatewayRouteTable to populate transitGatewayRouteTableId.
+	// Reference to a TransitGatewayRouteTable in ec2 to populate transitGatewayRouteTableId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableIDRef *v1.Reference `json:"transitGatewayRouteTableIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGatewayRouteTable to populate transitGatewayRouteTableId.
+	// Selector for a TransitGatewayRouteTable in ec2 to populate transitGatewayRouteTableId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableIDSelector *v1.Selector `json:"transitGatewayRouteTableIdSelector,omitempty" tf:"-"`
 }
@@ -66,28 +66,28 @@ type TransitGatewayRouteTablePropagationParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// Identifier of EC2 Transit Gateway Attachment.
-	// +crossplane:generate:reference:type=TransitGatewayVPCAttachment
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGatewayVPCAttachment
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentID *string `json:"transitGatewayAttachmentId,omitempty" tf:"transit_gateway_attachment_id,omitempty"`
 
-	// Reference to a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Reference to a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDRef *v1.Reference `json:"transitGatewayAttachmentIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Selector for a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDSelector *v1.Selector `json:"transitGatewayAttachmentIdSelector,omitempty" tf:"-"`
 
 	// Identifier of EC2 Transit Gateway Route Table.
-	// +crossplane:generate:reference:type=TransitGatewayRouteTable
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGatewayRouteTable
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableID *string `json:"transitGatewayRouteTableId,omitempty" tf:"transit_gateway_route_table_id,omitempty"`
 
-	// Reference to a TransitGatewayRouteTable to populate transitGatewayRouteTableId.
+	// Reference to a TransitGatewayRouteTable in ec2 to populate transitGatewayRouteTableId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableIDRef *v1.Reference `json:"transitGatewayRouteTableIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGatewayRouteTable to populate transitGatewayRouteTableId.
+	// Selector for a TransitGatewayRouteTable in ec2 to populate transitGatewayRouteTableId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayRouteTableIDSelector *v1.Selector `json:"transitGatewayRouteTableIdSelector,omitempty" tf:"-"`
 }

--- a/apis/ec2/v1beta1/zz_transitgatewayvpcattachment_types.go
+++ b/apis/ec2/v1beta1/zz_transitgatewayvpcattachment_types.go
@@ -50,14 +50,14 @@ type TransitGatewayVPCAttachmentInitParameters struct {
 	TransitGatewayDefaultRouteTablePropagation *bool `json:"transitGatewayDefaultRouteTablePropagation,omitempty" tf:"transit_gateway_default_route_table_propagation,omitempty"`
 
 	// Identifier of EC2 Transit Gateway.
-	// +crossplane:generate:reference:type=TransitGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGateway
 	TransitGatewayID *string `json:"transitGatewayId,omitempty" tf:"transit_gateway_id,omitempty"`
 
-	// Reference to a TransitGateway to populate transitGatewayId.
+	// Reference to a TransitGateway in ec2 to populate transitGatewayId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayIDRef *v1.Reference `json:"transitGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGateway to populate transitGatewayId.
+	// Selector for a TransitGateway in ec2 to populate transitGatewayId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayIDSelector *v1.Selector `json:"transitGatewayIdSelector,omitempty" tf:"-"`
 
@@ -165,15 +165,15 @@ type TransitGatewayVPCAttachmentParameters struct {
 	TransitGatewayDefaultRouteTablePropagation *bool `json:"transitGatewayDefaultRouteTablePropagation,omitempty" tf:"transit_gateway_default_route_table_propagation,omitempty"`
 
 	// Identifier of EC2 Transit Gateway.
-	// +crossplane:generate:reference:type=TransitGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGateway
 	// +kubebuilder:validation:Optional
 	TransitGatewayID *string `json:"transitGatewayId,omitempty" tf:"transit_gateway_id,omitempty"`
 
-	// Reference to a TransitGateway to populate transitGatewayId.
+	// Reference to a TransitGateway in ec2 to populate transitGatewayId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayIDRef *v1.Reference `json:"transitGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGateway to populate transitGatewayId.
+	// Selector for a TransitGateway in ec2 to populate transitGatewayId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayIDSelector *v1.Selector `json:"transitGatewayIdSelector,omitempty" tf:"-"`
 

--- a/apis/ec2/v1beta1/zz_transitgatewayvpcattachmentaccepter_types.go
+++ b/apis/ec2/v1beta1/zz_transitgatewayvpcattachmentaccepter_types.go
@@ -20,14 +20,14 @@ type TransitGatewayVPCAttachmentAccepterInitParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// The ID of the EC2 Transit Gateway Attachment to manage.
-	// +crossplane:generate:reference:type=TransitGatewayVPCAttachment
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGatewayVPCAttachment
 	TransitGatewayAttachmentID *string `json:"transitGatewayAttachmentId,omitempty" tf:"transit_gateway_attachment_id,omitempty"`
 
-	// Reference to a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Reference to a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDRef *v1.Reference `json:"transitGatewayAttachmentIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Selector for a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDSelector *v1.Selector `json:"transitGatewayAttachmentIdSelector,omitempty" tf:"-"`
 
@@ -96,15 +96,15 @@ type TransitGatewayVPCAttachmentAccepterParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// The ID of the EC2 Transit Gateway Attachment to manage.
-	// +crossplane:generate:reference:type=TransitGatewayVPCAttachment
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.TransitGatewayVPCAttachment
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentID *string `json:"transitGatewayAttachmentId,omitempty" tf:"transit_gateway_attachment_id,omitempty"`
 
-	// Reference to a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Reference to a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDRef *v1.Reference `json:"transitGatewayAttachmentIdRef,omitempty" tf:"-"`
 
-	// Selector for a TransitGatewayVPCAttachment to populate transitGatewayAttachmentId.
+	// Selector for a TransitGatewayVPCAttachment in ec2 to populate transitGatewayAttachmentId.
 	// +kubebuilder:validation:Optional
 	TransitGatewayAttachmentIDSelector *v1.Selector `json:"transitGatewayAttachmentIdSelector,omitempty" tf:"-"`
 

--- a/apis/ec2/v1beta1/zz_vpcipampool_types.go
+++ b/apis/ec2/v1beta1/zz_vpcipampool_types.go
@@ -42,14 +42,14 @@ type VPCIpamPoolInitParameters struct {
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`
 
 	// The ID of the scope in which you would like to create the IPAM pool.
-	// +crossplane:generate:reference:type=VPCIpamScope
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.VPCIpamScope
 	IpamScopeID *string `json:"ipamScopeId,omitempty" tf:"ipam_scope_id,omitempty"`
 
-	// Reference to a VPCIpamScope to populate ipamScopeId.
+	// Reference to a VPCIpamScope in ec2 to populate ipamScopeId.
 	// +kubebuilder:validation:Optional
 	IpamScopeIDRef *v1.Reference `json:"ipamScopeIdRef,omitempty" tf:"-"`
 
-	// Selector for a VPCIpamScope to populate ipamScopeId.
+	// Selector for a VPCIpamScope in ec2 to populate ipamScopeId.
 	// +kubebuilder:validation:Optional
 	IpamScopeIDSelector *v1.Selector `json:"ipamScopeIdSelector,omitempty" tf:"-"`
 
@@ -182,15 +182,15 @@ type VPCIpamPoolParameters struct {
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`
 
 	// The ID of the scope in which you would like to create the IPAM pool.
-	// +crossplane:generate:reference:type=VPCIpamScope
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.VPCIpamScope
 	// +kubebuilder:validation:Optional
 	IpamScopeID *string `json:"ipamScopeId,omitempty" tf:"ipam_scope_id,omitempty"`
 
-	// Reference to a VPCIpamScope to populate ipamScopeId.
+	// Reference to a VPCIpamScope in ec2 to populate ipamScopeId.
 	// +kubebuilder:validation:Optional
 	IpamScopeIDRef *v1.Reference `json:"ipamScopeIdRef,omitempty" tf:"-"`
 
-	// Selector for a VPCIpamScope to populate ipamScopeId.
+	// Selector for a VPCIpamScope in ec2 to populate ipamScopeId.
 	// +kubebuilder:validation:Optional
 	IpamScopeIDSelector *v1.Selector `json:"ipamScopeIdSelector,omitempty" tf:"-"`
 

--- a/apis/ec2/v1beta1/zz_vpcipamscope_types.go
+++ b/apis/ec2/v1beta1/zz_vpcipamscope_types.go
@@ -19,14 +19,14 @@ type VPCIpamScopeInitParameters struct {
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`
 
 	// The ID of the IPAM for which you're creating this scope.
-	// +crossplane:generate:reference:type=VPCIpam
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.VPCIpam
 	IpamID *string `json:"ipamId,omitempty" tf:"ipam_id,omitempty"`
 
-	// Reference to a VPCIpam to populate ipamId.
+	// Reference to a VPCIpam in ec2 to populate ipamId.
 	// +kubebuilder:validation:Optional
 	IpamIDRef *v1.Reference `json:"ipamIdRef,omitempty" tf:"-"`
 
-	// Selector for a VPCIpam to populate ipamId.
+	// Selector for a VPCIpam in ec2 to populate ipamId.
 	// +kubebuilder:validation:Optional
 	IpamIDSelector *v1.Selector `json:"ipamIdSelector,omitempty" tf:"-"`
 
@@ -76,15 +76,15 @@ type VPCIpamScopeParameters struct {
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`
 
 	// The ID of the IPAM for which you're creating this scope.
-	// +crossplane:generate:reference:type=VPCIpam
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.VPCIpam
 	// +kubebuilder:validation:Optional
 	IpamID *string `json:"ipamId,omitempty" tf:"ipam_id,omitempty"`
 
-	// Reference to a VPCIpam to populate ipamId.
+	// Reference to a VPCIpam in ec2 to populate ipamId.
 	// +kubebuilder:validation:Optional
 	IpamIDRef *v1.Reference `json:"ipamIdRef,omitempty" tf:"-"`
 
-	// Selector for a VPCIpam to populate ipamId.
+	// Selector for a VPCIpam in ec2 to populate ipamId.
 	// +kubebuilder:validation:Optional
 	IpamIDSelector *v1.Selector `json:"ipamIdSelector,omitempty" tf:"-"`
 

--- a/apis/ec2/v1beta1/zz_vpcpeeringconnection_types.go
+++ b/apis/ec2/v1beta1/zz_vpcpeeringconnection_types.go
@@ -53,14 +53,14 @@ type VPCPeeringConnectionInitParameters_2 struct {
 	PeerRegion *string `json:"peerRegion,omitempty" tf:"peer_region,omitempty"`
 
 	// The ID of the VPC with which you are creating the VPC Peering Connection.
-	// +crossplane:generate:reference:type=VPC
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.VPC
 	PeerVPCID *string `json:"peerVpcId,omitempty" tf:"peer_vpc_id,omitempty"`
 
-	// Reference to a VPC to populate peerVpcId.
+	// Reference to a VPC in ec2 to populate peerVpcId.
 	// +kubebuilder:validation:Optional
 	PeerVPCIDRef *v1.Reference `json:"peerVpcIdRef,omitempty" tf:"-"`
 
-	// Selector for a VPC to populate peerVpcId.
+	// Selector for a VPC in ec2 to populate peerVpcId.
 	// +kubebuilder:validation:Optional
 	PeerVPCIDSelector *v1.Selector `json:"peerVpcIdSelector,omitempty" tf:"-"`
 
@@ -140,15 +140,15 @@ type VPCPeeringConnectionParameters_2 struct {
 	PeerRegion *string `json:"peerRegion,omitempty" tf:"peer_region,omitempty"`
 
 	// The ID of the VPC with which you are creating the VPC Peering Connection.
-	// +crossplane:generate:reference:type=VPC
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.VPC
 	// +kubebuilder:validation:Optional
 	PeerVPCID *string `json:"peerVpcId,omitempty" tf:"peer_vpc_id,omitempty"`
 
-	// Reference to a VPC to populate peerVpcId.
+	// Reference to a VPC in ec2 to populate peerVpcId.
 	// +kubebuilder:validation:Optional
 	PeerVPCIDRef *v1.Reference `json:"peerVpcIdRef,omitempty" tf:"-"`
 
-	// Selector for a VPC to populate peerVpcId.
+	// Selector for a VPC in ec2 to populate peerVpcId.
 	// +kubebuilder:validation:Optional
 	PeerVPCIDSelector *v1.Selector `json:"peerVpcIdSelector,omitempty" tf:"-"`
 

--- a/apis/ec2/v1beta1/zz_vpnconnection_types.go
+++ b/apis/ec2/v1beta1/zz_vpnconnection_types.go
@@ -348,14 +348,14 @@ type VPNConnectionInitParameters_2 struct {
 	TypeSelector *v1.Selector `json:"typeSelector,omitempty" tf:"-"`
 
 	// The ID of the Virtual Private Gateway.
-	// +crossplane:generate:reference:type=VPNGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.VPNGateway
 	VPNGatewayID *string `json:"vpnGatewayId,omitempty" tf:"vpn_gateway_id,omitempty"`
 
-	// Reference to a VPNGateway to populate vpnGatewayId.
+	// Reference to a VPNGateway in ec2 to populate vpnGatewayId.
 	// +kubebuilder:validation:Optional
 	VPNGatewayIDRef *v1.Reference `json:"vpnGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a VPNGateway to populate vpnGatewayId.
+	// Selector for a VPNGateway in ec2 to populate vpnGatewayId.
 	// +kubebuilder:validation:Optional
 	VPNGatewayIDSelector *v1.Selector `json:"vpnGatewayIdSelector,omitempty" tf:"-"`
 }
@@ -854,15 +854,15 @@ type VPNConnectionParameters_2 struct {
 	TypeSelector *v1.Selector `json:"typeSelector,omitempty" tf:"-"`
 
 	// The ID of the Virtual Private Gateway.
-	// +crossplane:generate:reference:type=VPNGateway
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ec2/v1beta1.VPNGateway
 	// +kubebuilder:validation:Optional
 	VPNGatewayID *string `json:"vpnGatewayId,omitempty" tf:"vpn_gateway_id,omitempty"`
 
-	// Reference to a VPNGateway to populate vpnGatewayId.
+	// Reference to a VPNGateway in ec2 to populate vpnGatewayId.
 	// +kubebuilder:validation:Optional
 	VPNGatewayIDRef *v1.Reference `json:"vpnGatewayIdRef,omitempty" tf:"-"`
 
-	// Selector for a VPNGateway to populate vpnGatewayId.
+	// Selector for a VPNGateway in ec2 to populate vpnGatewayId.
 	// +kubebuilder:validation:Optional
 	VPNGatewayIDSelector *v1.Selector `json:"vpnGatewayIdSelector,omitempty" tf:"-"`
 }

--- a/apis/ecs/v1beta1/zz_capacityprovider_types.go
+++ b/apis/ecs/v1beta1/zz_capacityprovider_types.go
@@ -16,7 +16,7 @@ import (
 type AutoScalingGroupProviderInitParameters struct {
 
 	// - ARN of the associated auto scaling group.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/autoscaling/v1beta1.AutoscalingGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/autoscaling/v1beta2.AutoscalingGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	AutoScalingGroupArn *string `json:"autoScalingGroupArn,omitempty" tf:"auto_scaling_group_arn,omitempty"`
 
@@ -50,7 +50,7 @@ type AutoScalingGroupProviderObservation struct {
 type AutoScalingGroupProviderParameters struct {
 
 	// - ARN of the associated auto scaling group.
-	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/autoscaling/v1beta1.AutoscalingGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/autoscaling/v1beta2.AutoscalingGroup
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	// +kubebuilder:validation:Optional
 	AutoScalingGroupArn *string `json:"autoScalingGroupArn,omitempty" tf:"auto_scaling_group_arn,omitempty"`

--- a/apis/ecs/v1beta1/zz_generated.resolvers.go
+++ b/apis/ecs/v1beta1/zz_generated.resolvers.go
@@ -28,7 +28,7 @@ func (mg *CapacityProvider) ResolveReferences( // ResolveReferences of this Capa
 
 	for i3 := 0; i3 < len(mg.Spec.ForProvider.AutoScalingGroupProvider); i3++ {
 		{
-			m, l, err = apisresolver.GetManagedResource("autoscaling.aws.upbound.io", "v1beta1", "AutoscalingGroup", "AutoscalingGroupList")
+			m, l, err = apisresolver.GetManagedResource("autoscaling.aws.upbound.io", "v1beta2", "AutoscalingGroup", "AutoscalingGroupList")
 			if err != nil {
 				return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
 			}
@@ -49,7 +49,7 @@ func (mg *CapacityProvider) ResolveReferences( // ResolveReferences of this Capa
 	}
 	for i3 := 0; i3 < len(mg.Spec.InitProvider.AutoScalingGroupProvider); i3++ {
 		{
-			m, l, err = apisresolver.GetManagedResource("autoscaling.aws.upbound.io", "v1beta1", "AutoscalingGroup", "AutoscalingGroupList")
+			m, l, err = apisresolver.GetManagedResource("autoscaling.aws.upbound.io", "v1beta2", "AutoscalingGroup", "AutoscalingGroupList")
 			if err != nil {
 				return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
 			}

--- a/apis/ecs/v1beta1/zz_service_types.go
+++ b/apis/ecs/v1beta1/zz_service_types.go
@@ -572,14 +572,14 @@ type ServiceInitParameters struct {
 	CapacityProviderStrategy []CapacityProviderStrategyInitParameters `json:"capacityProviderStrategy,omitempty" tf:"capacity_provider_strategy,omitempty"`
 
 	// Name of an ECS cluster.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ecs/v1beta1.Cluster
 	Cluster *string `json:"cluster,omitempty" tf:"cluster,omitempty"`
 
-	// Reference to a Cluster to populate cluster.
+	// Reference to a Cluster in ecs to populate cluster.
 	// +kubebuilder:validation:Optional
 	ClusterRef *v1.Reference `json:"clusterRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate cluster.
+	// Selector for a Cluster in ecs to populate cluster.
 	// +kubebuilder:validation:Optional
 	ClusterSelector *v1.Selector `json:"clusterSelector,omitempty" tf:"-"`
 
@@ -658,14 +658,14 @@ type ServiceInitParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Family and revision (family:revision) or full ARN of the task definition that you want to run in your service. Required unless using the EXTERNAL deployment controller. If a revision is not specified, the latest ACTIVE revision is used.
-	// +crossplane:generate:reference:type=TaskDefinition
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ecs/v1beta1.TaskDefinition
 	TaskDefinition *string `json:"taskDefinition,omitempty" tf:"task_definition,omitempty"`
 
-	// Reference to a TaskDefinition to populate taskDefinition.
+	// Reference to a TaskDefinition in ecs to populate taskDefinition.
 	// +kubebuilder:validation:Optional
 	TaskDefinitionRef *v1.Reference `json:"taskDefinitionRef,omitempty" tf:"-"`
 
-	// Selector for a TaskDefinition to populate taskDefinition.
+	// Selector for a TaskDefinition in ecs to populate taskDefinition.
 	// +kubebuilder:validation:Optional
 	TaskDefinitionSelector *v1.Selector `json:"taskDefinitionSelector,omitempty" tf:"-"`
 
@@ -781,15 +781,15 @@ type ServiceParameters struct {
 	CapacityProviderStrategy []CapacityProviderStrategyParameters `json:"capacityProviderStrategy,omitempty" tf:"capacity_provider_strategy,omitempty"`
 
 	// Name of an ECS cluster.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ecs/v1beta1.Cluster
 	// +kubebuilder:validation:Optional
 	Cluster *string `json:"cluster,omitempty" tf:"cluster,omitempty"`
 
-	// Reference to a Cluster to populate cluster.
+	// Reference to a Cluster in ecs to populate cluster.
 	// +kubebuilder:validation:Optional
 	ClusterRef *v1.Reference `json:"clusterRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate cluster.
+	// Selector for a Cluster in ecs to populate cluster.
 	// +kubebuilder:validation:Optional
 	ClusterSelector *v1.Selector `json:"clusterSelector,omitempty" tf:"-"`
 
@@ -894,15 +894,15 @@ type ServiceParameters struct {
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
 	// Family and revision (family:revision) or full ARN of the task definition that you want to run in your service. Required unless using the EXTERNAL deployment controller. If a revision is not specified, the latest ACTIVE revision is used.
-	// +crossplane:generate:reference:type=TaskDefinition
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/ecs/v1beta1.TaskDefinition
 	// +kubebuilder:validation:Optional
 	TaskDefinition *string `json:"taskDefinition,omitempty" tf:"task_definition,omitempty"`
 
-	// Reference to a TaskDefinition to populate taskDefinition.
+	// Reference to a TaskDefinition in ecs to populate taskDefinition.
 	// +kubebuilder:validation:Optional
 	TaskDefinitionRef *v1.Reference `json:"taskDefinitionRef,omitempty" tf:"-"`
 
-	// Selector for a TaskDefinition to populate taskDefinition.
+	// Selector for a TaskDefinition in ecs to populate taskDefinition.
 	// +kubebuilder:validation:Optional
 	TaskDefinitionSelector *v1.Selector `json:"taskDefinitionSelector,omitempty" tf:"-"`
 

--- a/apis/efs/v1beta1/zz_accesspoint_types.go
+++ b/apis/efs/v1beta1/zz_accesspoint_types.go
@@ -16,14 +16,14 @@ import (
 type AccessPointInitParameters struct {
 
 	// ID of the file system for which the access point is intended.
-	// +crossplane:generate:reference:type=FileSystem
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/efs/v1beta1.FileSystem
 	FileSystemID *string `json:"fileSystemId,omitempty" tf:"file_system_id,omitempty"`
 
-	// Reference to a FileSystem to populate fileSystemId.
+	// Reference to a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDRef *v1.Reference `json:"fileSystemIdRef,omitempty" tf:"-"`
 
-	// Selector for a FileSystem to populate fileSystemId.
+	// Selector for a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDSelector *v1.Selector `json:"fileSystemIdSelector,omitempty" tf:"-"`
 
@@ -73,15 +73,15 @@ type AccessPointObservation struct {
 type AccessPointParameters struct {
 
 	// ID of the file system for which the access point is intended.
-	// +crossplane:generate:reference:type=FileSystem
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/efs/v1beta1.FileSystem
 	// +kubebuilder:validation:Optional
 	FileSystemID *string `json:"fileSystemId,omitempty" tf:"file_system_id,omitempty"`
 
-	// Reference to a FileSystem to populate fileSystemId.
+	// Reference to a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDRef *v1.Reference `json:"fileSystemIdRef,omitempty" tf:"-"`
 
-	// Selector for a FileSystem to populate fileSystemId.
+	// Selector for a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDSelector *v1.Selector `json:"fileSystemIdSelector,omitempty" tf:"-"`
 

--- a/apis/efs/v1beta1/zz_backuppolicy_types.go
+++ b/apis/efs/v1beta1/zz_backuppolicy_types.go
@@ -38,14 +38,14 @@ type BackupPolicyInitParameters struct {
 	BackupPolicy []BackupPolicyBackupPolicyInitParameters `json:"backupPolicy,omitempty" tf:"backup_policy,omitempty"`
 
 	// The ID of the EFS file system.
-	// +crossplane:generate:reference:type=FileSystem
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/efs/v1beta1.FileSystem
 	FileSystemID *string `json:"fileSystemId,omitempty" tf:"file_system_id,omitempty"`
 
-	// Reference to a FileSystem to populate fileSystemId.
+	// Reference to a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDRef *v1.Reference `json:"fileSystemIdRef,omitempty" tf:"-"`
 
-	// Selector for a FileSystem to populate fileSystemId.
+	// Selector for a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDSelector *v1.Selector `json:"fileSystemIdSelector,omitempty" tf:"-"`
 }
@@ -69,15 +69,15 @@ type BackupPolicyParameters struct {
 	BackupPolicy []BackupPolicyBackupPolicyParameters `json:"backupPolicy,omitempty" tf:"backup_policy,omitempty"`
 
 	// The ID of the EFS file system.
-	// +crossplane:generate:reference:type=FileSystem
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/efs/v1beta1.FileSystem
 	// +kubebuilder:validation:Optional
 	FileSystemID *string `json:"fileSystemId,omitempty" tf:"file_system_id,omitempty"`
 
-	// Reference to a FileSystem to populate fileSystemId.
+	// Reference to a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDRef *v1.Reference `json:"fileSystemIdRef,omitempty" tf:"-"`
 
-	// Selector for a FileSystem to populate fileSystemId.
+	// Selector for a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDSelector *v1.Selector `json:"fileSystemIdSelector,omitempty" tf:"-"`
 

--- a/apis/efs/v1beta1/zz_filesystempolicy_types.go
+++ b/apis/efs/v1beta1/zz_filesystempolicy_types.go
@@ -19,14 +19,14 @@ type FileSystemPolicyInitParameters struct {
 	BypassPolicyLockoutSafetyCheck *bool `json:"bypassPolicyLockoutSafetyCheck,omitempty" tf:"bypass_policy_lockout_safety_check,omitempty"`
 
 	// The ID of the EFS file system.
-	// +crossplane:generate:reference:type=FileSystem
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/efs/v1beta1.FileSystem
 	FileSystemID *string `json:"fileSystemId,omitempty" tf:"file_system_id,omitempty"`
 
-	// Reference to a FileSystem to populate fileSystemId.
+	// Reference to a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDRef *v1.Reference `json:"fileSystemIdRef,omitempty" tf:"-"`
 
-	// Selector for a FileSystem to populate fileSystemId.
+	// Selector for a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDSelector *v1.Selector `json:"fileSystemIdSelector,omitempty" tf:"-"`
 
@@ -56,15 +56,15 @@ type FileSystemPolicyParameters struct {
 	BypassPolicyLockoutSafetyCheck *bool `json:"bypassPolicyLockoutSafetyCheck,omitempty" tf:"bypass_policy_lockout_safety_check,omitempty"`
 
 	// The ID of the EFS file system.
-	// +crossplane:generate:reference:type=FileSystem
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/efs/v1beta1.FileSystem
 	// +kubebuilder:validation:Optional
 	FileSystemID *string `json:"fileSystemId,omitempty" tf:"file_system_id,omitempty"`
 
-	// Reference to a FileSystem to populate fileSystemId.
+	// Reference to a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDRef *v1.Reference `json:"fileSystemIdRef,omitempty" tf:"-"`
 
-	// Selector for a FileSystem to populate fileSystemId.
+	// Selector for a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDSelector *v1.Selector `json:"fileSystemIdSelector,omitempty" tf:"-"`
 

--- a/apis/efs/v1beta1/zz_mounttarget_types.go
+++ b/apis/efs/v1beta1/zz_mounttarget_types.go
@@ -16,14 +16,14 @@ import (
 type MountTargetInitParameters struct {
 
 	// The ID of the file system for which the mount target is intended.
-	// +crossplane:generate:reference:type=FileSystem
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/efs/v1beta1.FileSystem
 	FileSystemID *string `json:"fileSystemId,omitempty" tf:"file_system_id,omitempty"`
 
-	// Reference to a FileSystem to populate fileSystemId.
+	// Reference to a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDRef *v1.Reference `json:"fileSystemIdRef,omitempty" tf:"-"`
 
-	// Selector for a FileSystem to populate fileSystemId.
+	// Selector for a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDSelector *v1.Selector `json:"fileSystemIdSelector,omitempty" tf:"-"`
 
@@ -103,15 +103,15 @@ type MountTargetObservation struct {
 type MountTargetParameters struct {
 
 	// The ID of the file system for which the mount target is intended.
-	// +crossplane:generate:reference:type=FileSystem
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/efs/v1beta1.FileSystem
 	// +kubebuilder:validation:Optional
 	FileSystemID *string `json:"fileSystemId,omitempty" tf:"file_system_id,omitempty"`
 
-	// Reference to a FileSystem to populate fileSystemId.
+	// Reference to a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDRef *v1.Reference `json:"fileSystemIdRef,omitempty" tf:"-"`
 
-	// Selector for a FileSystem to populate fileSystemId.
+	// Selector for a FileSystem in efs to populate fileSystemId.
 	// +kubebuilder:validation:Optional
 	FileSystemIDSelector *v1.Selector `json:"fileSystemIdSelector,omitempty" tf:"-"`
 

--- a/apis/eks/v1beta1/zz_addon_types.go
+++ b/apis/eks/v1beta1/zz_addon_types.go
@@ -24,14 +24,14 @@ type AddonInitParameters struct {
 	AddonVersion *string `json:"addonVersion,omitempty" tf:"addon_version,omitempty"`
 
 	// 100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (^[0-9A-Za-z][A-Za-z0-9\-_]+$).
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/eks/v1beta1.Cluster
 	ClusterName *string `json:"clusterName,omitempty" tf:"cluster_name,omitempty"`
 
-	// Reference to a Cluster to populate clusterName.
+	// Reference to a Cluster in eks to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameRef *v1.Reference `json:"clusterNameRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate clusterName.
+	// Selector for a Cluster in eks to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameSelector *v1.Selector `json:"clusterNameSelector,omitempty" tf:"-"`
 
@@ -143,15 +143,15 @@ type AddonParameters struct {
 	AddonVersion *string `json:"addonVersion,omitempty" tf:"addon_version,omitempty"`
 
 	// 100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (^[0-9A-Za-z][A-Za-z0-9\-_]+$).
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/eks/v1beta1.Cluster
 	// +kubebuilder:validation:Optional
 	ClusterName *string `json:"clusterName,omitempty" tf:"cluster_name,omitempty"`
 
-	// Reference to a Cluster to populate clusterName.
+	// Reference to a Cluster in eks to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameRef *v1.Reference `json:"clusterNameRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate clusterName.
+	// Selector for a Cluster in eks to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameSelector *v1.Selector `json:"clusterNameSelector,omitempty" tf:"-"`
 

--- a/apis/eks/v1beta1/zz_fargateprofile_types.go
+++ b/apis/eks/v1beta1/zz_fargateprofile_types.go
@@ -16,14 +16,14 @@ import (
 type FargateProfileInitParameters struct {
 
 	// 100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (^[0-9A-Za-z][A-Za-z0-9\-_]+$).
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/eks/v1beta1.Cluster
 	ClusterName *string `json:"clusterName,omitempty" tf:"cluster_name,omitempty"`
 
-	// Reference to a Cluster to populate clusterName.
+	// Reference to a Cluster in eks to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameRef *v1.Reference `json:"clusterNameRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate clusterName.
+	// Selector for a Cluster in eks to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameSelector *v1.Selector `json:"clusterNameSelector,omitempty" tf:"-"`
 
@@ -99,15 +99,15 @@ type FargateProfileObservation struct {
 type FargateProfileParameters struct {
 
 	// 100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (^[0-9A-Za-z][A-Za-z0-9\-_]+$).
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/eks/v1beta1.Cluster
 	// +kubebuilder:validation:Optional
 	ClusterName *string `json:"clusterName,omitempty" tf:"cluster_name,omitempty"`
 
-	// Reference to a Cluster to populate clusterName.
+	// Reference to a Cluster in eks to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameRef *v1.Reference `json:"clusterNameRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate clusterName.
+	// Selector for a Cluster in eks to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameSelector *v1.Selector `json:"clusterNameSelector,omitempty" tf:"-"`
 

--- a/apis/eks/v1beta1/zz_identityproviderconfig_types.go
+++ b/apis/eks/v1beta1/zz_identityproviderconfig_types.go
@@ -16,14 +16,14 @@ import (
 type IdentityProviderConfigInitParameters struct {
 
 	// –  Name of the EKS Cluster.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/eks/v1beta1.Cluster
 	ClusterName *string `json:"clusterName,omitempty" tf:"cluster_name,omitempty"`
 
-	// Reference to a Cluster to populate clusterName.
+	// Reference to a Cluster in eks to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameRef *v1.Reference `json:"clusterNameRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate clusterName.
+	// Selector for a Cluster in eks to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameSelector *v1.Selector `json:"clusterNameSelector,omitempty" tf:"-"`
 
@@ -146,15 +146,15 @@ type IdentityProviderConfigOidcParameters struct {
 type IdentityProviderConfigParameters struct {
 
 	// –  Name of the EKS Cluster.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/eks/v1beta1.Cluster
 	// +kubebuilder:validation:Optional
 	ClusterName *string `json:"clusterName,omitempty" tf:"cluster_name,omitempty"`
 
-	// Reference to a Cluster to populate clusterName.
+	// Reference to a Cluster in eks to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameRef *v1.Reference `json:"clusterNameRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate clusterName.
+	// Selector for a Cluster in eks to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameSelector *v1.Selector `json:"clusterNameSelector,omitempty" tf:"-"`
 

--- a/apis/eks/v1beta1/zz_nodegroup_types.go
+++ b/apis/eks/v1beta1/zz_nodegroup_types.go
@@ -233,16 +233,16 @@ type NodeGroupParameters struct {
 	CapacityType *string `json:"capacityType,omitempty" tf:"capacity_type,omitempty"`
 
 	// 100 characters in length. Must begin with an alphanumeric character, and must only contain alphanumeric characters, dashes and underscores (^[0-9A-Za-z][A-Za-z0-9\-_]+$).
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/eks/v1beta1.Cluster
 	// +crossplane:generate:reference:extractor=ExternalNameIfClusterActive()
 	// +kubebuilder:validation:Optional
 	ClusterName *string `json:"clusterName,omitempty" tf:"cluster_name,omitempty"`
 
-	// Reference to a Cluster to populate clusterName.
+	// Reference to a Cluster in eks to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameRef *v1.Reference `json:"clusterNameRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate clusterName.
+	// Selector for a Cluster in eks to populate clusterName.
 	// +kubebuilder:validation:Optional
 	ClusterNameSelector *v1.Selector `json:"clusterNameSelector,omitempty" tf:"-"`
 

--- a/apis/elasticache/v1beta1/zz_usergroup_types.go
+++ b/apis/elasticache/v1beta1/zz_usergroup_types.go
@@ -22,16 +22,16 @@ type UserGroupInitParameters struct {
 	// +mapType=granular
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
-	// References to User to populate userIds.
+	// References to User in elasticache to populate userIds.
 	// +kubebuilder:validation:Optional
 	UserIDRefs []v1.Reference `json:"userIdRefs,omitempty" tf:"-"`
 
-	// Selector for a list of User to populate userIds.
+	// Selector for a list of User in elasticache to populate userIds.
 	// +kubebuilder:validation:Optional
 	UserIDSelector *v1.Selector `json:"userIdSelector,omitempty" tf:"-"`
 
 	// The list of user IDs that belong to the user group.
-	// +crossplane:generate:reference:type=User
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/elasticache/v1beta1.User
 	// +crossplane:generate:reference:refFieldName=UserIDRefs
 	// +crossplane:generate:reference:selectorFieldName=UserIDSelector
 	// +listType=set
@@ -78,16 +78,16 @@ type UserGroupParameters struct {
 	// +mapType=granular
 	Tags map[string]*string `json:"tags,omitempty" tf:"tags,omitempty"`
 
-	// References to User to populate userIds.
+	// References to User in elasticache to populate userIds.
 	// +kubebuilder:validation:Optional
 	UserIDRefs []v1.Reference `json:"userIdRefs,omitempty" tf:"-"`
 
-	// Selector for a list of User to populate userIds.
+	// Selector for a list of User in elasticache to populate userIds.
 	// +kubebuilder:validation:Optional
 	UserIDSelector *v1.Selector `json:"userIdSelector,omitempty" tf:"-"`
 
 	// The list of user IDs that belong to the user group.
-	// +crossplane:generate:reference:type=User
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/elasticache/v1beta1.User
 	// +crossplane:generate:reference:refFieldName=UserIDRefs
 	// +crossplane:generate:reference:selectorFieldName=UserIDSelector
 	// +kubebuilder:validation:Optional

--- a/apis/elb/v1beta1/zz_attachment_types.go
+++ b/apis/elb/v1beta1/zz_attachment_types.go
@@ -16,14 +16,14 @@ import (
 type AttachmentInitParameters struct {
 
 	// The name of the ELB.
-	// +crossplane:generate:reference:type=ELB
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/elb/v1beta1.ELB
 	ELB *string `json:"elb,omitempty" tf:"elb,omitempty"`
 
-	// Reference to a ELB to populate elb.
+	// Reference to a ELB in elb to populate elb.
 	// +kubebuilder:validation:Optional
 	ELBRef *v1.Reference `json:"elbRef,omitempty" tf:"-"`
 
-	// Selector for a ELB to populate elb.
+	// Selector for a ELB in elb to populate elb.
 	// +kubebuilder:validation:Optional
 	ELBSelector *v1.Selector `json:"elbSelector,omitempty" tf:"-"`
 
@@ -54,15 +54,15 @@ type AttachmentObservation struct {
 type AttachmentParameters struct {
 
 	// The name of the ELB.
-	// +crossplane:generate:reference:type=ELB
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/elb/v1beta1.ELB
 	// +kubebuilder:validation:Optional
 	ELB *string `json:"elb,omitempty" tf:"elb,omitempty"`
 
-	// Reference to a ELB to populate elb.
+	// Reference to a ELB in elb to populate elb.
 	// +kubebuilder:validation:Optional
 	ELBRef *v1.Reference `json:"elbRef,omitempty" tf:"-"`
 
-	// Selector for a ELB to populate elb.
+	// Selector for a ELB in elb to populate elb.
 	// +kubebuilder:validation:Optional
 	ELBSelector *v1.Selector `json:"elbSelector,omitempty" tf:"-"`
 

--- a/apis/elbv2/v1beta1/zz_lblistener_types.go
+++ b/apis/elbv2/v1beta1/zz_lblistener_types.go
@@ -242,14 +242,14 @@ type DefaultActionInitParameters struct {
 	Redirect []RedirectInitParameters `json:"redirect,omitempty" tf:"redirect,omitempty"`
 
 	// ARN of the Target Group to which to route traffic. Specify only if type is forward and you want to route to a single target group. To route to one or more target groups, use a forward block instead.
-	// +crossplane:generate:reference:type=LBTargetGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/elbv2/v1beta1.LBTargetGroup
 	TargetGroupArn *string `json:"targetGroupArn,omitempty" tf:"target_group_arn,omitempty"`
 
-	// Reference to a LBTargetGroup to populate targetGroupArn.
+	// Reference to a LBTargetGroup in elbv2 to populate targetGroupArn.
 	// +kubebuilder:validation:Optional
 	TargetGroupArnRef *v1.Reference `json:"targetGroupArnRef,omitempty" tf:"-"`
 
-	// Selector for a LBTargetGroup to populate targetGroupArn.
+	// Selector for a LBTargetGroup in elbv2 to populate targetGroupArn.
 	// +kubebuilder:validation:Optional
 	TargetGroupArnSelector *v1.Selector `json:"targetGroupArnSelector,omitempty" tf:"-"`
 
@@ -311,15 +311,15 @@ type DefaultActionParameters struct {
 	Redirect []RedirectParameters `json:"redirect,omitempty" tf:"redirect,omitempty"`
 
 	// ARN of the Target Group to which to route traffic. Specify only if type is forward and you want to route to a single target group. To route to one or more target groups, use a forward block instead.
-	// +crossplane:generate:reference:type=LBTargetGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/elbv2/v1beta1.LBTargetGroup
 	// +kubebuilder:validation:Optional
 	TargetGroupArn *string `json:"targetGroupArn,omitempty" tf:"target_group_arn,omitempty"`
 
-	// Reference to a LBTargetGroup to populate targetGroupArn.
+	// Reference to a LBTargetGroup in elbv2 to populate targetGroupArn.
 	// +kubebuilder:validation:Optional
 	TargetGroupArnRef *v1.Reference `json:"targetGroupArnRef,omitempty" tf:"-"`
 
-	// Selector for a LBTargetGroup to populate targetGroupArn.
+	// Selector for a LBTargetGroup in elbv2 to populate targetGroupArn.
 	// +kubebuilder:validation:Optional
 	TargetGroupArnSelector *v1.Selector `json:"targetGroupArnSelector,omitempty" tf:"-"`
 
@@ -408,14 +408,14 @@ type LBListenerInitParameters struct {
 	DefaultAction []DefaultActionInitParameters `json:"defaultAction,omitempty" tf:"default_action,omitempty"`
 
 	// ARN of the load balancer.
-	// +crossplane:generate:reference:type=LB
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/elbv2/v1beta1.LB
 	LoadBalancerArn *string `json:"loadBalancerArn,omitempty" tf:"load_balancer_arn,omitempty"`
 
-	// Reference to a LB to populate loadBalancerArn.
+	// Reference to a LB in elbv2 to populate loadBalancerArn.
 	// +kubebuilder:validation:Optional
 	LoadBalancerArnRef *v1.Reference `json:"loadBalancerArnRef,omitempty" tf:"-"`
 
-	// Selector for a LB to populate loadBalancerArn.
+	// Selector for a LB in elbv2 to populate loadBalancerArn.
 	// +kubebuilder:validation:Optional
 	LoadBalancerArnSelector *v1.Selector `json:"loadBalancerArnSelector,omitempty" tf:"-"`
 
@@ -492,15 +492,15 @@ type LBListenerParameters struct {
 	DefaultAction []DefaultActionParameters `json:"defaultAction,omitempty" tf:"default_action,omitempty"`
 
 	// ARN of the load balancer.
-	// +crossplane:generate:reference:type=LB
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/elbv2/v1beta1.LB
 	// +kubebuilder:validation:Optional
 	LoadBalancerArn *string `json:"loadBalancerArn,omitempty" tf:"load_balancer_arn,omitempty"`
 
-	// Reference to a LB to populate loadBalancerArn.
+	// Reference to a LB in elbv2 to populate loadBalancerArn.
 	// +kubebuilder:validation:Optional
 	LoadBalancerArnRef *v1.Reference `json:"loadBalancerArnRef,omitempty" tf:"-"`
 
-	// Selector for a LB to populate loadBalancerArn.
+	// Selector for a LB in elbv2 to populate loadBalancerArn.
 	// +kubebuilder:validation:Optional
 	LoadBalancerArnSelector *v1.Selector `json:"loadBalancerArnSelector,omitempty" tf:"-"`
 
@@ -671,14 +671,14 @@ type StickinessParameters struct {
 type TargetGroupInitParameters struct {
 
 	// ARN of the target group.
-	// +crossplane:generate:reference:type=LBTargetGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/elbv2/v1beta1.LBTargetGroup
 	Arn *string `json:"arn,omitempty" tf:"arn,omitempty"`
 
-	// Reference to a LBTargetGroup to populate arn.
+	// Reference to a LBTargetGroup in elbv2 to populate arn.
 	// +kubebuilder:validation:Optional
 	ArnRef *v1.Reference `json:"arnRef,omitempty" tf:"-"`
 
-	// Selector for a LBTargetGroup to populate arn.
+	// Selector for a LBTargetGroup in elbv2 to populate arn.
 	// +kubebuilder:validation:Optional
 	ArnSelector *v1.Selector `json:"arnSelector,omitempty" tf:"-"`
 
@@ -698,15 +698,15 @@ type TargetGroupObservation struct {
 type TargetGroupParameters struct {
 
 	// ARN of the target group.
-	// +crossplane:generate:reference:type=LBTargetGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/elbv2/v1beta1.LBTargetGroup
 	// +kubebuilder:validation:Optional
 	Arn *string `json:"arn,omitempty" tf:"arn,omitempty"`
 
-	// Reference to a LBTargetGroup to populate arn.
+	// Reference to a LBTargetGroup in elbv2 to populate arn.
 	// +kubebuilder:validation:Optional
 	ArnRef *v1.Reference `json:"arnRef,omitempty" tf:"-"`
 
-	// Selector for a LBTargetGroup to populate arn.
+	// Selector for a LBTargetGroup in elbv2 to populate arn.
 	// +kubebuilder:validation:Optional
 	ArnSelector *v1.Selector `json:"arnSelector,omitempty" tf:"-"`
 

--- a/apis/elbv2/v1beta1/zz_lbtargetgroupattachment_types.go
+++ b/apis/elbv2/v1beta1/zz_lbtargetgroupattachment_types.go
@@ -22,14 +22,14 @@ type LBTargetGroupAttachmentInitParameters struct {
 	Port *float64 `json:"port,omitempty" tf:"port,omitempty"`
 
 	// The ARN of the target group with which to register targets.
-	// +crossplane:generate:reference:type=LBTargetGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/elbv2/v1beta1.LBTargetGroup
 	TargetGroupArn *string `json:"targetGroupArn,omitempty" tf:"target_group_arn,omitempty"`
 
-	// Reference to a LBTargetGroup to populate targetGroupArn.
+	// Reference to a LBTargetGroup in elbv2 to populate targetGroupArn.
 	// +kubebuilder:validation:Optional
 	TargetGroupArnRef *v1.Reference `json:"targetGroupArnRef,omitempty" tf:"-"`
 
-	// Selector for a LBTargetGroup to populate targetGroupArn.
+	// Selector for a LBTargetGroup in elbv2 to populate targetGroupArn.
 	// +kubebuilder:validation:Optional
 	TargetGroupArnSelector *v1.Selector `json:"targetGroupArnSelector,omitempty" tf:"-"`
 
@@ -71,15 +71,15 @@ type LBTargetGroupAttachmentParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// The ARN of the target group with which to register targets.
-	// +crossplane:generate:reference:type=LBTargetGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/elbv2/v1beta1.LBTargetGroup
 	// +kubebuilder:validation:Optional
 	TargetGroupArn *string `json:"targetGroupArn,omitempty" tf:"target_group_arn,omitempty"`
 
-	// Reference to a LBTargetGroup to populate targetGroupArn.
+	// Reference to a LBTargetGroup in elbv2 to populate targetGroupArn.
 	// +kubebuilder:validation:Optional
 	TargetGroupArnRef *v1.Reference `json:"targetGroupArnRef,omitempty" tf:"-"`
 
-	// Selector for a LBTargetGroup to populate targetGroupArn.
+	// Selector for a LBTargetGroup in elbv2 to populate targetGroupArn.
 	// +kubebuilder:validation:Optional
 	TargetGroupArnSelector *v1.Selector `json:"targetGroupArnSelector,omitempty" tf:"-"`
 

--- a/apis/gamelift/v1beta1/zz_fleet_types.go
+++ b/apis/gamelift/v1beta1/zz_fleet_types.go
@@ -84,14 +84,14 @@ type EC2InboundPermissionParameters struct {
 type FleetInitParameters struct {
 
 	// ID of the GameLift Build to be deployed on the fleet.
-	// +crossplane:generate:reference:type=Build
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/gamelift/v1beta1.Build
 	BuildID *string `json:"buildId,omitempty" tf:"build_id,omitempty"`
 
-	// Reference to a Build to populate buildId.
+	// Reference to a Build in gamelift to populate buildId.
 	// +kubebuilder:validation:Optional
 	BuildIDRef *v1.Reference `json:"buildIdRef,omitempty" tf:"-"`
 
-	// Selector for a Build to populate buildId.
+	// Selector for a Build in gamelift to populate buildId.
 	// +kubebuilder:validation:Optional
 	BuildIDSelector *v1.Selector `json:"buildIdSelector,omitempty" tf:"-"`
 
@@ -216,15 +216,15 @@ type FleetObservation struct {
 type FleetParameters struct {
 
 	// ID of the GameLift Build to be deployed on the fleet.
-	// +crossplane:generate:reference:type=Build
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/gamelift/v1beta1.Build
 	// +kubebuilder:validation:Optional
 	BuildID *string `json:"buildId,omitempty" tf:"build_id,omitempty"`
 
-	// Reference to a Build to populate buildId.
+	// Reference to a Build in gamelift to populate buildId.
 	// +kubebuilder:validation:Optional
 	BuildIDRef *v1.Reference `json:"buildIdRef,omitempty" tf:"-"`
 
-	// Selector for a Build to populate buildId.
+	// Selector for a Build in gamelift to populate buildId.
 	// +kubebuilder:validation:Optional
 	BuildIDSelector *v1.Selector `json:"buildIdSelector,omitempty" tf:"-"`
 

--- a/apis/globalaccelerator/v1beta1/zz_endpointgroup_types.go
+++ b/apis/globalaccelerator/v1beta1/zz_endpointgroup_types.go
@@ -73,14 +73,14 @@ type EndpointGroupInitParameters struct {
 	HealthCheckProtocol *string `json:"healthCheckProtocol,omitempty" tf:"health_check_protocol,omitempty"`
 
 	// The Amazon Resource Name (ARN) of the listener.
-	// +crossplane:generate:reference:type=Listener
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/globalaccelerator/v1beta1.Listener
 	ListenerArn *string `json:"listenerArn,omitempty" tf:"listener_arn,omitempty"`
 
-	// Reference to a Listener to populate listenerArn.
+	// Reference to a Listener in globalaccelerator to populate listenerArn.
 	// +kubebuilder:validation:Optional
 	ListenerArnRef *v1.Reference `json:"listenerArnRef,omitempty" tf:"-"`
 
-	// Selector for a Listener to populate listenerArn.
+	// Selector for a Listener in globalaccelerator to populate listenerArn.
 	// +kubebuilder:validation:Optional
 	ListenerArnSelector *v1.Selector `json:"listenerArnSelector,omitempty" tf:"-"`
 
@@ -160,15 +160,15 @@ type EndpointGroupParameters struct {
 	HealthCheckProtocol *string `json:"healthCheckProtocol,omitempty" tf:"health_check_protocol,omitempty"`
 
 	// The Amazon Resource Name (ARN) of the listener.
-	// +crossplane:generate:reference:type=Listener
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/globalaccelerator/v1beta1.Listener
 	// +kubebuilder:validation:Optional
 	ListenerArn *string `json:"listenerArn,omitempty" tf:"listener_arn,omitempty"`
 
-	// Reference to a Listener to populate listenerArn.
+	// Reference to a Listener in globalaccelerator to populate listenerArn.
 	// +kubebuilder:validation:Optional
 	ListenerArnRef *v1.Reference `json:"listenerArnRef,omitempty" tf:"-"`
 
-	// Selector for a Listener to populate listenerArn.
+	// Selector for a Listener in globalaccelerator to populate listenerArn.
 	// +kubebuilder:validation:Optional
 	ListenerArnSelector *v1.Selector `json:"listenerArnSelector,omitempty" tf:"-"`
 

--- a/apis/globalaccelerator/v1beta1/zz_listener_types.go
+++ b/apis/globalaccelerator/v1beta1/zz_listener_types.go
@@ -16,14 +16,14 @@ import (
 type ListenerInitParameters struct {
 
 	// The Amazon Resource Name (ARN) of your accelerator.
-	// +crossplane:generate:reference:type=Accelerator
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/globalaccelerator/v1beta1.Accelerator
 	AcceleratorArn *string `json:"acceleratorArn,omitempty" tf:"accelerator_arn,omitempty"`
 
-	// Reference to a Accelerator to populate acceleratorArn.
+	// Reference to a Accelerator in globalaccelerator to populate acceleratorArn.
 	// +kubebuilder:validation:Optional
 	AcceleratorArnRef *v1.Reference `json:"acceleratorArnRef,omitempty" tf:"-"`
 
-	// Selector for a Accelerator to populate acceleratorArn.
+	// Selector for a Accelerator in globalaccelerator to populate acceleratorArn.
 	// +kubebuilder:validation:Optional
 	AcceleratorArnSelector *v1.Selector `json:"acceleratorArnSelector,omitempty" tf:"-"`
 
@@ -58,15 +58,15 @@ type ListenerObservation struct {
 type ListenerParameters struct {
 
 	// The Amazon Resource Name (ARN) of your accelerator.
-	// +crossplane:generate:reference:type=Accelerator
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/globalaccelerator/v1beta1.Accelerator
 	// +kubebuilder:validation:Optional
 	AcceleratorArn *string `json:"acceleratorArn,omitempty" tf:"accelerator_arn,omitempty"`
 
-	// Reference to a Accelerator to populate acceleratorArn.
+	// Reference to a Accelerator in globalaccelerator to populate acceleratorArn.
 	// +kubebuilder:validation:Optional
 	AcceleratorArnRef *v1.Reference `json:"acceleratorArnRef,omitempty" tf:"-"`
 
-	// Selector for a Accelerator to populate acceleratorArn.
+	// Selector for a Accelerator in globalaccelerator to populate acceleratorArn.
 	// +kubebuilder:validation:Optional
 	AcceleratorArnSelector *v1.Selector `json:"acceleratorArnSelector,omitempty" tf:"-"`
 

--- a/apis/grafana/v1beta1/zz_roleassociation_types.go
+++ b/apis/grafana/v1beta1/zz_roleassociation_types.go
@@ -27,14 +27,14 @@ type RoleAssociationInitParameters struct {
 	UserIds []*string `json:"userIds,omitempty" tf:"user_ids,omitempty"`
 
 	// The workspace id.
-	// +crossplane:generate:reference:type=Workspace
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/grafana/v1beta1.Workspace
 	WorkspaceID *string `json:"workspaceId,omitempty" tf:"workspace_id,omitempty"`
 
-	// Reference to a Workspace to populate workspaceId.
+	// Reference to a Workspace in grafana to populate workspaceId.
 	// +kubebuilder:validation:Optional
 	WorkspaceIDRef *v1.Reference `json:"workspaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a Workspace to populate workspaceId.
+	// Selector for a Workspace in grafana to populate workspaceId.
 	// +kubebuilder:validation:Optional
 	WorkspaceIDSelector *v1.Selector `json:"workspaceIdSelector,omitempty" tf:"-"`
 }
@@ -80,15 +80,15 @@ type RoleAssociationParameters struct {
 	UserIds []*string `json:"userIds,omitempty" tf:"user_ids,omitempty"`
 
 	// The workspace id.
-	// +crossplane:generate:reference:type=Workspace
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/grafana/v1beta1.Workspace
 	// +kubebuilder:validation:Optional
 	WorkspaceID *string `json:"workspaceId,omitempty" tf:"workspace_id,omitempty"`
 
-	// Reference to a Workspace to populate workspaceId.
+	// Reference to a Workspace in grafana to populate workspaceId.
 	// +kubebuilder:validation:Optional
 	WorkspaceIDRef *v1.Reference `json:"workspaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a Workspace to populate workspaceId.
+	// Selector for a Workspace in grafana to populate workspaceId.
 	// +kubebuilder:validation:Optional
 	WorkspaceIDSelector *v1.Selector `json:"workspaceIdSelector,omitempty" tf:"-"`
 }

--- a/apis/grafana/v1beta1/zz_workspacesamlconfiguration_types.go
+++ b/apis/grafana/v1beta1/zz_workspacesamlconfiguration_types.go
@@ -52,14 +52,14 @@ type WorkspaceSAMLConfigurationInitParameters struct {
 	RoleAssertion *string `json:"roleAssertion,omitempty" tf:"role_assertion,omitempty"`
 
 	// The workspace id.
-	// +crossplane:generate:reference:type=Workspace
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/grafana/v1beta1.Workspace
 	WorkspaceID *string `json:"workspaceId,omitempty" tf:"workspace_id,omitempty"`
 
-	// Reference to a Workspace to populate workspaceId.
+	// Reference to a Workspace in grafana to populate workspaceId.
 	// +kubebuilder:validation:Optional
 	WorkspaceIDRef *v1.Reference `json:"workspaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a Workspace to populate workspaceId.
+	// Selector for a Workspace in grafana to populate workspaceId.
 	// +kubebuilder:validation:Optional
 	WorkspaceIDSelector *v1.Selector `json:"workspaceIdSelector,omitempty" tf:"-"`
 }
@@ -167,15 +167,15 @@ type WorkspaceSAMLConfigurationParameters struct {
 	RoleAssertion *string `json:"roleAssertion,omitempty" tf:"role_assertion,omitempty"`
 
 	// The workspace id.
-	// +crossplane:generate:reference:type=Workspace
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/grafana/v1beta1.Workspace
 	// +kubebuilder:validation:Optional
 	WorkspaceID *string `json:"workspaceId,omitempty" tf:"workspace_id,omitempty"`
 
-	// Reference to a Workspace to populate workspaceId.
+	// Reference to a Workspace in grafana to populate workspaceId.
 	// +kubebuilder:validation:Optional
 	WorkspaceIDRef *v1.Reference `json:"workspaceIdRef,omitempty" tf:"-"`
 
-	// Selector for a Workspace to populate workspaceId.
+	// Selector for a Workspace in grafana to populate workspaceId.
 	// +kubebuilder:validation:Optional
 	WorkspaceIDSelector *v1.Selector `json:"workspaceIdSelector,omitempty" tf:"-"`
 }

--- a/apis/iam/v1beta1/zz_groupmembership_types.go
+++ b/apis/iam/v1beta1/zz_groupmembership_types.go
@@ -16,30 +16,30 @@ import (
 type GroupMembershipInitParameters struct {
 
 	// –  The IAM Group name to attach the list of users to
-	// +crossplane:generate:reference:type=Group
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/iam/v1beta1.Group
 	Group *string `json:"group,omitempty" tf:"group,omitempty"`
 
-	// Reference to a Group to populate group.
+	// Reference to a Group in iam to populate group.
 	// +kubebuilder:validation:Optional
 	GroupRef *v1.Reference `json:"groupRef,omitempty" tf:"-"`
 
-	// Selector for a Group to populate group.
+	// Selector for a Group in iam to populate group.
 	// +kubebuilder:validation:Optional
 	GroupSelector *v1.Selector `json:"groupSelector,omitempty" tf:"-"`
 
 	// The name to identify the Group Membership
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// References to User to populate users.
+	// References to User in iam to populate users.
 	// +kubebuilder:validation:Optional
 	UserRefs []v1.Reference `json:"userRefs,omitempty" tf:"-"`
 
-	// Selector for a list of User to populate users.
+	// Selector for a list of User in iam to populate users.
 	// +kubebuilder:validation:Optional
 	UserSelector *v1.Selector `json:"userSelector,omitempty" tf:"-"`
 
 	// A list of IAM User names to associate with the Group
-	// +crossplane:generate:reference:type=User
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/iam/v1beta1.User
 	// +crossplane:generate:reference:refFieldName=UserRefs
 	// +crossplane:generate:reference:selectorFieldName=UserSelector
 	// +listType=set
@@ -64,15 +64,15 @@ type GroupMembershipObservation struct {
 type GroupMembershipParameters struct {
 
 	// –  The IAM Group name to attach the list of users to
-	// +crossplane:generate:reference:type=Group
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/iam/v1beta1.Group
 	// +kubebuilder:validation:Optional
 	Group *string `json:"group,omitempty" tf:"group,omitempty"`
 
-	// Reference to a Group to populate group.
+	// Reference to a Group in iam to populate group.
 	// +kubebuilder:validation:Optional
 	GroupRef *v1.Reference `json:"groupRef,omitempty" tf:"-"`
 
-	// Selector for a Group to populate group.
+	// Selector for a Group in iam to populate group.
 	// +kubebuilder:validation:Optional
 	GroupSelector *v1.Selector `json:"groupSelector,omitempty" tf:"-"`
 
@@ -80,16 +80,16 @@ type GroupMembershipParameters struct {
 	// +kubebuilder:validation:Optional
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// References to User to populate users.
+	// References to User in iam to populate users.
 	// +kubebuilder:validation:Optional
 	UserRefs []v1.Reference `json:"userRefs,omitempty" tf:"-"`
 
-	// Selector for a list of User to populate users.
+	// Selector for a list of User in iam to populate users.
 	// +kubebuilder:validation:Optional
 	UserSelector *v1.Selector `json:"userSelector,omitempty" tf:"-"`
 
 	// A list of IAM User names to associate with the Group
-	// +crossplane:generate:reference:type=User
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/iam/v1beta1.User
 	// +crossplane:generate:reference:refFieldName=UserRefs
 	// +crossplane:generate:reference:selectorFieldName=UserSelector
 	// +kubebuilder:validation:Optional

--- a/apis/iam/v1beta1/zz_servicespecificcredential_types.go
+++ b/apis/iam/v1beta1/zz_servicespecificcredential_types.go
@@ -22,14 +22,14 @@ type ServiceSpecificCredentialInitParameters struct {
 	Status *string `json:"status,omitempty" tf:"status,omitempty"`
 
 	// The name of the IAM user that is to be associated with the credentials. The new service-specific credentials have the same permissions as the associated user except that they can be used only to access the specified service.
-	// +crossplane:generate:reference:type=User
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/iam/v1beta1.User
 	UserName *string `json:"userName,omitempty" tf:"user_name,omitempty"`
 
-	// Reference to a User to populate userName.
+	// Reference to a User in iam to populate userName.
 	// +kubebuilder:validation:Optional
 	UserNameRef *v1.Reference `json:"userNameRef,omitempty" tf:"-"`
 
-	// Selector for a User to populate userName.
+	// Selector for a User in iam to populate userName.
 	// +kubebuilder:validation:Optional
 	UserNameSelector *v1.Selector `json:"userNameSelector,omitempty" tf:"-"`
 }
@@ -66,15 +66,15 @@ type ServiceSpecificCredentialParameters struct {
 	Status *string `json:"status,omitempty" tf:"status,omitempty"`
 
 	// The name of the IAM user that is to be associated with the credentials. The new service-specific credentials have the same permissions as the associated user except that they can be used only to access the specified service.
-	// +crossplane:generate:reference:type=User
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/iam/v1beta1.User
 	// +kubebuilder:validation:Optional
 	UserName *string `json:"userName,omitempty" tf:"user_name,omitempty"`
 
-	// Reference to a User to populate userName.
+	// Reference to a User in iam to populate userName.
 	// +kubebuilder:validation:Optional
 	UserNameRef *v1.Reference `json:"userNameRef,omitempty" tf:"-"`
 
-	// Selector for a User to populate userName.
+	// Selector for a User in iam to populate userName.
 	// +kubebuilder:validation:Optional
 	UserNameSelector *v1.Selector `json:"userNameSelector,omitempty" tf:"-"`
 }

--- a/apis/iam/v1beta1/zz_userloginprofile_types.go
+++ b/apis/iam/v1beta1/zz_userloginprofile_types.go
@@ -25,14 +25,14 @@ type UserLoginProfileInitParameters struct {
 	PgpKey *string `json:"pgpKey,omitempty" tf:"pgp_key,omitempty"`
 
 	// The IAM user's name.
-	// +crossplane:generate:reference:type=User
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/iam/v1beta1.User
 	User *string `json:"user,omitempty" tf:"user,omitempty"`
 
-	// Reference to a User to populate user.
+	// Reference to a User in iam to populate user.
 	// +kubebuilder:validation:Optional
 	UserRef *v1.Reference `json:"userRef,omitempty" tf:"-"`
 
-	// Selector for a User to populate user.
+	// Selector for a User in iam to populate user.
 	// +kubebuilder:validation:Optional
 	UserSelector *v1.Selector `json:"userSelector,omitempty" tf:"-"`
 }
@@ -78,15 +78,15 @@ type UserLoginProfileParameters struct {
 	PgpKey *string `json:"pgpKey,omitempty" tf:"pgp_key,omitempty"`
 
 	// The IAM user's name.
-	// +crossplane:generate:reference:type=User
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/iam/v1beta1.User
 	// +kubebuilder:validation:Optional
 	User *string `json:"user,omitempty" tf:"user,omitempty"`
 
-	// Reference to a User to populate user.
+	// Reference to a User in iam to populate user.
 	// +kubebuilder:validation:Optional
 	UserRef *v1.Reference `json:"userRef,omitempty" tf:"-"`
 
-	// Selector for a User to populate user.
+	// Selector for a User in iam to populate user.
 	// +kubebuilder:validation:Optional
 	UserSelector *v1.Selector `json:"userSelector,omitempty" tf:"-"`
 }

--- a/apis/iam/v1beta1/zz_usersshkey_types.go
+++ b/apis/iam/v1beta1/zz_usersshkey_types.go
@@ -25,14 +25,14 @@ type UserSSHKeyInitParameters struct {
 	Status *string `json:"status,omitempty" tf:"status,omitempty"`
 
 	// The name of the IAM user to associate the SSH public key with.
-	// +crossplane:generate:reference:type=User
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/iam/v1beta1.User
 	Username *string `json:"username,omitempty" tf:"username,omitempty"`
 
-	// Reference to a User to populate username.
+	// Reference to a User in iam to populate username.
 	// +kubebuilder:validation:Optional
 	UsernameRef *v1.Reference `json:"usernameRef,omitempty" tf:"-"`
 
-	// Selector for a User to populate username.
+	// Selector for a User in iam to populate username.
 	// +kubebuilder:validation:Optional
 	UsernameSelector *v1.Selector `json:"usernameSelector,omitempty" tf:"-"`
 }
@@ -75,15 +75,15 @@ type UserSSHKeyParameters struct {
 	Status *string `json:"status,omitempty" tf:"status,omitempty"`
 
 	// The name of the IAM user to associate the SSH public key with.
-	// +crossplane:generate:reference:type=User
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/iam/v1beta1.User
 	// +kubebuilder:validation:Optional
 	Username *string `json:"username,omitempty" tf:"username,omitempty"`
 
-	// Reference to a User to populate username.
+	// Reference to a User in iam to populate username.
 	// +kubebuilder:validation:Optional
 	UsernameRef *v1.Reference `json:"usernameRef,omitempty" tf:"-"`
 
-	// Selector for a User to populate username.
+	// Selector for a User in iam to populate username.
 	// +kubebuilder:validation:Optional
 	UsernameSelector *v1.Selector `json:"usernameSelector,omitempty" tf:"-"`
 }

--- a/apis/kms/v1beta1/zz_alias_types.go
+++ b/apis/kms/v1beta1/zz_alias_types.go
@@ -16,14 +16,14 @@ import (
 type AliasInitParameters struct {
 
 	// Identifier for the key for which the alias is for, can be either an ARN or key_id.
-	// +crossplane:generate:reference:type=Key
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
 	TargetKeyID *string `json:"targetKeyId,omitempty" tf:"target_key_id,omitempty"`
 
-	// Reference to a Key to populate targetKeyId.
+	// Reference to a Key in kms to populate targetKeyId.
 	// +kubebuilder:validation:Optional
 	TargetKeyIDRef *v1.Reference `json:"targetKeyIdRef,omitempty" tf:"-"`
 
-	// Selector for a Key to populate targetKeyId.
+	// Selector for a Key in kms to populate targetKeyId.
 	// +kubebuilder:validation:Optional
 	TargetKeyIDSelector *v1.Selector `json:"targetKeyIdSelector,omitempty" tf:"-"`
 }
@@ -50,15 +50,15 @@ type AliasParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// Identifier for the key for which the alias is for, can be either an ARN or key_id.
-	// +crossplane:generate:reference:type=Key
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
 	// +kubebuilder:validation:Optional
 	TargetKeyID *string `json:"targetKeyId,omitempty" tf:"target_key_id,omitempty"`
 
-	// Reference to a Key to populate targetKeyId.
+	// Reference to a Key in kms to populate targetKeyId.
 	// +kubebuilder:validation:Optional
 	TargetKeyIDRef *v1.Reference `json:"targetKeyIdRef,omitempty" tf:"-"`
 
-	// Selector for a Key to populate targetKeyId.
+	// Selector for a Key in kms to populate targetKeyId.
 	// +kubebuilder:validation:Optional
 	TargetKeyIDSelector *v1.Selector `json:"targetKeyIdSelector,omitempty" tf:"-"`
 }

--- a/apis/kms/v1beta1/zz_ciphertext_types.go
+++ b/apis/kms/v1beta1/zz_ciphertext_types.go
@@ -20,14 +20,14 @@ type CiphertextInitParameters struct {
 	Context map[string]*string `json:"context,omitempty" tf:"context,omitempty"`
 
 	// Globally unique key ID for the customer master key.
-	// +crossplane:generate:reference:type=Key
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
 	KeyID *string `json:"keyId,omitempty" tf:"key_id,omitempty"`
 
-	// Reference to a Key to populate keyId.
+	// Reference to a Key in kms to populate keyId.
 	// +kubebuilder:validation:Optional
 	KeyIDRef *v1.Reference `json:"keyIdRef,omitempty" tf:"-"`
 
-	// Selector for a Key to populate keyId.
+	// Selector for a Key in kms to populate keyId.
 	// +kubebuilder:validation:Optional
 	KeyIDSelector *v1.Selector `json:"keyIdSelector,omitempty" tf:"-"`
 }
@@ -55,15 +55,15 @@ type CiphertextParameters struct {
 	Context map[string]*string `json:"context,omitempty" tf:"context,omitempty"`
 
 	// Globally unique key ID for the customer master key.
-	// +crossplane:generate:reference:type=Key
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
 	// +kubebuilder:validation:Optional
 	KeyID *string `json:"keyId,omitempty" tf:"key_id,omitempty"`
 
-	// Reference to a Key to populate keyId.
+	// Reference to a Key in kms to populate keyId.
 	// +kubebuilder:validation:Optional
 	KeyIDRef *v1.Reference `json:"keyIdRef,omitempty" tf:"-"`
 
-	// Selector for a Key to populate keyId.
+	// Selector for a Key in kms to populate keyId.
 	// +kubebuilder:validation:Optional
 	KeyIDSelector *v1.Selector `json:"keyIdSelector,omitempty" tf:"-"`
 

--- a/apis/kms/v1beta1/zz_grant_types.go
+++ b/apis/kms/v1beta1/zz_grant_types.go
@@ -71,15 +71,15 @@ type GrantInitParameters struct {
 	GranteePrincipalSelector *v1.Selector `json:"granteePrincipalSelector,omitempty" tf:"-"`
 
 	// The unique identifier for the customer master key (CMK) that the grant applies to. Specify the key ID or the Amazon Resource Name (ARN) of the CMK. To specify a CMK in a different AWS account, you must use the key ARN.
-	// +crossplane:generate:reference:type=Key
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	KeyID *string `json:"keyId,omitempty" tf:"key_id,omitempty"`
 
-	// Reference to a Key to populate keyId.
+	// Reference to a Key in kms to populate keyId.
 	// +kubebuilder:validation:Optional
 	KeyIDRef *v1.Reference `json:"keyIdRef,omitempty" tf:"-"`
 
-	// Selector for a Key to populate keyId.
+	// Selector for a Key in kms to populate keyId.
 	// +kubebuilder:validation:Optional
 	KeyIDSelector *v1.Selector `json:"keyIdSelector,omitempty" tf:"-"`
 
@@ -162,16 +162,16 @@ type GrantParameters struct {
 	GranteePrincipalSelector *v1.Selector `json:"granteePrincipalSelector,omitempty" tf:"-"`
 
 	// The unique identifier for the customer master key (CMK) that the grant applies to. Specify the key ID or the Amazon Resource Name (ARN) of the CMK. To specify a CMK in a different AWS account, you must use the key ARN.
-	// +crossplane:generate:reference:type=Key
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	// +kubebuilder:validation:Optional
 	KeyID *string `json:"keyId,omitempty" tf:"key_id,omitempty"`
 
-	// Reference to a Key to populate keyId.
+	// Reference to a Key in kms to populate keyId.
 	// +kubebuilder:validation:Optional
 	KeyIDRef *v1.Reference `json:"keyIdRef,omitempty" tf:"-"`
 
-	// Selector for a Key to populate keyId.
+	// Selector for a Key in kms to populate keyId.
 	// +kubebuilder:validation:Optional
 	KeyIDSelector *v1.Selector `json:"keyIdSelector,omitempty" tf:"-"`
 

--- a/apis/kms/v1beta1/zz_replicaexternalkey_types.go
+++ b/apis/kms/v1beta1/zz_replicaexternalkey_types.go
@@ -35,15 +35,15 @@ type ReplicaExternalKeyInitParameters struct {
 	Policy *string `json:"policy,omitempty" tf:"policy,omitempty"`
 
 	// The ARN of the multi-Region primary key to replicate. The primary key must be in a different AWS Region of the same AWS Partition. You can create only one replica of a given primary key in each AWS Region.
-	// +crossplane:generate:reference:type=ExternalKey
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.ExternalKey
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	PrimaryKeyArn *string `json:"primaryKeyArn,omitempty" tf:"primary_key_arn,omitempty"`
 
-	// Reference to a ExternalKey to populate primaryKeyArn.
+	// Reference to a ExternalKey in kms to populate primaryKeyArn.
 	// +kubebuilder:validation:Optional
 	PrimaryKeyArnRef *v1.Reference `json:"primaryKeyArnRef,omitempty" tf:"-"`
 
-	// Selector for a ExternalKey to populate primaryKeyArn.
+	// Selector for a ExternalKey in kms to populate primaryKeyArn.
 	// +kubebuilder:validation:Optional
 	PrimaryKeyArnSelector *v1.Selector `json:"primaryKeyArnSelector,omitempty" tf:"-"`
 
@@ -139,16 +139,16 @@ type ReplicaExternalKeyParameters struct {
 	Policy *string `json:"policy,omitempty" tf:"policy,omitempty"`
 
 	// The ARN of the multi-Region primary key to replicate. The primary key must be in a different AWS Region of the same AWS Partition. You can create only one replica of a given primary key in each AWS Region.
-	// +crossplane:generate:reference:type=ExternalKey
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.ExternalKey
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	// +kubebuilder:validation:Optional
 	PrimaryKeyArn *string `json:"primaryKeyArn,omitempty" tf:"primary_key_arn,omitempty"`
 
-	// Reference to a ExternalKey to populate primaryKeyArn.
+	// Reference to a ExternalKey in kms to populate primaryKeyArn.
 	// +kubebuilder:validation:Optional
 	PrimaryKeyArnRef *v1.Reference `json:"primaryKeyArnRef,omitempty" tf:"-"`
 
-	// Selector for a ExternalKey to populate primaryKeyArn.
+	// Selector for a ExternalKey in kms to populate primaryKeyArn.
 	// +kubebuilder:validation:Optional
 	PrimaryKeyArnSelector *v1.Selector `json:"primaryKeyArnSelector,omitempty" tf:"-"`
 

--- a/apis/kms/v1beta1/zz_replicakey_types.go
+++ b/apis/kms/v1beta1/zz_replicakey_types.go
@@ -35,15 +35,15 @@ type ReplicaKeyInitParameters struct {
 	Policy *string `json:"policy,omitempty" tf:"policy,omitempty"`
 
 	// The ARN of the multi-Region primary key to replicate. The primary key must be in a different AWS Region of the same AWS Partition. You can create only one replica of a given primary key in each AWS Region.
-	// +crossplane:generate:reference:type=Key
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	PrimaryKeyArn *string `json:"primaryKeyArn,omitempty" tf:"primary_key_arn,omitempty"`
 
-	// Reference to a Key to populate primaryKeyArn.
+	// Reference to a Key in kms to populate primaryKeyArn.
 	// +kubebuilder:validation:Optional
 	PrimaryKeyArnRef *v1.Reference `json:"primaryKeyArnRef,omitempty" tf:"-"`
 
-	// Selector for a Key to populate primaryKeyArn.
+	// Selector for a Key in kms to populate primaryKeyArn.
 	// +kubebuilder:validation:Optional
 	PrimaryKeyArnSelector *v1.Selector `json:"primaryKeyArnSelector,omitempty" tf:"-"`
 
@@ -129,16 +129,16 @@ type ReplicaKeyParameters struct {
 	Policy *string `json:"policy,omitempty" tf:"policy,omitempty"`
 
 	// The ARN of the multi-Region primary key to replicate. The primary key must be in a different AWS Region of the same AWS Partition. You can create only one replica of a given primary key in each AWS Region.
-	// +crossplane:generate:reference:type=Key
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	// +kubebuilder:validation:Optional
 	PrimaryKeyArn *string `json:"primaryKeyArn,omitempty" tf:"primary_key_arn,omitempty"`
 
-	// Reference to a Key to populate primaryKeyArn.
+	// Reference to a Key in kms to populate primaryKeyArn.
 	// +kubebuilder:validation:Optional
 	PrimaryKeyArnRef *v1.Reference `json:"primaryKeyArnRef,omitempty" tf:"-"`
 
-	// Selector for a Key to populate primaryKeyArn.
+	// Selector for a Key in kms to populate primaryKeyArn.
 	// +kubebuilder:validation:Optional
 	PrimaryKeyArnSelector *v1.Selector `json:"primaryKeyArnSelector,omitempty" tf:"-"`
 

--- a/apis/lambda/v1beta1/zz_alias_types.go
+++ b/apis/lambda/v1beta1/zz_alias_types.go
@@ -55,15 +55,15 @@ type AliasParameters struct {
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`
 
 	// Lambda Function name or ARN.
-	// +crossplane:generate:reference:type=Function
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/lambda/v1beta1.Function
 	// +kubebuilder:validation:Optional
 	FunctionName *string `json:"functionName,omitempty" tf:"function_name,omitempty"`
 
-	// Reference to a Function to populate functionName.
+	// Reference to a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameRef *v1.Reference `json:"functionNameRef,omitempty" tf:"-"`
 
-	// Selector for a Function to populate functionName.
+	// Selector for a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameSelector *v1.Selector `json:"functionNameSelector,omitempty" tf:"-"`
 

--- a/apis/lambda/v1beta1/zz_eventsourcemapping_types.go
+++ b/apis/lambda/v1beta1/zz_eventsourcemapping_types.go
@@ -117,15 +117,15 @@ type EventSourceMappingInitParameters struct {
 	FilterCriteria []FilterCriteriaInitParameters `json:"filterCriteria,omitempty" tf:"filter_criteria,omitempty"`
 
 	// The name or the ARN of the Lambda function that will be subscribing to events.
-	// +crossplane:generate:reference:type=Function
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/lambda/v1beta1.Function
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	FunctionName *string `json:"functionName,omitempty" tf:"function_name,omitempty"`
 
-	// Reference to a Function to populate functionName.
+	// Reference to a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameRef *v1.Reference `json:"functionNameRef,omitempty" tf:"-"`
 
-	// Selector for a Function to populate functionName.
+	// Selector for a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameSelector *v1.Selector `json:"functionNameSelector,omitempty" tf:"-"`
 
@@ -303,16 +303,16 @@ type EventSourceMappingParameters struct {
 	FilterCriteria []FilterCriteriaParameters `json:"filterCriteria,omitempty" tf:"filter_criteria,omitempty"`
 
 	// The name or the ARN of the Lambda function that will be subscribing to events.
-	// +crossplane:generate:reference:type=Function
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/lambda/v1beta1.Function
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	// +kubebuilder:validation:Optional
 	FunctionName *string `json:"functionName,omitempty" tf:"function_name,omitempty"`
 
-	// Reference to a Function to populate functionName.
+	// Reference to a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameRef *v1.Reference `json:"functionNameRef,omitempty" tf:"-"`
 
-	// Selector for a Function to populate functionName.
+	// Selector for a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameSelector *v1.Selector `json:"functionNameSelector,omitempty" tf:"-"`
 

--- a/apis/lambda/v1beta1/zz_functionurl_types.go
+++ b/apis/lambda/v1beta1/zz_functionurl_types.go
@@ -103,14 +103,14 @@ type FunctionURLInitParameters struct {
 	Cors []CorsInitParameters `json:"cors,omitempty" tf:"cors,omitempty"`
 
 	// The name (or ARN) of the Lambda function.
-	// +crossplane:generate:reference:type=Function
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/lambda/v1beta1.Function
 	FunctionName *string `json:"functionName,omitempty" tf:"function_name,omitempty"`
 
-	// Reference to a Function to populate functionName.
+	// Reference to a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameRef *v1.Reference `json:"functionNameRef,omitempty" tf:"-"`
 
-	// Selector for a Function to populate functionName.
+	// Selector for a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameSelector *v1.Selector `json:"functionNameSelector,omitempty" tf:"-"`
 
@@ -161,15 +161,15 @@ type FunctionURLParameters struct {
 	Cors []CorsParameters `json:"cors,omitempty" tf:"cors,omitempty"`
 
 	// The name (or ARN) of the Lambda function.
-	// +crossplane:generate:reference:type=Function
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/lambda/v1beta1.Function
 	// +kubebuilder:validation:Optional
 	FunctionName *string `json:"functionName,omitempty" tf:"function_name,omitempty"`
 
-	// Reference to a Function to populate functionName.
+	// Reference to a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameRef *v1.Reference `json:"functionNameRef,omitempty" tf:"-"`
 
-	// Selector for a Function to populate functionName.
+	// Selector for a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameSelector *v1.Selector `json:"functionNameSelector,omitempty" tf:"-"`
 

--- a/apis/lambda/v1beta1/zz_invocation_types.go
+++ b/apis/lambda/v1beta1/zz_invocation_types.go
@@ -16,14 +16,14 @@ import (
 type InvocationInitParameters struct {
 
 	// Name of the lambda function.
-	// +crossplane:generate:reference:type=Function
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/lambda/v1beta1.Function
 	FunctionName *string `json:"functionName,omitempty" tf:"function_name,omitempty"`
 
-	// Reference to a Function to populate functionName.
+	// Reference to a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameRef *v1.Reference `json:"functionNameRef,omitempty" tf:"-"`
 
-	// Selector for a Function to populate functionName.
+	// Selector for a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameSelector *v1.Selector `json:"functionNameSelector,omitempty" tf:"-"`
 
@@ -74,15 +74,15 @@ type InvocationObservation struct {
 type InvocationParameters struct {
 
 	// Name of the lambda function.
-	// +crossplane:generate:reference:type=Function
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/lambda/v1beta1.Function
 	// +kubebuilder:validation:Optional
 	FunctionName *string `json:"functionName,omitempty" tf:"function_name,omitempty"`
 
-	// Reference to a Function to populate functionName.
+	// Reference to a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameRef *v1.Reference `json:"functionNameRef,omitempty" tf:"-"`
 
-	// Selector for a Function to populate functionName.
+	// Selector for a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameSelector *v1.Selector `json:"functionNameSelector,omitempty" tf:"-"`
 

--- a/apis/lambda/v1beta1/zz_permission_types.go
+++ b/apis/lambda/v1beta1/zz_permission_types.go
@@ -22,14 +22,14 @@ type PermissionInitParameters struct {
 	EventSourceToken *string `json:"eventSourceToken,omitempty" tf:"event_source_token,omitempty"`
 
 	// Name of the Lambda function whose resource policy you are updating
-	// +crossplane:generate:reference:type=Function
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/lambda/v1beta1.Function
 	FunctionName *string `json:"functionName,omitempty" tf:"function_name,omitempty"`
 
-	// Reference to a Function to populate functionName.
+	// Reference to a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameRef *v1.Reference `json:"functionNameRef,omitempty" tf:"-"`
 
-	// Selector for a Function to populate functionName.
+	// Selector for a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameSelector *v1.Selector `json:"functionNameSelector,omitempty" tf:"-"`
 
@@ -43,14 +43,14 @@ type PermissionInitParameters struct {
 	PrincipalOrgID *string `json:"principalOrgId,omitempty" tf:"principal_org_id,omitempty"`
 
 	// Query parameter to specify function version or alias name. The permission will then apply to the specific qualified ARN e.g., arn:aws:lambda:aws-region:acct-id:function:function-name:2
-	// +crossplane:generate:reference:type=Alias
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/lambda/v1beta1.Alias
 	Qualifier *string `json:"qualifier,omitempty" tf:"qualifier,omitempty"`
 
-	// Reference to a Alias to populate qualifier.
+	// Reference to a Alias in lambda to populate qualifier.
 	// +kubebuilder:validation:Optional
 	QualifierRef *v1.Reference `json:"qualifierRef,omitempty" tf:"-"`
 
-	// Selector for a Alias to populate qualifier.
+	// Selector for a Alias in lambda to populate qualifier.
 	// +kubebuilder:validation:Optional
 	QualifierSelector *v1.Selector `json:"qualifierSelector,omitempty" tf:"-"`
 
@@ -124,15 +124,15 @@ type PermissionParameters struct {
 	EventSourceToken *string `json:"eventSourceToken,omitempty" tf:"event_source_token,omitempty"`
 
 	// Name of the Lambda function whose resource policy you are updating
-	// +crossplane:generate:reference:type=Function
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/lambda/v1beta1.Function
 	// +kubebuilder:validation:Optional
 	FunctionName *string `json:"functionName,omitempty" tf:"function_name,omitempty"`
 
-	// Reference to a Function to populate functionName.
+	// Reference to a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameRef *v1.Reference `json:"functionNameRef,omitempty" tf:"-"`
 
-	// Selector for a Function to populate functionName.
+	// Selector for a Function in lambda to populate functionName.
 	// +kubebuilder:validation:Optional
 	FunctionNameSelector *v1.Selector `json:"functionNameSelector,omitempty" tf:"-"`
 
@@ -149,15 +149,15 @@ type PermissionParameters struct {
 	PrincipalOrgID *string `json:"principalOrgId,omitempty" tf:"principal_org_id,omitempty"`
 
 	// Query parameter to specify function version or alias name. The permission will then apply to the specific qualified ARN e.g., arn:aws:lambda:aws-region:acct-id:function:function-name:2
-	// +crossplane:generate:reference:type=Alias
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/lambda/v1beta1.Alias
 	// +kubebuilder:validation:Optional
 	Qualifier *string `json:"qualifier,omitempty" tf:"qualifier,omitempty"`
 
-	// Reference to a Alias to populate qualifier.
+	// Reference to a Alias in lambda to populate qualifier.
 	// +kubebuilder:validation:Optional
 	QualifierRef *v1.Reference `json:"qualifierRef,omitempty" tf:"-"`
 
-	// Selector for a Alias to populate qualifier.
+	// Selector for a Alias in lambda to populate qualifier.
 	// +kubebuilder:validation:Optional
 	QualifierSelector *v1.Selector `json:"qualifierSelector,omitempty" tf:"-"`
 

--- a/apis/licensemanager/v1beta1/zz_association_types.go
+++ b/apis/licensemanager/v1beta1/zz_association_types.go
@@ -16,15 +16,15 @@ import (
 type AssociationInitParameters struct {
 
 	// ARN of the license configuration.
-	// +crossplane:generate:reference:type=LicenseConfiguration
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/licensemanager/v1beta1.LicenseConfiguration
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	LicenseConfigurationArn *string `json:"licenseConfigurationArn,omitempty" tf:"license_configuration_arn,omitempty"`
 
-	// Reference to a LicenseConfiguration to populate licenseConfigurationArn.
+	// Reference to a LicenseConfiguration in licensemanager to populate licenseConfigurationArn.
 	// +kubebuilder:validation:Optional
 	LicenseConfigurationArnRef *v1.Reference `json:"licenseConfigurationArnRef,omitempty" tf:"-"`
 
-	// Selector for a LicenseConfiguration to populate licenseConfigurationArn.
+	// Selector for a LicenseConfiguration in licensemanager to populate licenseConfigurationArn.
 	// +kubebuilder:validation:Optional
 	LicenseConfigurationArnSelector *v1.Selector `json:"licenseConfigurationArnSelector,omitempty" tf:"-"`
 
@@ -57,16 +57,16 @@ type AssociationObservation struct {
 type AssociationParameters struct {
 
 	// ARN of the license configuration.
-	// +crossplane:generate:reference:type=LicenseConfiguration
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/licensemanager/v1beta1.LicenseConfiguration
 	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	// +kubebuilder:validation:Optional
 	LicenseConfigurationArn *string `json:"licenseConfigurationArn,omitempty" tf:"license_configuration_arn,omitempty"`
 
-	// Reference to a LicenseConfiguration to populate licenseConfigurationArn.
+	// Reference to a LicenseConfiguration in licensemanager to populate licenseConfigurationArn.
 	// +kubebuilder:validation:Optional
 	LicenseConfigurationArnRef *v1.Reference `json:"licenseConfigurationArnRef,omitempty" tf:"-"`
 
-	// Selector for a LicenseConfiguration to populate licenseConfigurationArn.
+	// Selector for a LicenseConfiguration in licensemanager to populate licenseConfigurationArn.
 	// +kubebuilder:validation:Optional
 	LicenseConfigurationArnSelector *v1.Selector `json:"licenseConfigurationArnSelector,omitempty" tf:"-"`
 

--- a/apis/neptune/v1beta1/zz_cluster_types.go
+++ b/apis/neptune/v1beta1/zz_cluster_types.go
@@ -81,14 +81,14 @@ type ClusterInitParameters struct {
 	KMSKeyArnSelector *v1.Selector `json:"kmsKeyArnSelector,omitempty" tf:"-"`
 
 	// A cluster parameter group to associate with the cluster.
-	// +crossplane:generate:reference:type=ClusterParameterGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.ClusterParameterGroup
 	NeptuneClusterParameterGroupName *string `json:"neptuneClusterParameterGroupName,omitempty" tf:"neptune_cluster_parameter_group_name,omitempty"`
 
-	// Reference to a ClusterParameterGroup to populate neptuneClusterParameterGroupName.
+	// Reference to a ClusterParameterGroup in neptune to populate neptuneClusterParameterGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneClusterParameterGroupNameRef *v1.Reference `json:"neptuneClusterParameterGroupNameRef,omitempty" tf:"-"`
 
-	// Selector for a ClusterParameterGroup to populate neptuneClusterParameterGroupName.
+	// Selector for a ClusterParameterGroup in neptune to populate neptuneClusterParameterGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneClusterParameterGroupNameSelector *v1.Selector `json:"neptuneClusterParameterGroupNameSelector,omitempty" tf:"-"`
 
@@ -96,14 +96,14 @@ type ClusterInitParameters struct {
 	NeptuneInstanceParameterGroupName *string `json:"neptuneInstanceParameterGroupName,omitempty" tf:"neptune_instance_parameter_group_name,omitempty"`
 
 	// A Neptune subnet group to associate with this Neptune instance.
-	// +crossplane:generate:reference:type=SubnetGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.SubnetGroup
 	NeptuneSubnetGroupName *string `json:"neptuneSubnetGroupName,omitempty" tf:"neptune_subnet_group_name,omitempty"`
 
-	// Reference to a SubnetGroup to populate neptuneSubnetGroupName.
+	// Reference to a SubnetGroup in neptune to populate neptuneSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneSubnetGroupNameRef *v1.Reference `json:"neptuneSubnetGroupNameRef,omitempty" tf:"-"`
 
-	// Selector for a SubnetGroup to populate neptuneSubnetGroupName.
+	// Selector for a SubnetGroup in neptune to populate neptuneSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneSubnetGroupNameSelector *v1.Selector `json:"neptuneSubnetGroupNameSelector,omitempty" tf:"-"`
 
@@ -117,14 +117,14 @@ type ClusterInitParameters struct {
 	PreferredMaintenanceWindow *string `json:"preferredMaintenanceWindow,omitempty" tf:"preferred_maintenance_window,omitempty"`
 
 	// ARN of a source Neptune cluster or Neptune instance if this Neptune cluster is to be created as a Read Replica.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.Cluster
 	ReplicationSourceIdentifier *string `json:"replicationSourceIdentifier,omitempty" tf:"replication_source_identifier,omitempty"`
 
-	// Reference to a Cluster to populate replicationSourceIdentifier.
+	// Reference to a Cluster in neptune to populate replicationSourceIdentifier.
 	// +kubebuilder:validation:Optional
 	ReplicationSourceIdentifierRef *v1.Reference `json:"replicationSourceIdentifierRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate replicationSourceIdentifier.
+	// Selector for a Cluster in neptune to populate replicationSourceIdentifier.
 	// +kubebuilder:validation:Optional
 	ReplicationSourceIdentifierSelector *v1.Selector `json:"replicationSourceIdentifierSelector,omitempty" tf:"-"`
 
@@ -135,14 +135,14 @@ type ClusterInitParameters struct {
 	SkipFinalSnapshot *bool `json:"skipFinalSnapshot,omitempty" tf:"skip_final_snapshot,omitempty"`
 
 	// Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a Neptune cluster snapshot, or the ARN when specifying a Neptune snapshot. Automated snapshots should not be used for this attribute, unless from a different cluster. Automated snapshots are deleted as part of cluster destruction when the resource is replaced.
-	// +crossplane:generate:reference:type=ClusterSnapshot
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.ClusterSnapshot
 	SnapshotIdentifier *string `json:"snapshotIdentifier,omitempty" tf:"snapshot_identifier,omitempty"`
 
-	// Reference to a ClusterSnapshot to populate snapshotIdentifier.
+	// Reference to a ClusterSnapshot in neptune to populate snapshotIdentifier.
 	// +kubebuilder:validation:Optional
 	SnapshotIdentifierRef *v1.Reference `json:"snapshotIdentifierRef,omitempty" tf:"-"`
 
-	// Selector for a ClusterSnapshot to populate snapshotIdentifier.
+	// Selector for a ClusterSnapshot in neptune to populate snapshotIdentifier.
 	// +kubebuilder:validation:Optional
 	SnapshotIdentifierSelector *v1.Selector `json:"snapshotIdentifierSelector,omitempty" tf:"-"`
 
@@ -366,15 +366,15 @@ type ClusterParameters struct {
 	KMSKeyArnSelector *v1.Selector `json:"kmsKeyArnSelector,omitempty" tf:"-"`
 
 	// A cluster parameter group to associate with the cluster.
-	// +crossplane:generate:reference:type=ClusterParameterGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.ClusterParameterGroup
 	// +kubebuilder:validation:Optional
 	NeptuneClusterParameterGroupName *string `json:"neptuneClusterParameterGroupName,omitempty" tf:"neptune_cluster_parameter_group_name,omitempty"`
 
-	// Reference to a ClusterParameterGroup to populate neptuneClusterParameterGroupName.
+	// Reference to a ClusterParameterGroup in neptune to populate neptuneClusterParameterGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneClusterParameterGroupNameRef *v1.Reference `json:"neptuneClusterParameterGroupNameRef,omitempty" tf:"-"`
 
-	// Selector for a ClusterParameterGroup to populate neptuneClusterParameterGroupName.
+	// Selector for a ClusterParameterGroup in neptune to populate neptuneClusterParameterGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneClusterParameterGroupNameSelector *v1.Selector `json:"neptuneClusterParameterGroupNameSelector,omitempty" tf:"-"`
 
@@ -383,15 +383,15 @@ type ClusterParameters struct {
 	NeptuneInstanceParameterGroupName *string `json:"neptuneInstanceParameterGroupName,omitempty" tf:"neptune_instance_parameter_group_name,omitempty"`
 
 	// A Neptune subnet group to associate with this Neptune instance.
-	// +crossplane:generate:reference:type=SubnetGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.SubnetGroup
 	// +kubebuilder:validation:Optional
 	NeptuneSubnetGroupName *string `json:"neptuneSubnetGroupName,omitempty" tf:"neptune_subnet_group_name,omitempty"`
 
-	// Reference to a SubnetGroup to populate neptuneSubnetGroupName.
+	// Reference to a SubnetGroup in neptune to populate neptuneSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneSubnetGroupNameRef *v1.Reference `json:"neptuneSubnetGroupNameRef,omitempty" tf:"-"`
 
-	// Selector for a SubnetGroup to populate neptuneSubnetGroupName.
+	// Selector for a SubnetGroup in neptune to populate neptuneSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneSubnetGroupNameSelector *v1.Selector `json:"neptuneSubnetGroupNameSelector,omitempty" tf:"-"`
 
@@ -413,15 +413,15 @@ type ClusterParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// ARN of a source Neptune cluster or Neptune instance if this Neptune cluster is to be created as a Read Replica.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.Cluster
 	// +kubebuilder:validation:Optional
 	ReplicationSourceIdentifier *string `json:"replicationSourceIdentifier,omitempty" tf:"replication_source_identifier,omitempty"`
 
-	// Reference to a Cluster to populate replicationSourceIdentifier.
+	// Reference to a Cluster in neptune to populate replicationSourceIdentifier.
 	// +kubebuilder:validation:Optional
 	ReplicationSourceIdentifierRef *v1.Reference `json:"replicationSourceIdentifierRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate replicationSourceIdentifier.
+	// Selector for a Cluster in neptune to populate replicationSourceIdentifier.
 	// +kubebuilder:validation:Optional
 	ReplicationSourceIdentifierSelector *v1.Selector `json:"replicationSourceIdentifierSelector,omitempty" tf:"-"`
 
@@ -434,15 +434,15 @@ type ClusterParameters struct {
 	SkipFinalSnapshot *bool `json:"skipFinalSnapshot,omitempty" tf:"skip_final_snapshot,omitempty"`
 
 	// Specifies whether or not to create this cluster from a snapshot. You can use either the name or ARN when specifying a Neptune cluster snapshot, or the ARN when specifying a Neptune snapshot. Automated snapshots should not be used for this attribute, unless from a different cluster. Automated snapshots are deleted as part of cluster destruction when the resource is replaced.
-	// +crossplane:generate:reference:type=ClusterSnapshot
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.ClusterSnapshot
 	// +kubebuilder:validation:Optional
 	SnapshotIdentifier *string `json:"snapshotIdentifier,omitempty" tf:"snapshot_identifier,omitempty"`
 
-	// Reference to a ClusterSnapshot to populate snapshotIdentifier.
+	// Reference to a ClusterSnapshot in neptune to populate snapshotIdentifier.
 	// +kubebuilder:validation:Optional
 	SnapshotIdentifierRef *v1.Reference `json:"snapshotIdentifierRef,omitempty" tf:"-"`
 
-	// Selector for a ClusterSnapshot to populate snapshotIdentifier.
+	// Selector for a ClusterSnapshot in neptune to populate snapshotIdentifier.
 	// +kubebuilder:validation:Optional
 	SnapshotIdentifierSelector *v1.Selector `json:"snapshotIdentifierSelector,omitempty" tf:"-"`
 

--- a/apis/neptune/v1beta1/zz_clusterendpoint_types.go
+++ b/apis/neptune/v1beta1/zz_clusterendpoint_types.go
@@ -16,14 +16,14 @@ import (
 type ClusterEndpointInitParameters struct {
 
 	// The DB cluster identifier of the DB cluster associated with the endpoint.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.Cluster
 	ClusterIdentifier *string `json:"clusterIdentifier,omitempty" tf:"cluster_identifier,omitempty"`
 
-	// Reference to a Cluster to populate clusterIdentifier.
+	// Reference to a Cluster in neptune to populate clusterIdentifier.
 	// +kubebuilder:validation:Optional
 	ClusterIdentifierRef *v1.Reference `json:"clusterIdentifierRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate clusterIdentifier.
+	// Selector for a Cluster in neptune to populate clusterIdentifier.
 	// +kubebuilder:validation:Optional
 	ClusterIdentifierSelector *v1.Selector `json:"clusterIdentifierSelector,omitempty" tf:"-"`
 
@@ -80,15 +80,15 @@ type ClusterEndpointObservation struct {
 type ClusterEndpointParameters struct {
 
 	// The DB cluster identifier of the DB cluster associated with the endpoint.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.Cluster
 	// +kubebuilder:validation:Optional
 	ClusterIdentifier *string `json:"clusterIdentifier,omitempty" tf:"cluster_identifier,omitempty"`
 
-	// Reference to a Cluster to populate clusterIdentifier.
+	// Reference to a Cluster in neptune to populate clusterIdentifier.
 	// +kubebuilder:validation:Optional
 	ClusterIdentifierRef *v1.Reference `json:"clusterIdentifierRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate clusterIdentifier.
+	// Selector for a Cluster in neptune to populate clusterIdentifier.
 	// +kubebuilder:validation:Optional
 	ClusterIdentifierSelector *v1.Selector `json:"clusterIdentifierSelector,omitempty" tf:"-"`
 

--- a/apis/neptune/v1beta1/zz_clusterinstance_types.go
+++ b/apis/neptune/v1beta1/zz_clusterinstance_types.go
@@ -26,14 +26,14 @@ type ClusterInstanceInitParameters struct {
 	AvailabilityZone *string `json:"availabilityZone,omitempty" tf:"availability_zone,omitempty"`
 
 	// The identifier of the aws_neptune_cluster in which to launch this instance.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.Cluster
 	ClusterIdentifier *string `json:"clusterIdentifier,omitempty" tf:"cluster_identifier,omitempty"`
 
-	// Reference to a Cluster to populate clusterIdentifier.
+	// Reference to a Cluster in neptune to populate clusterIdentifier.
 	// +kubebuilder:validation:Optional
 	ClusterIdentifierRef *v1.Reference `json:"clusterIdentifierRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate clusterIdentifier.
+	// Selector for a Cluster in neptune to populate clusterIdentifier.
 	// +kubebuilder:validation:Optional
 	ClusterIdentifierSelector *v1.Selector `json:"clusterIdentifierSelector,omitempty" tf:"-"`
 
@@ -47,26 +47,26 @@ type ClusterInstanceInitParameters struct {
 	InstanceClass *string `json:"instanceClass,omitempty" tf:"instance_class,omitempty"`
 
 	// The name of the neptune parameter group to associate with this instance.
-	// +crossplane:generate:reference:type=ParameterGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.ParameterGroup
 	NeptuneParameterGroupName *string `json:"neptuneParameterGroupName,omitempty" tf:"neptune_parameter_group_name,omitempty"`
 
-	// Reference to a ParameterGroup to populate neptuneParameterGroupName.
+	// Reference to a ParameterGroup in neptune to populate neptuneParameterGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneParameterGroupNameRef *v1.Reference `json:"neptuneParameterGroupNameRef,omitempty" tf:"-"`
 
-	// Selector for a ParameterGroup to populate neptuneParameterGroupName.
+	// Selector for a ParameterGroup in neptune to populate neptuneParameterGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneParameterGroupNameSelector *v1.Selector `json:"neptuneParameterGroupNameSelector,omitempty" tf:"-"`
 
 	// A subnet group to associate with this neptune instance. NOTE: This must match the neptune_subnet_group_name of the attached aws_neptune_cluster.
-	// +crossplane:generate:reference:type=SubnetGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.SubnetGroup
 	NeptuneSubnetGroupName *string `json:"neptuneSubnetGroupName,omitempty" tf:"neptune_subnet_group_name,omitempty"`
 
-	// Reference to a SubnetGroup to populate neptuneSubnetGroupName.
+	// Reference to a SubnetGroup in neptune to populate neptuneSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneSubnetGroupNameRef *v1.Reference `json:"neptuneSubnetGroupNameRef,omitempty" tf:"-"`
 
-	// Selector for a SubnetGroup to populate neptuneSubnetGroupName.
+	// Selector for a SubnetGroup in neptune to populate neptuneSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneSubnetGroupNameSelector *v1.Selector `json:"neptuneSubnetGroupNameSelector,omitempty" tf:"-"`
 
@@ -186,15 +186,15 @@ type ClusterInstanceParameters struct {
 	AvailabilityZone *string `json:"availabilityZone,omitempty" tf:"availability_zone,omitempty"`
 
 	// The identifier of the aws_neptune_cluster in which to launch this instance.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.Cluster
 	// +kubebuilder:validation:Optional
 	ClusterIdentifier *string `json:"clusterIdentifier,omitempty" tf:"cluster_identifier,omitempty"`
 
-	// Reference to a Cluster to populate clusterIdentifier.
+	// Reference to a Cluster in neptune to populate clusterIdentifier.
 	// +kubebuilder:validation:Optional
 	ClusterIdentifierRef *v1.Reference `json:"clusterIdentifierRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate clusterIdentifier.
+	// Selector for a Cluster in neptune to populate clusterIdentifier.
 	// +kubebuilder:validation:Optional
 	ClusterIdentifierSelector *v1.Selector `json:"clusterIdentifierSelector,omitempty" tf:"-"`
 
@@ -211,28 +211,28 @@ type ClusterInstanceParameters struct {
 	InstanceClass *string `json:"instanceClass,omitempty" tf:"instance_class,omitempty"`
 
 	// The name of the neptune parameter group to associate with this instance.
-	// +crossplane:generate:reference:type=ParameterGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.ParameterGroup
 	// +kubebuilder:validation:Optional
 	NeptuneParameterGroupName *string `json:"neptuneParameterGroupName,omitempty" tf:"neptune_parameter_group_name,omitempty"`
 
-	// Reference to a ParameterGroup to populate neptuneParameterGroupName.
+	// Reference to a ParameterGroup in neptune to populate neptuneParameterGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneParameterGroupNameRef *v1.Reference `json:"neptuneParameterGroupNameRef,omitempty" tf:"-"`
 
-	// Selector for a ParameterGroup to populate neptuneParameterGroupName.
+	// Selector for a ParameterGroup in neptune to populate neptuneParameterGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneParameterGroupNameSelector *v1.Selector `json:"neptuneParameterGroupNameSelector,omitempty" tf:"-"`
 
 	// A subnet group to associate with this neptune instance. NOTE: This must match the neptune_subnet_group_name of the attached aws_neptune_cluster.
-	// +crossplane:generate:reference:type=SubnetGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.SubnetGroup
 	// +kubebuilder:validation:Optional
 	NeptuneSubnetGroupName *string `json:"neptuneSubnetGroupName,omitempty" tf:"neptune_subnet_group_name,omitempty"`
 
-	// Reference to a SubnetGroup to populate neptuneSubnetGroupName.
+	// Reference to a SubnetGroup in neptune to populate neptuneSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneSubnetGroupNameRef *v1.Reference `json:"neptuneSubnetGroupNameRef,omitempty" tf:"-"`
 
-	// Selector for a SubnetGroup to populate neptuneSubnetGroupName.
+	// Selector for a SubnetGroup in neptune to populate neptuneSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	NeptuneSubnetGroupNameSelector *v1.Selector `json:"neptuneSubnetGroupNameSelector,omitempty" tf:"-"`
 

--- a/apis/neptune/v1beta1/zz_clustersnapshot_types.go
+++ b/apis/neptune/v1beta1/zz_clustersnapshot_types.go
@@ -16,14 +16,14 @@ import (
 type ClusterSnapshotInitParameters struct {
 
 	// The DB Cluster Identifier from which to take the snapshot.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.Cluster
 	DBClusterIdentifier *string `json:"dbClusterIdentifier,omitempty" tf:"db_cluster_identifier,omitempty"`
 
-	// Reference to a Cluster to populate dbClusterIdentifier.
+	// Reference to a Cluster in neptune to populate dbClusterIdentifier.
 	// +kubebuilder:validation:Optional
 	DBClusterIdentifierRef *v1.Reference `json:"dbClusterIdentifierRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate dbClusterIdentifier.
+	// Selector for a Cluster in neptune to populate dbClusterIdentifier.
 	// +kubebuilder:validation:Optional
 	DBClusterIdentifierSelector *v1.Selector `json:"dbClusterIdentifierSelector,omitempty" tf:"-"`
 }
@@ -77,15 +77,15 @@ type ClusterSnapshotObservation struct {
 type ClusterSnapshotParameters struct {
 
 	// The DB Cluster Identifier from which to take the snapshot.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/neptune/v1beta1.Cluster
 	// +kubebuilder:validation:Optional
 	DBClusterIdentifier *string `json:"dbClusterIdentifier,omitempty" tf:"db_cluster_identifier,omitempty"`
 
-	// Reference to a Cluster to populate dbClusterIdentifier.
+	// Reference to a Cluster in neptune to populate dbClusterIdentifier.
 	// +kubebuilder:validation:Optional
 	DBClusterIdentifierRef *v1.Reference `json:"dbClusterIdentifierRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate dbClusterIdentifier.
+	// Selector for a Cluster in neptune to populate dbClusterIdentifier.
 	// +kubebuilder:validation:Optional
 	DBClusterIdentifierSelector *v1.Selector `json:"dbClusterIdentifierSelector,omitempty" tf:"-"`
 

--- a/apis/networkmanager/v1beta1/zz_connectattachment_types.go
+++ b/apis/networkmanager/v1beta1/zz_connectattachment_types.go
@@ -16,14 +16,14 @@ import (
 type ConnectAttachmentInitParameters struct {
 
 	// The ID of a core network where you want to create the attachment.
-	// +crossplane:generate:reference:type=CoreNetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/networkmanager/v1beta1.CoreNetwork
 	CoreNetworkID *string `json:"coreNetworkId,omitempty" tf:"core_network_id,omitempty"`
 
-	// Reference to a CoreNetwork to populate coreNetworkId.
+	// Reference to a CoreNetwork in networkmanager to populate coreNetworkId.
 	// +kubebuilder:validation:Optional
 	CoreNetworkIDRef *v1.Reference `json:"coreNetworkIdRef,omitempty" tf:"-"`
 
-	// Selector for a CoreNetwork to populate coreNetworkId.
+	// Selector for a CoreNetwork in networkmanager to populate coreNetworkId.
 	// +kubebuilder:validation:Optional
 	CoreNetworkIDSelector *v1.Selector `json:"coreNetworkIdSelector,omitempty" tf:"-"`
 
@@ -117,15 +117,15 @@ type ConnectAttachmentObservation struct {
 type ConnectAttachmentParameters struct {
 
 	// The ID of a core network where you want to create the attachment.
-	// +crossplane:generate:reference:type=CoreNetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/networkmanager/v1beta1.CoreNetwork
 	// +kubebuilder:validation:Optional
 	CoreNetworkID *string `json:"coreNetworkId,omitempty" tf:"core_network_id,omitempty"`
 
-	// Reference to a CoreNetwork to populate coreNetworkId.
+	// Reference to a CoreNetwork in networkmanager to populate coreNetworkId.
 	// +kubebuilder:validation:Optional
 	CoreNetworkIDRef *v1.Reference `json:"coreNetworkIdRef,omitempty" tf:"-"`
 
-	// Selector for a CoreNetwork to populate coreNetworkId.
+	// Selector for a CoreNetwork in networkmanager to populate coreNetworkId.
 	// +kubebuilder:validation:Optional
 	CoreNetworkIDSelector *v1.Selector `json:"coreNetworkIdSelector,omitempty" tf:"-"`
 

--- a/apis/networkmanager/v1beta1/zz_link_types.go
+++ b/apis/networkmanager/v1beta1/zz_link_types.go
@@ -67,14 +67,14 @@ type LinkInitParameters struct {
 	ProviderName *string `json:"providerName,omitempty" tf:"provider_name,omitempty"`
 
 	// The ID of the site.
-	// +crossplane:generate:reference:type=Site
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/networkmanager/v1beta1.Site
 	SiteID *string `json:"siteId,omitempty" tf:"site_id,omitempty"`
 
-	// Reference to a Site to populate siteId.
+	// Reference to a Site in networkmanager to populate siteId.
 	// +kubebuilder:validation:Optional
 	SiteIDRef *v1.Reference `json:"siteIdRef,omitempty" tf:"-"`
 
-	// Selector for a Site to populate siteId.
+	// Selector for a Site in networkmanager to populate siteId.
 	// +kubebuilder:validation:Optional
 	SiteIDSelector *v1.Selector `json:"siteIdSelector,omitempty" tf:"-"`
 
@@ -154,15 +154,15 @@ type LinkParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// The ID of the site.
-	// +crossplane:generate:reference:type=Site
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/networkmanager/v1beta1.Site
 	// +kubebuilder:validation:Optional
 	SiteID *string `json:"siteId,omitempty" tf:"site_id,omitempty"`
 
-	// Reference to a Site to populate siteId.
+	// Reference to a Site in networkmanager to populate siteId.
 	// +kubebuilder:validation:Optional
 	SiteIDRef *v1.Reference `json:"siteIdRef,omitempty" tf:"-"`
 
-	// Selector for a Site to populate siteId.
+	// Selector for a Site in networkmanager to populate siteId.
 	// +kubebuilder:validation:Optional
 	SiteIDSelector *v1.Selector `json:"siteIdSelector,omitempty" tf:"-"`
 

--- a/apis/networkmanager/v1beta1/zz_linkassociation_types.go
+++ b/apis/networkmanager/v1beta1/zz_linkassociation_types.go
@@ -33,15 +33,15 @@ type LinkAssociationObservation struct {
 type LinkAssociationParameters struct {
 
 	// The ID of the device.
-	// +crossplane:generate:reference:type=Device
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/networkmanager/v1beta1.Device
 	// +kubebuilder:validation:Optional
 	DeviceID *string `json:"deviceId,omitempty" tf:"device_id,omitempty"`
 
-	// Reference to a Device to populate deviceId.
+	// Reference to a Device in networkmanager to populate deviceId.
 	// +kubebuilder:validation:Optional
 	DeviceIDRef *v1.Reference `json:"deviceIdRef,omitempty" tf:"-"`
 
-	// Selector for a Device to populate deviceId.
+	// Selector for a Device in networkmanager to populate deviceId.
 	// +kubebuilder:validation:Optional
 	DeviceIDSelector *v1.Selector `json:"deviceIdSelector,omitempty" tf:"-"`
 

--- a/apis/networkmanager/v1beta1/zz_vpcattachment_types.go
+++ b/apis/networkmanager/v1beta1/zz_vpcattachment_types.go
@@ -16,14 +16,14 @@ import (
 type VPCAttachmentInitParameters struct {
 
 	// The ID of a core network for the VPC attachment.
-	// +crossplane:generate:reference:type=CoreNetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/networkmanager/v1beta1.CoreNetwork
 	CoreNetworkID *string `json:"coreNetworkId,omitempty" tf:"core_network_id,omitempty"`
 
-	// Reference to a CoreNetwork to populate coreNetworkId.
+	// Reference to a CoreNetwork in networkmanager to populate coreNetworkId.
 	// +kubebuilder:validation:Optional
 	CoreNetworkIDRef *v1.Reference `json:"coreNetworkIdRef,omitempty" tf:"-"`
 
-	// Selector for a CoreNetwork to populate coreNetworkId.
+	// Selector for a CoreNetwork in networkmanager to populate coreNetworkId.
 	// +kubebuilder:validation:Optional
 	CoreNetworkIDSelector *v1.Selector `json:"coreNetworkIdSelector,omitempty" tf:"-"`
 
@@ -157,15 +157,15 @@ type VPCAttachmentOptionsParameters struct {
 type VPCAttachmentParameters struct {
 
 	// The ID of a core network for the VPC attachment.
-	// +crossplane:generate:reference:type=CoreNetwork
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/networkmanager/v1beta1.CoreNetwork
 	// +kubebuilder:validation:Optional
 	CoreNetworkID *string `json:"coreNetworkId,omitempty" tf:"core_network_id,omitempty"`
 
-	// Reference to a CoreNetwork to populate coreNetworkId.
+	// Reference to a CoreNetwork in networkmanager to populate coreNetworkId.
 	// +kubebuilder:validation:Optional
 	CoreNetworkIDRef *v1.Reference `json:"coreNetworkIdRef,omitempty" tf:"-"`
 
-	// Selector for a CoreNetwork to populate coreNetworkId.
+	// Selector for a CoreNetwork in networkmanager to populate coreNetworkId.
 	// +kubebuilder:validation:Optional
 	CoreNetworkIDSelector *v1.Selector `json:"coreNetworkIdSelector,omitempty" tf:"-"`
 

--- a/apis/opensearch/v1beta1/zz_domainpolicy_types.go
+++ b/apis/opensearch/v1beta1/zz_domainpolicy_types.go
@@ -19,14 +19,14 @@ type DomainPolicyInitParameters struct {
 	AccessPolicies *string `json:"accessPolicies,omitempty" tf:"access_policies,omitempty"`
 
 	// Name of the domain.
-	// +crossplane:generate:reference:type=Domain
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/opensearch/v1beta1.Domain
 	DomainName *string `json:"domainName,omitempty" tf:"domain_name,omitempty"`
 
-	// Reference to a Domain to populate domainName.
+	// Reference to a Domain in opensearch to populate domainName.
 	// +kubebuilder:validation:Optional
 	DomainNameRef *v1.Reference `json:"domainNameRef,omitempty" tf:"-"`
 
-	// Selector for a Domain to populate domainName.
+	// Selector for a Domain in opensearch to populate domainName.
 	// +kubebuilder:validation:Optional
 	DomainNameSelector *v1.Selector `json:"domainNameSelector,omitempty" tf:"-"`
 }
@@ -49,15 +49,15 @@ type DomainPolicyParameters struct {
 	AccessPolicies *string `json:"accessPolicies,omitempty" tf:"access_policies,omitempty"`
 
 	// Name of the domain.
-	// +crossplane:generate:reference:type=Domain
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/opensearch/v1beta1.Domain
 	// +kubebuilder:validation:Optional
 	DomainName *string `json:"domainName,omitempty" tf:"domain_name,omitempty"`
 
-	// Reference to a Domain to populate domainName.
+	// Reference to a Domain in opensearch to populate domainName.
 	// +kubebuilder:validation:Optional
 	DomainNameRef *v1.Reference `json:"domainNameRef,omitempty" tf:"-"`
 
-	// Selector for a Domain to populate domainName.
+	// Selector for a Domain in opensearch to populate domainName.
 	// +kubebuilder:validation:Optional
 	DomainNameSelector *v1.Selector `json:"domainNameSelector,omitempty" tf:"-"`
 

--- a/apis/opsworks/v1beta1/zz_instance_types.go
+++ b/apis/opsworks/v1beta1/zz_instance_types.go
@@ -168,14 +168,14 @@ type InstanceInitParameters struct {
 	InstanceType *string `json:"instanceType,omitempty" tf:"instance_type,omitempty"`
 
 	// List of the layers the instance will belong to.
-	// +crossplane:generate:reference:type=CustomLayer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/opsworks/v1beta1.CustomLayer
 	LayerIds []*string `json:"layerIds,omitempty" tf:"layer_ids,omitempty"`
 
-	// References to CustomLayer to populate layerIds.
+	// References to CustomLayer in opsworks to populate layerIds.
 	// +kubebuilder:validation:Optional
 	LayerIdsRefs []v1.Reference `json:"layerIdsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of CustomLayer to populate layerIds.
+	// Selector for a list of CustomLayer in opsworks to populate layerIds.
 	// +kubebuilder:validation:Optional
 	LayerIdsSelector *v1.Selector `json:"layerIdsSelector,omitempty" tf:"-"`
 
@@ -459,15 +459,15 @@ type InstanceParameters struct {
 	InstanceType *string `json:"instanceType,omitempty" tf:"instance_type,omitempty"`
 
 	// List of the layers the instance will belong to.
-	// +crossplane:generate:reference:type=CustomLayer
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/opsworks/v1beta1.CustomLayer
 	// +kubebuilder:validation:Optional
 	LayerIds []*string `json:"layerIds,omitempty" tf:"layer_ids,omitempty"`
 
-	// References to CustomLayer to populate layerIds.
+	// References to CustomLayer in opsworks to populate layerIds.
 	// +kubebuilder:validation:Optional
 	LayerIdsRefs []v1.Reference `json:"layerIdsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of CustomLayer to populate layerIds.
+	// Selector for a list of CustomLayer in opsworks to populate layerIds.
 	// +kubebuilder:validation:Optional
 	LayerIdsSelector *v1.Selector `json:"layerIdsSelector,omitempty" tf:"-"`
 

--- a/apis/rds/v1beta1/zz_cluster_types.go
+++ b/apis/rds/v1beta1/zz_cluster_types.go
@@ -72,14 +72,14 @@ type ClusterInitParameters struct {
 
 	// DB subnet group to associate with this DB cluster.
 	// NOTE: This must match the db_subnet_group_name specified on every aws_rds_cluster_instance in the cluster.
-	// +crossplane:generate:reference:type=SubnetGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/rds/v1beta1.SubnetGroup
 	DBSubnetGroupName *string `json:"dbSubnetGroupName,omitempty" tf:"db_subnet_group_name,omitempty"`
 
-	// Reference to a SubnetGroup to populate dbSubnetGroupName.
+	// Reference to a SubnetGroup in rds to populate dbSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	DBSubnetGroupNameRef *v1.Reference `json:"dbSubnetGroupNameRef,omitempty" tf:"-"`
 
-	// Selector for a SubnetGroup to populate dbSubnetGroupName.
+	// Selector for a SubnetGroup in rds to populate dbSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	DBSubnetGroupNameSelector *v1.Selector `json:"dbSubnetGroupNameSelector,omitempty" tf:"-"`
 
@@ -498,15 +498,15 @@ type ClusterParameters struct {
 
 	// DB subnet group to associate with this DB cluster.
 	// NOTE: This must match the db_subnet_group_name specified on every aws_rds_cluster_instance in the cluster.
-	// +crossplane:generate:reference:type=SubnetGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/rds/v1beta1.SubnetGroup
 	// +kubebuilder:validation:Optional
 	DBSubnetGroupName *string `json:"dbSubnetGroupName,omitempty" tf:"db_subnet_group_name,omitempty"`
 
-	// Reference to a SubnetGroup to populate dbSubnetGroupName.
+	// Reference to a SubnetGroup in rds to populate dbSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	DBSubnetGroupNameRef *v1.Reference `json:"dbSubnetGroupNameRef,omitempty" tf:"-"`
 
-	// Selector for a SubnetGroup to populate dbSubnetGroupName.
+	// Selector for a SubnetGroup in rds to populate dbSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	DBSubnetGroupNameSelector *v1.Selector `json:"dbSubnetGroupNameSelector,omitempty" tf:"-"`
 
@@ -702,14 +702,14 @@ type ClusterRestoreToPointInTimeInitParameters struct {
 	RestoreType *string `json:"restoreType,omitempty" tf:"restore_type,omitempty"`
 
 	// Identifier of the source database cluster from which to restore. When restoring from a cluster in another AWS account, the identifier is the ARN of that cluster.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/rds/v1beta1.Cluster
 	SourceClusterIdentifier *string `json:"sourceClusterIdentifier,omitempty" tf:"source_cluster_identifier,omitempty"`
 
-	// Reference to a Cluster to populate sourceClusterIdentifier.
+	// Reference to a Cluster in rds to populate sourceClusterIdentifier.
 	// +kubebuilder:validation:Optional
 	SourceClusterIdentifierRef *v1.Reference `json:"sourceClusterIdentifierRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate sourceClusterIdentifier.
+	// Selector for a Cluster in rds to populate sourceClusterIdentifier.
 	// +kubebuilder:validation:Optional
 	SourceClusterIdentifierSelector *v1.Selector `json:"sourceClusterIdentifierSelector,omitempty" tf:"-"`
 
@@ -745,15 +745,15 @@ type ClusterRestoreToPointInTimeParameters struct {
 	RestoreType *string `json:"restoreType,omitempty" tf:"restore_type,omitempty"`
 
 	// Identifier of the source database cluster from which to restore. When restoring from a cluster in another AWS account, the identifier is the ARN of that cluster.
-	// +crossplane:generate:reference:type=Cluster
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/rds/v1beta1.Cluster
 	// +kubebuilder:validation:Optional
 	SourceClusterIdentifier *string `json:"sourceClusterIdentifier,omitempty" tf:"source_cluster_identifier,omitempty"`
 
-	// Reference to a Cluster to populate sourceClusterIdentifier.
+	// Reference to a Cluster in rds to populate sourceClusterIdentifier.
 	// +kubebuilder:validation:Optional
 	SourceClusterIdentifierRef *v1.Reference `json:"sourceClusterIdentifierRef,omitempty" tf:"-"`
 
-	// Selector for a Cluster to populate sourceClusterIdentifier.
+	// Selector for a Cluster in rds to populate sourceClusterIdentifier.
 	// +kubebuilder:validation:Optional
 	SourceClusterIdentifierSelector *v1.Selector `json:"sourceClusterIdentifierSelector,omitempty" tf:"-"`
 

--- a/apis/rds/v1beta1/zz_clusterinstance_types.go
+++ b/apis/rds/v1beta1/zz_clusterinstance_types.go
@@ -59,14 +59,14 @@ type ClusterInstanceInitParameters struct {
 	DBParameterGroupNameSelector *v1.Selector `json:"dbParameterGroupNameSelector,omitempty" tf:"-"`
 
 	// DB subnet group to associate with this DB instance. NOTE: This must match the db_subnet_group_name of the attached aws_rds_cluster.
-	// +crossplane:generate:reference:type=SubnetGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/rds/v1beta1.SubnetGroup
 	DBSubnetGroupName *string `json:"dbSubnetGroupName,omitempty" tf:"db_subnet_group_name,omitempty"`
 
-	// Reference to a SubnetGroup to populate dbSubnetGroupName.
+	// Reference to a SubnetGroup in rds to populate dbSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	DBSubnetGroupNameRef *v1.Reference `json:"dbSubnetGroupNameRef,omitempty" tf:"-"`
 
-	// Selector for a SubnetGroup to populate dbSubnetGroupName.
+	// Selector for a SubnetGroup in rds to populate dbSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	DBSubnetGroupNameSelector *v1.Selector `json:"dbSubnetGroupNameSelector,omitempty" tf:"-"`
 
@@ -290,15 +290,15 @@ type ClusterInstanceParameters struct {
 	DBParameterGroupNameSelector *v1.Selector `json:"dbParameterGroupNameSelector,omitempty" tf:"-"`
 
 	// DB subnet group to associate with this DB instance. NOTE: This must match the db_subnet_group_name of the attached aws_rds_cluster.
-	// +crossplane:generate:reference:type=SubnetGroup
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/rds/v1beta1.SubnetGroup
 	// +kubebuilder:validation:Optional
 	DBSubnetGroupName *string `json:"dbSubnetGroupName,omitempty" tf:"db_subnet_group_name,omitempty"`
 
-	// Reference to a SubnetGroup to populate dbSubnetGroupName.
+	// Reference to a SubnetGroup in rds to populate dbSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	DBSubnetGroupNameRef *v1.Reference `json:"dbSubnetGroupNameRef,omitempty" tf:"-"`
 
-	// Selector for a SubnetGroup to populate dbSubnetGroupName.
+	// Selector for a SubnetGroup in rds to populate dbSubnetGroupName.
 	// +kubebuilder:validation:Optional
 	DBSubnetGroupNameSelector *v1.Selector `json:"dbSubnetGroupNameSelector,omitempty" tf:"-"`
 

--- a/apis/route53/v1beta1/zz_hostedzonednssec_types.go
+++ b/apis/route53/v1beta1/zz_hostedzonednssec_types.go
@@ -16,14 +16,14 @@ import (
 type HostedZoneDNSSECInitParameters struct {
 
 	// Identifier of the Route 53 Hosted Zone.
-	// +crossplane:generate:reference:type=Zone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/route53/v1beta1.Zone
 	HostedZoneID *string `json:"hostedZoneId,omitempty" tf:"hosted_zone_id,omitempty"`
 
-	// Reference to a Zone to populate hostedZoneId.
+	// Reference to a Zone in route53 to populate hostedZoneId.
 	// +kubebuilder:validation:Optional
 	HostedZoneIDRef *v1.Reference `json:"hostedZoneIdRef,omitempty" tf:"-"`
 
-	// Selector for a Zone to populate hostedZoneId.
+	// Selector for a Zone in route53 to populate hostedZoneId.
 	// +kubebuilder:validation:Optional
 	HostedZoneIDSelector *v1.Selector `json:"hostedZoneIdSelector,omitempty" tf:"-"`
 
@@ -46,15 +46,15 @@ type HostedZoneDNSSECObservation struct {
 type HostedZoneDNSSECParameters struct {
 
 	// Identifier of the Route 53 Hosted Zone.
-	// +crossplane:generate:reference:type=Zone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/route53/v1beta1.Zone
 	// +kubebuilder:validation:Optional
 	HostedZoneID *string `json:"hostedZoneId,omitempty" tf:"hosted_zone_id,omitempty"`
 
-	// Reference to a Zone to populate hostedZoneId.
+	// Reference to a Zone in route53 to populate hostedZoneId.
 	// +kubebuilder:validation:Optional
 	HostedZoneIDRef *v1.Reference `json:"hostedZoneIdRef,omitempty" tf:"-"`
 
-	// Selector for a Zone to populate hostedZoneId.
+	// Selector for a Zone in route53 to populate hostedZoneId.
 	// +kubebuilder:validation:Optional
 	HostedZoneIDSelector *v1.Selector `json:"hostedZoneIdSelector,omitempty" tf:"-"`
 

--- a/apis/route53/v1beta1/zz_record_types.go
+++ b/apis/route53/v1beta1/zz_record_types.go
@@ -174,14 +174,14 @@ type RecordInitParameters struct {
 	GeolocationRoutingPolicy []GeolocationRoutingPolicyInitParameters `json:"geolocationRoutingPolicy,omitempty" tf:"geolocation_routing_policy,omitempty"`
 
 	// The health check the record should be associated with.
-	// +crossplane:generate:reference:type=HealthCheck
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/route53/v1beta1.HealthCheck
 	HealthCheckID *string `json:"healthCheckId,omitempty" tf:"health_check_id,omitempty"`
 
-	// Reference to a HealthCheck to populate healthCheckId.
+	// Reference to a HealthCheck in route53 to populate healthCheckId.
 	// +kubebuilder:validation:Optional
 	HealthCheckIDRef *v1.Reference `json:"healthCheckIdRef,omitempty" tf:"-"`
 
-	// Selector for a HealthCheck to populate healthCheckId.
+	// Selector for a HealthCheck in route53 to populate healthCheckId.
 	// +kubebuilder:validation:Optional
 	HealthCheckIDSelector *v1.Selector `json:"healthCheckIdSelector,omitempty" tf:"-"`
 
@@ -211,14 +211,14 @@ type RecordInitParameters struct {
 	WeightedRoutingPolicy []WeightedRoutingPolicyInitParameters `json:"weightedRoutingPolicy,omitempty" tf:"weighted_routing_policy,omitempty"`
 
 	// The ID of the hosted zone to contain this record.
-	// +crossplane:generate:reference:type=Zone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/route53/v1beta1.Zone
 	ZoneID *string `json:"zoneId,omitempty" tf:"zone_id,omitempty"`
 
-	// Reference to a Zone to populate zoneId.
+	// Reference to a Zone in route53 to populate zoneId.
 	// +kubebuilder:validation:Optional
 	ZoneIDRef *v1.Reference `json:"zoneIdRef,omitempty" tf:"-"`
 
-	// Selector for a Zone to populate zoneId.
+	// Selector for a Zone in route53 to populate zoneId.
 	// +kubebuilder:validation:Optional
 	ZoneIDSelector *v1.Selector `json:"zoneIdSelector,omitempty" tf:"-"`
 }
@@ -302,15 +302,15 @@ type RecordParameters struct {
 	GeolocationRoutingPolicy []GeolocationRoutingPolicyParameters `json:"geolocationRoutingPolicy,omitempty" tf:"geolocation_routing_policy,omitempty"`
 
 	// The health check the record should be associated with.
-	// +crossplane:generate:reference:type=HealthCheck
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/route53/v1beta1.HealthCheck
 	// +kubebuilder:validation:Optional
 	HealthCheckID *string `json:"healthCheckId,omitempty" tf:"health_check_id,omitempty"`
 
-	// Reference to a HealthCheck to populate healthCheckId.
+	// Reference to a HealthCheck in route53 to populate healthCheckId.
 	// +kubebuilder:validation:Optional
 	HealthCheckIDRef *v1.Reference `json:"healthCheckIdRef,omitempty" tf:"-"`
 
-	// Selector for a HealthCheck to populate healthCheckId.
+	// Selector for a HealthCheck in route53 to populate healthCheckId.
 	// +kubebuilder:validation:Optional
 	HealthCheckIDSelector *v1.Selector `json:"healthCheckIdSelector,omitempty" tf:"-"`
 
@@ -354,15 +354,15 @@ type RecordParameters struct {
 	WeightedRoutingPolicy []WeightedRoutingPolicyParameters `json:"weightedRoutingPolicy,omitempty" tf:"weighted_routing_policy,omitempty"`
 
 	// The ID of the hosted zone to contain this record.
-	// +crossplane:generate:reference:type=Zone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/route53/v1beta1.Zone
 	// +kubebuilder:validation:Optional
 	ZoneID *string `json:"zoneId,omitempty" tf:"zone_id,omitempty"`
 
-	// Reference to a Zone to populate zoneId.
+	// Reference to a Zone in route53 to populate zoneId.
 	// +kubebuilder:validation:Optional
 	ZoneIDRef *v1.Reference `json:"zoneIdRef,omitempty" tf:"-"`
 
-	// Selector for a Zone to populate zoneId.
+	// Selector for a Zone in route53 to populate zoneId.
 	// +kubebuilder:validation:Optional
 	ZoneIDSelector *v1.Selector `json:"zoneIdSelector,omitempty" tf:"-"`
 }

--- a/apis/route53/v1beta1/zz_trafficpolicyinstance_types.go
+++ b/apis/route53/v1beta1/zz_trafficpolicyinstance_types.go
@@ -16,14 +16,14 @@ import (
 type TrafficPolicyInstanceInitParameters struct {
 
 	// ID of the hosted zone that you want Amazon Route 53 to create resource record sets in by using the configuration in a traffic policy.
-	// +crossplane:generate:reference:type=Zone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/route53/v1beta1.Zone
 	HostedZoneID *string `json:"hostedZoneId,omitempty" tf:"hosted_zone_id,omitempty"`
 
-	// Reference to a Zone to populate hostedZoneId.
+	// Reference to a Zone in route53 to populate hostedZoneId.
 	// +kubebuilder:validation:Optional
 	HostedZoneIDRef *v1.Reference `json:"hostedZoneIdRef,omitempty" tf:"-"`
 
-	// Selector for a Zone to populate hostedZoneId.
+	// Selector for a Zone in route53 to populate hostedZoneId.
 	// +kubebuilder:validation:Optional
 	HostedZoneIDSelector *v1.Selector `json:"hostedZoneIdSelector,omitempty" tf:"-"`
 
@@ -34,14 +34,14 @@ type TrafficPolicyInstanceInitParameters struct {
 	TTL *float64 `json:"ttl,omitempty" tf:"ttl,omitempty"`
 
 	// ID of the traffic policy that you want to use to create resource record sets in the specified hosted zone.
-	// +crossplane:generate:reference:type=TrafficPolicy
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/route53/v1beta1.TrafficPolicy
 	TrafficPolicyID *string `json:"trafficPolicyId,omitempty" tf:"traffic_policy_id,omitempty"`
 
-	// Reference to a TrafficPolicy to populate trafficPolicyId.
+	// Reference to a TrafficPolicy in route53 to populate trafficPolicyId.
 	// +kubebuilder:validation:Optional
 	TrafficPolicyIDRef *v1.Reference `json:"trafficPolicyIdRef,omitempty" tf:"-"`
 
-	// Selector for a TrafficPolicy to populate trafficPolicyId.
+	// Selector for a TrafficPolicy in route53 to populate trafficPolicyId.
 	// +kubebuilder:validation:Optional
 	TrafficPolicyIDSelector *v1.Selector `json:"trafficPolicyIdSelector,omitempty" tf:"-"`
 
@@ -73,15 +73,15 @@ type TrafficPolicyInstanceObservation struct {
 type TrafficPolicyInstanceParameters struct {
 
 	// ID of the hosted zone that you want Amazon Route 53 to create resource record sets in by using the configuration in a traffic policy.
-	// +crossplane:generate:reference:type=Zone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/route53/v1beta1.Zone
 	// +kubebuilder:validation:Optional
 	HostedZoneID *string `json:"hostedZoneId,omitempty" tf:"hosted_zone_id,omitempty"`
 
-	// Reference to a Zone to populate hostedZoneId.
+	// Reference to a Zone in route53 to populate hostedZoneId.
 	// +kubebuilder:validation:Optional
 	HostedZoneIDRef *v1.Reference `json:"hostedZoneIdRef,omitempty" tf:"-"`
 
-	// Selector for a Zone to populate hostedZoneId.
+	// Selector for a Zone in route53 to populate hostedZoneId.
 	// +kubebuilder:validation:Optional
 	HostedZoneIDSelector *v1.Selector `json:"hostedZoneIdSelector,omitempty" tf:"-"`
 
@@ -99,15 +99,15 @@ type TrafficPolicyInstanceParameters struct {
 	TTL *float64 `json:"ttl,omitempty" tf:"ttl,omitempty"`
 
 	// ID of the traffic policy that you want to use to create resource record sets in the specified hosted zone.
-	// +crossplane:generate:reference:type=TrafficPolicy
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/route53/v1beta1.TrafficPolicy
 	// +kubebuilder:validation:Optional
 	TrafficPolicyID *string `json:"trafficPolicyId,omitempty" tf:"traffic_policy_id,omitempty"`
 
-	// Reference to a TrafficPolicy to populate trafficPolicyId.
+	// Reference to a TrafficPolicy in route53 to populate trafficPolicyId.
 	// +kubebuilder:validation:Optional
 	TrafficPolicyIDRef *v1.Reference `json:"trafficPolicyIdRef,omitempty" tf:"-"`
 
-	// Selector for a TrafficPolicy to populate trafficPolicyId.
+	// Selector for a TrafficPolicy in route53 to populate trafficPolicyId.
 	// +kubebuilder:validation:Optional
 	TrafficPolicyIDSelector *v1.Selector `json:"trafficPolicyIdSelector,omitempty" tf:"-"`
 

--- a/apis/route53/v1beta1/zz_vpcassociationauthorization_types.go
+++ b/apis/route53/v1beta1/zz_vpcassociationauthorization_types.go
@@ -31,14 +31,14 @@ type VPCAssociationAuthorizationInitParameters struct {
 	VPCRegion *string `json:"vpcRegion,omitempty" tf:"vpc_region,omitempty"`
 
 	// The ID of the private hosted zone that you want to authorize associating a VPC with.
-	// +crossplane:generate:reference:type=Zone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/route53/v1beta1.Zone
 	ZoneID *string `json:"zoneId,omitempty" tf:"zone_id,omitempty"`
 
-	// Reference to a Zone to populate zoneId.
+	// Reference to a Zone in route53 to populate zoneId.
 	// +kubebuilder:validation:Optional
 	ZoneIDRef *v1.Reference `json:"zoneIdRef,omitempty" tf:"-"`
 
-	// Selector for a Zone to populate zoneId.
+	// Selector for a Zone in route53 to populate zoneId.
 	// +kubebuilder:validation:Optional
 	ZoneIDSelector *v1.Selector `json:"zoneIdSelector,omitempty" tf:"-"`
 }
@@ -83,15 +83,15 @@ type VPCAssociationAuthorizationParameters struct {
 	VPCRegion *string `json:"vpcRegion,omitempty" tf:"vpc_region,omitempty"`
 
 	// The ID of the private hosted zone that you want to authorize associating a VPC with.
-	// +crossplane:generate:reference:type=Zone
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/route53/v1beta1.Zone
 	// +kubebuilder:validation:Optional
 	ZoneID *string `json:"zoneId,omitempty" tf:"zone_id,omitempty"`
 
-	// Reference to a Zone to populate zoneId.
+	// Reference to a Zone in route53 to populate zoneId.
 	// +kubebuilder:validation:Optional
 	ZoneIDRef *v1.Reference `json:"zoneIdRef,omitempty" tf:"-"`
 
-	// Selector for a Zone to populate zoneId.
+	// Selector for a Zone in route53 to populate zoneId.
 	// +kubebuilder:validation:Optional
 	ZoneIDSelector *v1.Selector `json:"zoneIdSelector,omitempty" tf:"-"`
 }

--- a/apis/route53/v1beta1/zz_zone_types.go
+++ b/apis/route53/v1beta1/zz_zone_types.go
@@ -68,14 +68,14 @@ type ZoneInitParameters struct {
 	Comment *string `json:"comment,omitempty" tf:"comment,omitempty"`
 
 	// The ID of the reusable delegation set whose NS records you want to assign to the hosted zone. Conflicts with vpc as delegation sets can only be used for public zones.
-	// +crossplane:generate:reference:type=DelegationSet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/route53/v1beta1.DelegationSet
 	DelegationSetID *string `json:"delegationSetId,omitempty" tf:"delegation_set_id,omitempty"`
 
-	// Reference to a DelegationSet to populate delegationSetId.
+	// Reference to a DelegationSet in route53 to populate delegationSetId.
 	// +kubebuilder:validation:Optional
 	DelegationSetIDRef *v1.Reference `json:"delegationSetIdRef,omitempty" tf:"-"`
 
-	// Selector for a DelegationSet to populate delegationSetId.
+	// Selector for a DelegationSet in route53 to populate delegationSetId.
 	// +kubebuilder:validation:Optional
 	DelegationSetIDSelector *v1.Selector `json:"delegationSetIdSelector,omitempty" tf:"-"`
 
@@ -139,15 +139,15 @@ type ZoneParameters struct {
 	Comment *string `json:"comment,omitempty" tf:"comment,omitempty"`
 
 	// The ID of the reusable delegation set whose NS records you want to assign to the hosted zone. Conflicts with vpc as delegation sets can only be used for public zones.
-	// +crossplane:generate:reference:type=DelegationSet
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/route53/v1beta1.DelegationSet
 	// +kubebuilder:validation:Optional
 	DelegationSetID *string `json:"delegationSetId,omitempty" tf:"delegation_set_id,omitempty"`
 
-	// Reference to a DelegationSet to populate delegationSetId.
+	// Reference to a DelegationSet in route53 to populate delegationSetId.
 	// +kubebuilder:validation:Optional
 	DelegationSetIDRef *v1.Reference `json:"delegationSetIdRef,omitempty" tf:"-"`
 
-	// Selector for a DelegationSet to populate delegationSetId.
+	// Selector for a DelegationSet in route53 to populate delegationSetId.
 	// +kubebuilder:validation:Optional
 	DelegationSetIDSelector *v1.Selector `json:"delegationSetIdSelector,omitempty" tf:"-"`
 

--- a/apis/servicecatalog/v1beta1/zz_budgetresourceassociation_types.go
+++ b/apis/servicecatalog/v1beta1/zz_budgetresourceassociation_types.go
@@ -28,14 +28,14 @@ type BudgetResourceAssociationInitParameters struct {
 	BudgetNameSelector *v1.Selector `json:"budgetNameSelector,omitempty" tf:"-"`
 
 	// Resource identifier.
-	// +crossplane:generate:reference:type=Product
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/servicecatalog/v1beta1.Product
 	ResourceID *string `json:"resourceId,omitempty" tf:"resource_id,omitempty"`
 
-	// Reference to a Product to populate resourceId.
+	// Reference to a Product in servicecatalog to populate resourceId.
 	// +kubebuilder:validation:Optional
 	ResourceIDRef *v1.Reference `json:"resourceIdRef,omitempty" tf:"-"`
 
-	// Selector for a Product to populate resourceId.
+	// Selector for a Product in servicecatalog to populate resourceId.
 	// +kubebuilder:validation:Optional
 	ResourceIDSelector *v1.Selector `json:"resourceIdSelector,omitempty" tf:"-"`
 }
@@ -73,15 +73,15 @@ type BudgetResourceAssociationParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// Resource identifier.
-	// +crossplane:generate:reference:type=Product
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/servicecatalog/v1beta1.Product
 	// +kubebuilder:validation:Optional
 	ResourceID *string `json:"resourceId,omitempty" tf:"resource_id,omitempty"`
 
-	// Reference to a Product to populate resourceId.
+	// Reference to a Product in servicecatalog to populate resourceId.
 	// +kubebuilder:validation:Optional
 	ResourceIDRef *v1.Reference `json:"resourceIdRef,omitempty" tf:"-"`
 
-	// Selector for a Product to populate resourceId.
+	// Selector for a Product in servicecatalog to populate resourceId.
 	// +kubebuilder:validation:Optional
 	ResourceIDSelector *v1.Selector `json:"resourceIdSelector,omitempty" tf:"-"`
 }

--- a/apis/servicecatalog/v1beta1/zz_principalportfolioassociation_types.go
+++ b/apis/servicecatalog/v1beta1/zz_principalportfolioassociation_types.go
@@ -19,14 +19,14 @@ type PrincipalPortfolioAssociationInitParameters struct {
 	AcceptLanguage *string `json:"acceptLanguage,omitempty" tf:"accept_language,omitempty"`
 
 	// Portfolio identifier.
-	// +crossplane:generate:reference:type=Portfolio
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/servicecatalog/v1beta1.Portfolio
 	PortfolioID *string `json:"portfolioId,omitempty" tf:"portfolio_id,omitempty"`
 
-	// Reference to a Portfolio to populate portfolioId.
+	// Reference to a Portfolio in servicecatalog to populate portfolioId.
 	// +kubebuilder:validation:Optional
 	PortfolioIDRef *v1.Reference `json:"portfolioIdRef,omitempty" tf:"-"`
 
-	// Selector for a Portfolio to populate portfolioId.
+	// Selector for a Portfolio in servicecatalog to populate portfolioId.
 	// +kubebuilder:validation:Optional
 	PortfolioIDSelector *v1.Selector `json:"portfolioIdSelector,omitempty" tf:"-"`
 
@@ -72,15 +72,15 @@ type PrincipalPortfolioAssociationParameters struct {
 	AcceptLanguage *string `json:"acceptLanguage,omitempty" tf:"accept_language,omitempty"`
 
 	// Portfolio identifier.
-	// +crossplane:generate:reference:type=Portfolio
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/servicecatalog/v1beta1.Portfolio
 	// +kubebuilder:validation:Optional
 	PortfolioID *string `json:"portfolioId,omitempty" tf:"portfolio_id,omitempty"`
 
-	// Reference to a Portfolio to populate portfolioId.
+	// Reference to a Portfolio in servicecatalog to populate portfolioId.
 	// +kubebuilder:validation:Optional
 	PortfolioIDRef *v1.Reference `json:"portfolioIdRef,omitempty" tf:"-"`
 
-	// Selector for a Portfolio to populate portfolioId.
+	// Selector for a Portfolio in servicecatalog to populate portfolioId.
 	// +kubebuilder:validation:Optional
 	PortfolioIDSelector *v1.Selector `json:"portfolioIdSelector,omitempty" tf:"-"`
 

--- a/apis/servicecatalog/v1beta1/zz_productportfolioassociation_types.go
+++ b/apis/servicecatalog/v1beta1/zz_productportfolioassociation_types.go
@@ -19,26 +19,26 @@ type ProductPortfolioAssociationInitParameters struct {
 	AcceptLanguage *string `json:"acceptLanguage,omitempty" tf:"accept_language,omitempty"`
 
 	// Portfolio identifier.
-	// +crossplane:generate:reference:type=Portfolio
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/servicecatalog/v1beta1.Portfolio
 	PortfolioID *string `json:"portfolioId,omitempty" tf:"portfolio_id,omitempty"`
 
-	// Reference to a Portfolio to populate portfolioId.
+	// Reference to a Portfolio in servicecatalog to populate portfolioId.
 	// +kubebuilder:validation:Optional
 	PortfolioIDRef *v1.Reference `json:"portfolioIdRef,omitempty" tf:"-"`
 
-	// Selector for a Portfolio to populate portfolioId.
+	// Selector for a Portfolio in servicecatalog to populate portfolioId.
 	// +kubebuilder:validation:Optional
 	PortfolioIDSelector *v1.Selector `json:"portfolioIdSelector,omitempty" tf:"-"`
 
 	// Product identifier.
-	// +crossplane:generate:reference:type=Product
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/servicecatalog/v1beta1.Product
 	ProductID *string `json:"productId,omitempty" tf:"product_id,omitempty"`
 
-	// Reference to a Product to populate productId.
+	// Reference to a Product in servicecatalog to populate productId.
 	// +kubebuilder:validation:Optional
 	ProductIDRef *v1.Reference `json:"productIdRef,omitempty" tf:"-"`
 
-	// Selector for a Product to populate productId.
+	// Selector for a Product in servicecatalog to populate productId.
 	// +kubebuilder:validation:Optional
 	ProductIDSelector *v1.Selector `json:"productIdSelector,omitempty" tf:"-"`
 
@@ -71,28 +71,28 @@ type ProductPortfolioAssociationParameters struct {
 	AcceptLanguage *string `json:"acceptLanguage,omitempty" tf:"accept_language,omitempty"`
 
 	// Portfolio identifier.
-	// +crossplane:generate:reference:type=Portfolio
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/servicecatalog/v1beta1.Portfolio
 	// +kubebuilder:validation:Optional
 	PortfolioID *string `json:"portfolioId,omitempty" tf:"portfolio_id,omitempty"`
 
-	// Reference to a Portfolio to populate portfolioId.
+	// Reference to a Portfolio in servicecatalog to populate portfolioId.
 	// +kubebuilder:validation:Optional
 	PortfolioIDRef *v1.Reference `json:"portfolioIdRef,omitempty" tf:"-"`
 
-	// Selector for a Portfolio to populate portfolioId.
+	// Selector for a Portfolio in servicecatalog to populate portfolioId.
 	// +kubebuilder:validation:Optional
 	PortfolioIDSelector *v1.Selector `json:"portfolioIdSelector,omitempty" tf:"-"`
 
 	// Product identifier.
-	// +crossplane:generate:reference:type=Product
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/servicecatalog/v1beta1.Product
 	// +kubebuilder:validation:Optional
 	ProductID *string `json:"productId,omitempty" tf:"product_id,omitempty"`
 
-	// Reference to a Product to populate productId.
+	// Reference to a Product in servicecatalog to populate productId.
 	// +kubebuilder:validation:Optional
 	ProductIDRef *v1.Reference `json:"productIdRef,omitempty" tf:"-"`
 
-	// Selector for a Product to populate productId.
+	// Selector for a Product in servicecatalog to populate productId.
 	// +kubebuilder:validation:Optional
 	ProductIDSelector *v1.Selector `json:"productIdSelector,omitempty" tf:"-"`
 

--- a/apis/servicecatalog/v1beta1/zz_tagoptionresourceassociation_types.go
+++ b/apis/servicecatalog/v1beta1/zz_tagoptionresourceassociation_types.go
@@ -16,26 +16,26 @@ import (
 type TagOptionResourceAssociationInitParameters struct {
 
 	// Resource identifier.
-	// +crossplane:generate:reference:type=Product
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/servicecatalog/v1beta1.Product
 	ResourceID *string `json:"resourceId,omitempty" tf:"resource_id,omitempty"`
 
-	// Reference to a Product to populate resourceId.
+	// Reference to a Product in servicecatalog to populate resourceId.
 	// +kubebuilder:validation:Optional
 	ResourceIDRef *v1.Reference `json:"resourceIdRef,omitempty" tf:"-"`
 
-	// Selector for a Product to populate resourceId.
+	// Selector for a Product in servicecatalog to populate resourceId.
 	// +kubebuilder:validation:Optional
 	ResourceIDSelector *v1.Selector `json:"resourceIdSelector,omitempty" tf:"-"`
 
 	// Tag Option identifier.
-	// +crossplane:generate:reference:type=TagOption
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/servicecatalog/v1beta1.TagOption
 	TagOptionID *string `json:"tagOptionId,omitempty" tf:"tag_option_id,omitempty"`
 
-	// Reference to a TagOption to populate tagOptionId.
+	// Reference to a TagOption in servicecatalog to populate tagOptionId.
 	// +kubebuilder:validation:Optional
 	TagOptionIDRef *v1.Reference `json:"tagOptionIdRef,omitempty" tf:"-"`
 
-	// Selector for a TagOption to populate tagOptionId.
+	// Selector for a TagOption in servicecatalog to populate tagOptionId.
 	// +kubebuilder:validation:Optional
 	TagOptionIDSelector *v1.Selector `json:"tagOptionIdSelector,omitempty" tf:"-"`
 }
@@ -72,28 +72,28 @@ type TagOptionResourceAssociationParameters struct {
 	Region *string `json:"region" tf:"-"`
 
 	// Resource identifier.
-	// +crossplane:generate:reference:type=Product
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/servicecatalog/v1beta1.Product
 	// +kubebuilder:validation:Optional
 	ResourceID *string `json:"resourceId,omitempty" tf:"resource_id,omitempty"`
 
-	// Reference to a Product to populate resourceId.
+	// Reference to a Product in servicecatalog to populate resourceId.
 	// +kubebuilder:validation:Optional
 	ResourceIDRef *v1.Reference `json:"resourceIdRef,omitempty" tf:"-"`
 
-	// Selector for a Product to populate resourceId.
+	// Selector for a Product in servicecatalog to populate resourceId.
 	// +kubebuilder:validation:Optional
 	ResourceIDSelector *v1.Selector `json:"resourceIdSelector,omitempty" tf:"-"`
 
 	// Tag Option identifier.
-	// +crossplane:generate:reference:type=TagOption
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/servicecatalog/v1beta1.TagOption
 	// +kubebuilder:validation:Optional
 	TagOptionID *string `json:"tagOptionId,omitempty" tf:"tag_option_id,omitempty"`
 
-	// Reference to a TagOption to populate tagOptionId.
+	// Reference to a TagOption in servicecatalog to populate tagOptionId.
 	// +kubebuilder:validation:Optional
 	TagOptionIDRef *v1.Reference `json:"tagOptionIdRef,omitempty" tf:"-"`
 
-	// Selector for a TagOption to populate tagOptionId.
+	// Selector for a TagOption in servicecatalog to populate tagOptionId.
 	// +kubebuilder:validation:Optional
 	TagOptionIDSelector *v1.Selector `json:"tagOptionIdSelector,omitempty" tf:"-"`
 }

--- a/apis/transfer/v1beta1/zz_user_types.go
+++ b/apis/transfer/v1beta1/zz_user_types.go
@@ -115,14 +115,14 @@ type UserInitParameters struct {
 	RoleSelector *v1.Selector `json:"roleSelector,omitempty" tf:"-"`
 
 	// The Server ID of the Transfer Server (e.g., s-12345678)
-	// +crossplane:generate:reference:type=Server
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/transfer/v1beta1.Server
 	ServerID *string `json:"serverId,omitempty" tf:"server_id,omitempty"`
 
-	// Reference to a Server to populate serverId.
+	// Reference to a Server in transfer to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDRef *v1.Reference `json:"serverIdRef,omitempty" tf:"-"`
 
-	// Selector for a Server to populate serverId.
+	// Selector for a Server in transfer to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDSelector *v1.Selector `json:"serverIdSelector,omitempty" tf:"-"`
 
@@ -210,15 +210,15 @@ type UserParameters struct {
 	RoleSelector *v1.Selector `json:"roleSelector,omitempty" tf:"-"`
 
 	// The Server ID of the Transfer Server (e.g., s-12345678)
-	// +crossplane:generate:reference:type=Server
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/transfer/v1beta1.Server
 	// +kubebuilder:validation:Optional
 	ServerID *string `json:"serverId,omitempty" tf:"server_id,omitempty"`
 
-	// Reference to a Server to populate serverId.
+	// Reference to a Server in transfer to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDRef *v1.Reference `json:"serverIdRef,omitempty" tf:"-"`
 
-	// Selector for a Server to populate serverId.
+	// Selector for a Server in transfer to populate serverId.
 	// +kubebuilder:validation:Optional
 	ServerIDSelector *v1.Selector `json:"serverIdSelector,omitempty" tf:"-"`
 

--- a/config/acm/config.go
+++ b/config/acm/config.go
@@ -13,7 +13,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_acm_certificate_validation", func(r *config.Resource) {
 		r.References = map[string]config.Reference{
 			"certificate_arn": {
-				Type: "Certificate",
+				TerraformName: "aws_acm_certificate",
 			},
 		}
 		// Deletion takes a while.

--- a/config/acmpca/config.go
+++ b/config/acmpca/config.go
@@ -35,7 +35,7 @@ func Configure(p *config.Provider) {
 		r.TerraformResource.Schema["certificate_signing_request"].Sensitive = true
 		r.References = map[string]config.Reference{
 			"certificate_authority_arn": {
-				Type: "CertificateAuthority",
+				TerraformName: "aws_acmpca_certificate_authority",
 			},
 		}
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
@@ -55,7 +55,7 @@ func Configure(p *config.Provider) {
 		r.TerraformResource.Schema["certificate_chain"].Sensitive = true
 		r.References = map[string]config.Reference{
 			"certificate_authority_arn": {
-				Type: "CertificateAuthority",
+				TerraformName: "aws_acmpca_certificate_authority",
 			},
 		}
 	})

--- a/config/apigateway/config.go
+++ b/config/apigateway/config.go
@@ -18,7 +18,7 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_api_gateway_vpc_link", func(r *config.Resource) {
 		r.References["target_arns"] = config.Reference{
-			Type:              "github.com/upbound/provider-aws/apis/elbv2/v1beta1.LB",
+			TerraformName:     "aws_lb",
 			RefFieldName:      "TargetArnRefs",
 			SelectorFieldName: "TargetArnSelector",
 			Extractor:         common.PathARNExtractor,

--- a/config/apigatewayv2/config.go
+++ b/config/apigatewayv2/config.go
@@ -14,19 +14,19 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_apigatewayv2_api_mapping", func(r *config.Resource) {
 		r.References["api_id"] = config.Reference{
-			Type: "API",
+			TerraformName: "aws_apigatewayv2_api",
 		}
 		r.References["domain_name"] = config.Reference{
-			Type: "DomainName",
+			TerraformName: "aws_apigatewayv2_domain_name",
 		}
 		r.References["stage"] = config.Reference{
-			Type:      "Stage",
-			Extractor: common.PathTerraformIDExtractor,
+			TerraformName: "aws_apigatewayv2_stage",
+			Extractor:     common.PathTerraformIDExtractor,
 		}
 	})
 	p.AddResourceConfigurator("aws_apigatewayv2_authorizer", func(r *config.Resource) {
 		r.References["api_id"] = config.Reference{
-			Type: "API",
+			TerraformName: "aws_apigatewayv2_api",
 		}
 		r.References["authorizer_uri"] = config.Reference{
 			TerraformName: "aws_lambda_function",
@@ -35,13 +35,13 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("aws_apigatewayv2_domain_name", func(r *config.Resource) {
 		r.References["domain_name_configuration.certificate_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/acm/v1beta1.Certificate",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_acm_certificate",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 	p.AddResourceConfigurator("aws_apigatewayv2_deployment", func(r *config.Resource) {
 		r.References["api_id"] = config.Reference{
-			Type: "API",
+			TerraformName: "aws_apigatewayv2_api",
 		}
 		// Triggers is a meta-argument that has comma-separated list of other resources in the same HCL block that tells
 		// terraform to re-create the resource if those in the list changed. Upjet workspaces contain only a single
@@ -53,48 +53,48 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("aws_apigatewayv2_integration", func(r *config.Resource) {
 		r.References["api_id"] = config.Reference{
-			Type: "API",
+			TerraformName: "aws_apigatewayv2_api",
 		}
 	})
 	p.AddResourceConfigurator("aws_apigatewayv2_integration_response", func(r *config.Resource) {
 		r.References["api_id"] = config.Reference{
-			Type: "API",
+			TerraformName: "aws_apigatewayv2_api",
 		}
 		r.References["integration_id"] = config.Reference{
-			Type: "Integration",
+			TerraformName: "aws_apigatewayv2_integration",
 		}
 	})
 	p.AddResourceConfigurator("aws_apigatewayv2_model", func(r *config.Resource) {
 		r.References["api_id"] = config.Reference{
-			Type: "API",
+			TerraformName: "aws_apigatewayv2_api",
 		}
 	})
 	p.AddResourceConfigurator("aws_apigatewayv2_route", func(r *config.Resource) {
 		r.References["api_id"] = config.Reference{
-			Type: "API",
+			TerraformName: "aws_apigatewayv2_api",
 		}
 		r.References["target"] = config.Reference{
 			TerraformName: "aws_apigatewayv2_integration",
 			Extractor:     "github.com/upbound/provider-aws/config/common/apis.IntegrationIDPrefixed()",
 		}
 		r.References["authorizer_id"] = config.Reference{
-			Type: "Authorizer",
+			TerraformName: "aws_apigatewayv2_authorizer",
 		}
 	})
 	p.AddResourceConfigurator("aws_apigatewayv2_route_response", func(r *config.Resource) {
 		r.References["api_id"] = config.Reference{
-			Type: "API",
+			TerraformName: "aws_apigatewayv2_api",
 		}
 		r.References["route_id"] = config.Reference{
-			Type: "Route",
+			TerraformName: "aws_apigatewayv2_route",
 		}
 	})
 	p.AddResourceConfigurator("aws_apigatewayv2_stage", func(r *config.Resource) {
 		r.References["api_id"] = config.Reference{
-			Type: "API",
+			TerraformName: "aws_apigatewayv2_api",
 		}
 		r.References["deployment_id"] = config.Reference{
-			Type: "Deployment",
+			TerraformName: "aws_apigatewayv2_deployment",
 		}
 	})
 	p.AddResourceConfigurator("aws_apigatewayv2_vpclink", func(r *config.Resource) {

--- a/config/apprunner/config.go
+++ b/config/apprunner/config.go
@@ -12,12 +12,12 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_apprunner_vpc_connector", func(r *config.Resource) {
 		r.References["subnets"] = config.Reference{
-			Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+			TerraformName:     "aws_subnet",
 			RefFieldName:      "SubnetRefs",
 			SelectorFieldName: "SubnetSelector",
 		}
 		r.References["security_groups"] = config.Reference{
-			Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup",
+			TerraformName:     "aws_security_group",
 			RefFieldName:      "SecurityGroupRefs",
 			SelectorFieldName: "SecurityGroupSelector",
 		}

--- a/config/appstream/config.go
+++ b/config/appstream/config.go
@@ -12,7 +12,7 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_appstream_fleet", func(r *config.Resource) {
 		r.References["vpc_config.subnet_ids"] = config.Reference{
-			Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+			TerraformName:     "aws_subnet",
 			RefFieldName:      "SubnetIDRefs",
 			SelectorFieldName: "SubnetIDSelector",
 		}
@@ -21,7 +21,7 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("aws_appstream_image_builder", func(r *config.Resource) {
 		r.References["vpc_config.subnet_ids"] = config.Reference{
-			Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+			TerraformName:     "aws_subnet",
 			RefFieldName:      "SubnetIDRefs",
 			SelectorFieldName: "SubnetIDSelector",
 		}

--- a/config/athena/config.go
+++ b/config/athena/config.go
@@ -14,8 +14,8 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_athena_workgroup", func(r *config.Resource) {
 		r.References["configuration.result_configuration.encryption_configuration.kms_key_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_kms_key",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 }

--- a/config/autoscaling/config.go
+++ b/config/autoscaling/config.go
@@ -51,7 +51,7 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("aws_autoscaling_group_tag", func(r *config.Resource) {
 		r.References["autoscaling_group_name"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/autoscaling/v1beta1.AutoscalingGroup",
+			Type: "github.com/upbound/provider-aws/apis/autoscaling/v1beta2.AutoscalingGroup",
 		}
 		r.OverrideFieldNames = map[string]string{
 			"TagParameters":     "GroupTagTagParameters",

--- a/config/autoscaling/config.go
+++ b/config/autoscaling/config.go
@@ -29,7 +29,7 @@ func Configure(p *config.Provider) {
 		}
 
 		r.References["vpc_zone_identifier"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+			TerraformName: "aws_subnet",
 		}
 		delete(r.References, "launch_template.version")
 		r.UseAsync = true
@@ -42,16 +42,16 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("aws_autoscaling_attachment", func(r *config.Resource) {
 		r.References["autoscaling_group_name"] = config.Reference{
-			Type: "AutoscalingGroup",
+			TerraformName: "aws_autoscaling_group",
 		}
 		r.References["alb_target_group_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/elbv2/v1beta1.LBTargetGroup",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_lb_target_group",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 	p.AddResourceConfigurator("aws_autoscaling_group_tag", func(r *config.Resource) {
 		r.References["autoscaling_group_name"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/autoscaling/v1beta2.AutoscalingGroup",
+			TerraformName: "aws_autoscaling_group",
 		}
 		r.OverrideFieldNames = map[string]string{
 			"TagParameters":     "GroupTagTagParameters",

--- a/config/backup/config.go
+++ b/config/backup/config.go
@@ -14,33 +14,33 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_backup_vault", func(r *config.Resource) {
 		r.References["kms_key_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_kms_key",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 
 	p.AddResourceConfigurator("aws_backup_selection", func(r *config.Resource) {
 		r.References["iam_role_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_role",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.References["plan_id"] = config.Reference{
-			Type: "Plan",
+			TerraformName: "aws_backup_plan",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_backup_vault_notifications", func(r *config.Resource) {
 		r.References["sns_topic_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/sns/v1beta1.Topic",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_sns_topic",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.References["backup_vault_name"] = config.Reference{
-			Type: "Vault",
+			TerraformName: "aws_backup_vault",
 		}
 	})
 	p.AddResourceConfigurator("aws_backup_vault_lock_configuration", func(r *config.Resource) {
 		r.References["backup_vault_name"] = config.Reference{
-			Type: "Vault",
+			TerraformName: "aws_backup_vault",
 		}
 	})
 

--- a/config/budgets/config.go
+++ b/config/budgets/config.go
@@ -12,7 +12,7 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_budgets_budget_action", func(r *config.Resource) {
 		r.References["definition.iam_action_definition.aws_iam_role.example.name"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
+			TerraformName: "aws_iam_role",
 		}
 	})
 }

--- a/config/cloudfront/config.go
+++ b/config/cloudfront/config.go
@@ -29,7 +29,7 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_cloudfront_key_group", func(r *config.Resource) {
 		r.References["items"] = config.Reference{
-			Type:              "PublicKey",
+			TerraformName:     "aws_cloudfront_public_key",
 			RefFieldName:      "ItemRefs",
 			SelectorFieldName: "ItemSelector",
 		}

--- a/config/cloudwatchevents/config.go
+++ b/config/cloudwatchevents/config.go
@@ -26,18 +26,18 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_cloudwatch_event_permission", func(r *config.Resource) {
 		r.References["event_bus_name"] = config.Reference{
-			Type: "Bus",
+			TerraformName: "aws_cloudwatch_event_bus",
 		}
 		r.UseAsync = true
 	})
 	p.AddResourceConfigurator("aws_cloudwatch_event_rule", func(r *config.Resource) {
 		r.References["event_bus_name"] = config.Reference{
-			Type: "Bus",
+			TerraformName: "aws_cloudwatch_event_bus",
 		}
 	})
 	p.AddResourceConfigurator("aws_cloudwatch_event_target", func(r *config.Resource) {
 		r.References["event_bus_name"] = config.Reference{
-			Type: "Bus",
+			TerraformName: "aws_cloudwatch_event_bus",
 		}
 		delete(r.References, "arn")
 	})

--- a/config/cognitoidentity/config.go
+++ b/config/cognitoidentity/config.go
@@ -14,11 +14,11 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_cognito_identity_pool", func(r *config.Resource) {
 		r.References["saml_provider_arns"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.SAMLProvider",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_saml_provider",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.References["cognito_identity_providers.client_id"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/cognitoidp/v1beta1.UserPoolClient",
+			TerraformName: "aws_cognito_user_pool_client",
 		}
 	})
 }

--- a/config/cognitoidp/config.go
+++ b/config/cognitoidp/config.go
@@ -14,35 +14,35 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_cognito_user_pool_client", func(r *config.Resource) {
 		r.References["user_pool_id"] = config.Reference{
-			Type: "UserPool",
+			TerraformName: "aws_cognito_user_pool",
 		}
 	})
 	p.AddResourceConfigurator("aws_cognito_user_pool_domain", func(r *config.Resource) {
 		r.References["user_pool_id"] = config.Reference{
-			Type: "UserPool",
+			TerraformName: "aws_cognito_user_pool",
 		}
 	})
 	p.AddResourceConfigurator("aws_cognito_user_group", func(r *config.Resource) {
 		r.References["user_pool_id"] = config.Reference{
-			Type: "UserPool",
+			TerraformName: "aws_cognito_user_pool",
 		}
 	})
 	p.AddResourceConfigurator("aws_cognito_resource_server", func(r *config.Resource) {
 		r.References["user_pool_id"] = config.Reference{
-			Type: "UserPool",
+			TerraformName: "aws_cognito_user_pool",
 		}
 	})
 	p.AddResourceConfigurator("aws_cognito_identity_provider", func(r *config.Resource) {
 		r.References["user_pool_id"] = config.Reference{
-			Type: "UserPool",
+			TerraformName: "aws_cognito_user_pool",
 		}
 	})
 	p.AddResourceConfigurator("aws_cognito_user_pool_ui_customization", func(r *config.Resource) {
 		r.References["client_id"] = config.Reference{
-			Type: "UserPoolClient",
+			TerraformName: "aws_cognito_user_pool_client",
 		}
 		r.References["user_pool_id"] = config.Reference{
-			Type: "UserPool",
+			TerraformName: "aws_cognito_user_pool",
 		}
 	})
 	p.AddResourceConfigurator("aws_cognito_user_pool", func(r *config.Resource) {

--- a/config/cur/config.go
+++ b/config/cur/config.go
@@ -12,7 +12,7 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_cur_report_definition", func(r *config.Resource) {
 		r.References["s3_bucket"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/s3/v1beta1.Bucket",
+			TerraformName: "aws_s3_bucket",
 		}
 	})
 }

--- a/config/datasync/config.go
+++ b/config/datasync/config.go
@@ -14,14 +14,14 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_datasync_task", func(r *config.Resource) {
 		r.References["destination_location_arn"] = config.Reference{
-			Type: "LocationS3",
+			TerraformName: "aws_datasync_location_s3",
 		}
 		r.References["source_location_arn"] = config.Reference{
-			Type: "LocationS3",
+			TerraformName: "aws_datasync_location_s3",
 		}
 		r.References["cloudwatch_log_group_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/cloudwatchlogs/v1beta1.Group",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_cloudwatch_log_group",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 }

--- a/config/devicefarm/config.go
+++ b/config/devicefarm/config.go
@@ -12,7 +12,7 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_devicefarm_test_grid_project", func(r *config.Resource) {
 		r.References["vpc_config.subnet_ids"] = config.Reference{
-			Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+			TerraformName:     "aws_subnet",
 			RefFieldName:      "SubnetIDRefs",
 			SelectorFieldName: "SubnetIDSelector",
 		}
@@ -20,7 +20,7 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_devicefarm_test_grid_project", func(r *config.Resource) {
 		r.References["vpc_config.security_group_ids"] = config.Reference{
-			Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup",
+			TerraformName:     "aws_security_group",
 			RefFieldName:      "SecurityGroupIDRefs",
 			SelectorFieldName: "SecurityGroupIDSelector",
 		}

--- a/config/directconnect/config.go
+++ b/config/directconnect/config.go
@@ -14,15 +14,15 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_dx_public_virtual_interface", func(r *config.Resource) {
 		r.References["connection_id"] = config.Reference{
-			Type: "Connection",
+			TerraformName: "aws_dx_connection",
 		}
 	})
 	p.AddResourceConfigurator("aws_dx_private_virtual_interface", func(r *config.Resource) {
 		r.References["connection_id"] = config.Reference{
-			Type: "Connection",
+			TerraformName: "aws_dx_connection",
 		}
 		r.References["vpn_gateway_id"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.VPNGateway",
+			TerraformName: "aws_vpn_gateway",
 		}
 		r.UseAsync = true
 	})
@@ -35,37 +35,37 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("aws_dx_hosted_transit_virtual_interface", func(r *config.Resource) {
 		r.References["connection_id"] = config.Reference{
-			Type: "Connection",
+			TerraformName: "aws_dx_connection",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_dx_hosted_public_virtual_interface", func(r *config.Resource) {
 		r.References["connection_id"] = config.Reference{
-			Type: "Connection",
+			TerraformName: "aws_dx_connection",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_dx_hosted_private_virtual_interface", func(r *config.Resource) {
 		r.References["connection_id"] = config.Reference{
-			Type: "Connection",
+			TerraformName: "aws_dx_connection",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_dx_hosted_private_virtual_interface_accepter", func(r *config.Resource) {
 		r.References["virtual_interface_id"] = config.Reference{
-			Type: "HostedPrivateVirtualInterface",
+			TerraformName: "aws_dx_hosted_private_virtual_interface",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_dx_hosted_public_virtual_interface_accepter", func(r *config.Resource) {
 		r.References["virtual_interface_id"] = config.Reference{
-			Type: "HostedPublicVirtualInterface",
+			TerraformName: "aws_dx_hosted_public_virtual_interface",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_dx_hosted_transit_virtual_interface_accepter", func(r *config.Resource) {
 		r.References["virtual_interface_id"] = config.Reference{
-			Type: "HostedTransitVirtualInterface",
+			TerraformName: "aws_dx_hosted_transit_virtual_interface",
 		}
 	})
 
@@ -78,11 +78,11 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_dx_macsec_key_association", func(r *config.Resource) {
 		r.References["connection_id"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/directconnect/v1beta1.Connection",
+			TerraformName: "aws_dx_connection",
 		}
 		r.References["secret_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/secretsmanager/v1beta1.Secret",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_secretsmanager_secret",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 

--- a/config/dms/config.go
+++ b/config/dms/config.go
@@ -16,16 +16,16 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_dms_endpoint", func(r *config.Resource) {
 		r.References = config.References{
 			"secrets_manager_access_role_arn": {
-				Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-				Extractor: common.PathARNExtractor,
+				TerraformName: "aws_iam_role",
+				Extractor:     common.PathARNExtractor,
 			},
 			"service_access_role": {
-				Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-				Extractor: common.PathARNExtractor,
+				TerraformName: "aws_iam_role",
+				Extractor:     common.PathARNExtractor,
 			},
 			"kms_key_arn": {
-				Type:      "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
-				Extractor: common.PathARNExtractor,
+				TerraformName: "aws_kms_key",
+				Extractor:     common.PathARNExtractor,
 			},
 		}
 		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {

--- a/config/docdb/config.go
+++ b/config/docdb/config.go
@@ -55,14 +55,14 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_docdb_cluster_instance", func(r *config.Resource) {
 		r.References["cluster_identifier"] = config.Reference{
-			Type: "Cluster",
+			TerraformName: "aws_docdb_cluster",
 		}
 		r.UseAsync = true
 	})
 
 	p.AddResourceConfigurator("aws_docdb_subnet_group", func(r *config.Resource) {
 		r.References["subnet_ids"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+			TerraformName: "aws_subnet",
 		}
 	})
 }

--- a/config/ds/config.go
+++ b/config/ds/config.go
@@ -10,10 +10,10 @@ import "github.com/crossplane/upjet/pkg/config"
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_directory_service_directory", func(r *config.Resource) {
 		r.References["vpc_settings.subnet_ids"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+			TerraformName: "aws_subnet",
 		}
 		r.References["connect_settings.subnet_ids"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+			TerraformName: "aws_subnet",
 		}
 	})
 }

--- a/config/dynamodb/config.go
+++ b/config/dynamodb/config.go
@@ -15,13 +15,13 @@ func Configure(p *config.Provider) {
 	// currently needs an ARN reference for external name
 	p.AddResourceConfigurator("aws_dynamodb_contributor_insights", func(r *config.Resource) {
 		r.References["table_name"] = config.Reference{
-			Type: "Table",
+			TerraformName: "aws_dynamodb_table",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_dynamodb_kinesis_streaming_destination", func(r *config.Resource) {
 		r.References["table_name"] = config.Reference{
-			Type: "Table",
+			TerraformName: "aws_dynamodb_table",
 		}
 
 		r.References["stream_arn"] = config.Reference{
@@ -32,7 +32,7 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_dynamodb_table_item", func(r *config.Resource) {
 		r.References["table_name"] = config.Reference{
-			Type: "Table",
+			TerraformName: "aws_dynamodb_table",
 		}
 		delete(r.References, "hash_key")
 	})

--- a/config/ebs/config.go
+++ b/config/ebs/config.go
@@ -13,7 +13,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_ebs_volume", func(r *config.Resource) {
 		r.References = map[string]config.Reference{
 			"kms_key_id": {
-				Type: "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
+				TerraformName: "aws_kms_key",
 			},
 		}
 	})

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -16,26 +16,26 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_instance", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["subnet_id"] = config.Reference{
-			Type: "Subnet",
+			TerraformName: "aws_subnet",
 		}
 		r.References["vpc_security_group_ids"] = config.Reference{
-			Type:              "SecurityGroup",
+			TerraformName:     "aws_security_group",
 			RefFieldName:      "VPCSecurityGroupIDRefs",
 			SelectorFieldName: "VPCSecurityGroupIDSelector",
 		}
 		r.References["security_groups"] = config.Reference{
-			Type:              "SecurityGroup",
+			TerraformName:     "aws_security_group",
 			RefFieldName:      "SecurityGroupRefs",
 			SelectorFieldName: "SecurityGroupSelector",
 		}
 		r.References["root_block_device.kms_key_id"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
+			TerraformName: "aws_kms_key",
 		}
 		r.References["network_interface.network_interface_id"] = config.Reference{
-			Type: "NetworkInterface",
+			TerraformName: "aws_network_interface",
 		}
 		r.References["ebs_block_device.kms_key_id"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
+			TerraformName: "aws_kms_key",
 		}
 		r.LateInitializer = config.LateInitializer{
 			// NOTE(muvaf): These are ignored because they conflict with each other.
@@ -57,58 +57,58 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("aws_eip", func(r *config.Resource) {
 		r.References["instance"] = config.Reference{
-			Type: "Instance",
+			TerraformName: "aws_instance",
 		}
 		r.References["network_interface"] = config.Reference{
-			Type: "NetworkInterface",
+			TerraformName: "aws_network_interface",
 		}
 		r.UseAsync = true
 	})
 
 	p.AddResourceConfigurator("aws_ec2_transit_gateway_route", func(r *config.Resource) {
 		r.References["transit_gateway_attachment_id"] = config.Reference{
-			Type: "TransitGatewayVPCAttachment",
+			TerraformName: "aws_ec2_transit_gateway_vpc_attachment",
 		}
 		r.References["transit_gateway_route_table_id"] = config.Reference{
-			Type: "TransitGatewayRouteTable",
+			TerraformName: "aws_ec2_transit_gateway_route_table",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_ec2_transit_gateway_route_table", func(r *config.Resource) {
 		r.References["transit_gateway_id"] = config.Reference{
-			Type: "TransitGateway",
+			TerraformName: "aws_ec2_transit_gateway",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_ec2_transit_gateway_route_table_association", func(r *config.Resource) {
 		r.References["transit_gateway_attachment_id"] = config.Reference{
-			Type: "TransitGatewayVPCAttachment",
+			TerraformName: "aws_ec2_transit_gateway_vpc_attachment",
 		}
 		r.References["transit_gateway_route_table_id"] = config.Reference{
-			Type: "TransitGatewayRouteTable",
+			TerraformName: "aws_ec2_transit_gateway_route_table",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_ec2_transit_gateway_vpc_attachment", func(r *config.Resource) {
 		r.References["transit_gateway_id"] = config.Reference{
-			Type: "TransitGateway",
+			TerraformName: "aws_ec2_transit_gateway",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_ec2_transit_gateway_vpc_attachment_accepter", func(r *config.Resource) {
 		r.References["transit_gateway_attachment_id"] = config.Reference{
-			Type: "TransitGatewayVPCAttachment",
+			TerraformName: "aws_ec2_transit_gateway_vpc_attachment",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_ec2_transit_gateway_connect", func(r *config.Resource) {
 		r.References["subnet_ids"] = config.Reference{
-			Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+			TerraformName:     "aws_subnet",
 			RefFieldName:      "SubnetIDRefs",
 			SelectorFieldName: "SubnetIDSelector",
 		}
 		r.References["vpc_id"] = config.Reference{
-			Type:              "VPC",
+			TerraformName:     "aws_vpc",
 			RefFieldName:      "VPCIDRef",
 			SelectorFieldName: "VPCIDSelector",
 		}
@@ -116,31 +116,31 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_launch_template", func(r *config.Resource) {
 		r.References["security_group_names"] = config.Reference{
-			Type:              "SecurityGroup",
+			TerraformName:     "aws_security_group",
 			RefFieldName:      "SecurityGroupNameRefs",
 			SelectorFieldName: "SecurityGroupNameSelector",
 		}
 		r.References["block_device_mappings.ebs.kms_key_id"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_kms_key",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.References["iam_instance_profile.arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.InstanceProfile",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_instance_profile",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.References["iam_instance_profile.name"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/iam/v1beta1.InstanceProfile",
+			TerraformName: "aws_iam_instance_profile",
 		}
 		r.References["network_interfaces.network_interface_id"] = config.Reference{
-			Type: "NetworkInterface",
+			TerraformName: "aws_network_interface",
 		}
 		r.References["network_interfaces.security_groups"] = config.Reference{
-			Type:              "SecurityGroup",
+			TerraformName:     "aws_security_group",
 			RefFieldName:      "SecurityGroupRefs",
 			SelectorFieldName: "SecurityGroupSelector",
 		}
 		r.References["network_interfaces.subnet_id"] = config.Reference{
-			Type: "Subnet",
+			TerraformName: "aws_subnet",
 		}
 	})
 
@@ -166,15 +166,15 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_network_interface", func(r *config.Resource) {
 		r.References["subnet_id"] = config.Reference{
-			Type: "Subnet",
+			TerraformName: "aws_subnet",
 		}
 		r.References["security_groups"] = config.Reference{
-			Type:              "SecurityGroup",
+			TerraformName:     "aws_security_group",
 			RefFieldName:      "SecurityGroupRefs",
 			SelectorFieldName: "SecurityGroupSelector",
 		}
 		r.References["attachment.instance"] = config.Reference{
-			Type: "Instance",
+			TerraformName: "aws_instance",
 		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{
@@ -198,10 +198,10 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_security_group_rule", func(r *config.Resource) {
 		r.References["security_group_id"] = config.Reference{
-			Type: "SecurityGroup",
+			TerraformName: "aws_security_group",
 		}
 		r.References["source_security_group_id"] = config.Reference{
-			Type: "SecurityGroup",
+			TerraformName: "aws_security_group",
 		}
 		r.References["prefix_list_ids"] = config.Reference{
 			TerraformName:     "aws_ec2_managed_prefix_list",
@@ -255,7 +255,7 @@ func Configure(p *config.Provider) {
 		// Mutually exclusive with aws_vpc_peering_connection_options
 		config.MoveToStatus(r.TerraformResource, "accepter", "requester")
 		r.References["peer_vpc_id"] = config.Reference{
-			Type: "VPC",
+			TerraformName: "aws_vpc",
 		}
 	})
 
@@ -297,31 +297,31 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_route_table_association", func(r *config.Resource) {
 		r.References["subnet_id"] = config.Reference{
-			Type: "Subnet",
+			TerraformName: "aws_subnet",
 		}
 		r.References["route_table_id"] = config.Reference{
-			Type: "RouteTable",
+			TerraformName: "aws_route_table",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_main_route_table_association", func(r *config.Resource) {
 		r.References["route_table_id"] = config.Reference{
-			Type: "RouteTable",
+			TerraformName: "aws_route_table",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_ec2_transit_gateway_route_table_propagation", func(r *config.Resource) {
 		r.References["transit_gateway_attachment_id"] = config.Reference{
-			Type: "TransitGatewayVPCAttachment",
+			TerraformName: "aws_ec2_transit_gateway_vpc_attachment",
 		}
 		r.References["transit_gateway_route_table_id"] = config.Reference{
-			Type: "TransitGatewayRouteTable",
+			TerraformName: "aws_ec2_transit_gateway_route_table",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_nat_gateway", func(r *config.Resource) {
 		r.References["subnet_id"] = config.Reference{
-			Type: "Subnet",
+			TerraformName: "aws_subnet",
 		}
 	})
 
@@ -367,7 +367,7 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_ec2_transit_gateway_multicast_domain", func(r *config.Resource) {
 		r.References["transit_gateway_id"] = config.Reference{
-			Type: "TransitGateway",
+			TerraformName: "aws_ec2_transit_gateway",
 		}
 	})
 
@@ -404,25 +404,25 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_vpc_ipam_pool", func(r *config.Resource) {
 		r.References["ipam_scope_id"] = config.Reference{
-			Type: "VPCIpamScope",
+			TerraformName: "aws_vpc_ipam_scope",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_vpc_ipam_scope", func(r *config.Resource) {
 		r.References["ipam_id"] = config.Reference{
-			Type: "VPCIpam",
+			TerraformName: "aws_vpc_ipam",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_ami", func(r *config.Resource) {
 		r.References["ebs_block_device.snapshot_id"] = config.Reference{
-			Type: "EBSSnapshot",
+			TerraformName: "aws_ebs_snapshot",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_ami_copy", func(r *config.Resource) {
 		r.References["source_ami_id"] = config.Reference{
-			Type: "AMI",
+			TerraformName: "aws_ami",
 		}
 		r.TerraformConfigurationInjector = func(jsonMap map[string]any, params map[string]any) error {
 			params["ebs_block_device"] = []any{}
@@ -442,13 +442,13 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_ami_launch_permission", func(r *config.Resource) {
 		r.References["image_id"] = config.Reference{
-			Type: "AMI",
+			TerraformName: "aws_ami",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_vpn_connection", func(r *config.Resource) {
 		r.References["vpn_gateway_id"] = config.Reference{
-			Type: "VPNGateway",
+			TerraformName: "aws_vpn_gateway",
 		}
 	})
 

--- a/config/ecr/config.go
+++ b/config/ecr/config.go
@@ -15,8 +15,8 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_ecr_repository", func(r *config.Resource) {
 		r.References = map[string]config.Reference{
 			"encryption_configuration.kms_key": {
-				Type:      "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
-				Extractor: common.PathARNExtractor,
+				TerraformName: "aws_kms_key",
+				Extractor:     common.PathARNExtractor,
 			},
 		}
 		// Deletion takes a while.

--- a/config/ecs/config.go
+++ b/config/ecs/config.go
@@ -33,10 +33,10 @@ func Configure(p *config.Provider) {
 
 		r.References = config.References{
 			"execute_command_configuration.kms_key_id": config.Reference{
-				Type: "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
+				TerraformName: "aws_kms_key",
 			},
 			"log_configuration.s3_bucket_name": config.Reference{
-				Type: "github.com/upbound/provider-aws/apis/s3/v1beta1.Bucket",
+				TerraformName: "aws_s3_bucket",
 			},
 		}
 
@@ -61,25 +61,25 @@ func Configure(p *config.Provider) {
 		}
 		r.References = config.References{
 			"cluster": config.Reference{
-				Type: "Cluster",
+				TerraformName: "aws_ecs_cluster",
 			},
 			"task_definition": config.Reference{
-				Type: "TaskDefinition",
+				TerraformName: "aws_ecs_task_definition",
 			},
 			"iam_role": config.Reference{
-				Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-				Extractor: common.PathARNExtractor,
+				TerraformName: "aws_iam_role",
+				Extractor:     common.PathARNExtractor,
 			},
 			"load_balancer.target_group_arn": config.Reference{
-				Type: "github.com/upbound/provider-aws/apis/elbv2/v1beta1.LBTargetGroup",
+				TerraformName: "aws_lb_target_group",
 			},
 			"network_configuration.subnets": config.Reference{
-				Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+				TerraformName:     "aws_subnet",
 				RefFieldName:      "SubnetRefs",
 				SelectorFieldName: "SubnetSelector",
 			},
 			"network_configuration.security_groups": config.Reference{
-				Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup",
+				TerraformName:     "aws_security_group",
 				RefFieldName:      "SecurityGroupRefs",
 				SelectorFieldName: "SecurityGroupSelector",
 			},
@@ -91,8 +91,8 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_ecs_capacity_provider", func(r *config.Resource) {
 		r.References = config.References{
 			"auto_scaling_group_provider.auto_scaling_group_arn": config.Reference{
-				Type:      "github.com/upbound/provider-aws/apis/autoscaling/v1beta2.AutoscalingGroup",
-				Extractor: common.PathARNExtractor,
+				TerraformName: "aws_autoscaling_group",
+				Extractor:     common.PathARNExtractor,
 			},
 		}
 	})
@@ -100,8 +100,8 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_ecs_task_definition", func(r *config.Resource) {
 		r.References = config.References{
 			"execution_role_arn": config.Reference{
-				Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-				Extractor: common.PathARNExtractor,
+				TerraformName: "aws_iam_role",
+				Extractor:     common.PathARNExtractor,
 			},
 		}
 	})

--- a/config/ecs/config.go
+++ b/config/ecs/config.go
@@ -91,7 +91,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_ecs_capacity_provider", func(r *config.Resource) {
 		r.References = config.References{
 			"auto_scaling_group_provider.auto_scaling_group_arn": config.Reference{
-				Type:      "github.com/upbound/provider-aws/apis/autoscaling/v1beta1.AutoscalingGroup",
+				Type:      "github.com/upbound/provider-aws/apis/autoscaling/v1beta2.AutoscalingGroup",
 				Extractor: common.PathARNExtractor,
 			},
 		}

--- a/config/efs/config.go
+++ b/config/efs/config.go
@@ -15,13 +15,13 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_efs_mount_target", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["file_system_id"] = config.Reference{
-			Type: "FileSystem",
+			TerraformName: "aws_efs_file_system",
 		}
 		r.References["subnet_id"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+			TerraformName: "aws_subnet",
 		}
 		r.References["security_groups"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup",
+			TerraformName: "aws_security_group",
 		}
 		/*r.MetaResource.Examples[0].Dependencies["aws_efs_file_system.foo"] = `{"creation_token": "my-product-foo", "region": "us-west-1"}`
 		if err := r.MetaResource.Examples[0].Dependencies.SetPathValue("aws_subnet.alpha", "availability_zone", "us-west-1b"); err != nil {
@@ -30,25 +30,25 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("aws_efs_access_point", func(r *config.Resource) {
 		r.References["file_system_id"] = config.Reference{
-			Type: "FileSystem",
+			TerraformName: "aws_efs_file_system",
 		}
 		// r.MetaResource.Examples[0].Dependencies["aws_efs_file_system.foo"] = `{"creation_token": "my-product-foo", "region": "us-west-1"}`
 	})
 	p.AddResourceConfigurator("aws_efs_backup_policy", func(r *config.Resource) {
 		r.References["file_system_id"] = config.Reference{
-			Type: "FileSystem",
+			TerraformName: "aws_efs_file_system",
 		}
 	})
 	p.AddResourceConfigurator("aws_efs_file_system_policy", func(r *config.Resource) {
 		r.References["file_system_id"] = config.Reference{
-			Type: "FileSystem",
+			TerraformName: "aws_efs_file_system",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_efs_file_system", func(r *config.Resource) {
 		r.References["kms_key_id"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_kms_key",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 }

--- a/config/eks/config.go
+++ b/config/eks/config.go
@@ -15,16 +15,16 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_eks_cluster", func(r *config.Resource) {
 		r.References = config.References{
 			"role_arn": {
-				Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-				Extractor: common.PathARNExtractor,
+				TerraformName: "aws_iam_role",
+				Extractor:     common.PathARNExtractor,
 			},
 			"vpc_config.subnet_ids": {
-				Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+				TerraformName:     "aws_subnet",
 				RefFieldName:      "SubnetIDRefs",
 				SelectorFieldName: "SubnetIDSelector",
 			},
 			"vpc_config.security_group_ids": {
-				Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup",
+				TerraformName:     "aws_security_group",
 				RefFieldName:      "SecurityGroupIDRefs",
 				SelectorFieldName: "SecurityGroupIDSelector",
 			},
@@ -44,20 +44,20 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("aws_eks_node_group", func(r *config.Resource) {
 		r.References["cluster_name"] = config.Reference{
-			Type:      "Cluster",
-			Extractor: "ExternalNameIfClusterActive()",
+			TerraformName: "aws_eks_cluster",
+			Extractor:     "ExternalNameIfClusterActive()",
 		}
 		r.References["node_role_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_role",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.References["remote_access.source_security_group_ids"] = config.Reference{
-			Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup",
+			TerraformName:     "aws_security_group",
 			RefFieldName:      "SourceSecurityGroupIDRefs",
 			SelectorFieldName: "SourceSecurityGroupIDSelector",
 		}
 		r.References["subnet_ids"] = config.Reference{
-			Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+			TerraformName:     "aws_subnet",
 			RefFieldName:      "SubnetIDRefs",
 			SelectorFieldName: "SubnetIDSelector",
 		}
@@ -75,7 +75,7 @@ func Configure(p *config.Provider) {
 		// OmittedFields in config.ExternalName works only for the top-level fields.
 		r.References = config.References{
 			"cluster_name": {
-				Type: "Cluster",
+				TerraformName: "aws_eks_cluster",
 			},
 		}
 		r.UseAsync = true
@@ -84,14 +84,14 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_eks_fargate_profile", func(r *config.Resource) {
 		r.References = config.References{
 			"cluster_name": {
-				Type: "Cluster",
+				TerraformName: "aws_eks_cluster",
 			},
 			"pod_execution_role_arn": {
-				Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-				Extractor: common.PathARNExtractor,
+				TerraformName: "aws_iam_role",
+				Extractor:     common.PathARNExtractor,
 			},
 			"subnet_ids": {
-				Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+				TerraformName:     "aws_subnet",
 				RefFieldName:      "SubnetIDRefs",
 				SelectorFieldName: "SubnetIDSelector",
 			},
@@ -101,11 +101,11 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_eks_addon", func(r *config.Resource) {
 		r.References = config.References{
 			"cluster_name": {
-				Type: "Cluster",
+				TerraformName: "aws_eks_cluster",
 			},
 			"service_account_role_arn": {
-				Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-				Extractor: common.PathARNExtractor,
+				TerraformName: "aws_iam_role",
+				Extractor:     common.PathARNExtractor,
 			},
 		}
 		r.UseAsync = true

--- a/config/elasticache/config.go
+++ b/config/elasticache/config.go
@@ -28,10 +28,10 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 
 	p.AddResourceConfigurator("aws_elasticache_replication_group", func(r *config.Resource) {
 		r.References["subnet_group_name"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/elasticache/v1beta1.SubnetGroup",
+			TerraformName: "aws_elasticache_subnet_group",
 		}
 		r.References["kms_key_id"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
+			TerraformName: "aws_kms_key",
 		}
 		r.LateInitializer = config.LateInitializer{
 			// Conflicting configuration arguments: "number_cache_clusters": conflicts with cluster_mode.0.num_node_groups
@@ -120,7 +120,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 
 	p.AddResourceConfigurator("aws_elasticache_user_group", func(r *config.Resource) {
 		r.References["user_ids"] = config.Reference{
-			Type:              "User",
+			TerraformName:     "aws_elasticache_user",
 			RefFieldName:      "UserIDRefs",
 			SelectorFieldName: "UserIDSelector",
 		}

--- a/config/elb/config.go
+++ b/config/elb/config.go
@@ -10,10 +10,10 @@ import "github.com/crossplane/upjet/pkg/config"
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_elb", func(r *config.Resource) {
 		r.References["instances"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.Instance",
+			TerraformName: "aws_instance",
 		}
 		r.References["subnets"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+			TerraformName: "aws_subnet",
 		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"access_logs"},
@@ -22,10 +22,10 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_elb_attachment", func(r *config.Resource) {
 		r.References["elb"] = config.Reference{
-			Type: "ELB",
+			TerraformName: "aws_elb",
 		}
 		r.References["instance"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.Instance",
+			TerraformName: "aws_instance",
 		}
 	})
 }

--- a/config/elbv2/config.go
+++ b/config/elbv2/config.go
@@ -12,20 +12,20 @@ func Configure(p *config.Provider) {
 		r.ExternalName.OmittedFields = append(r.ExternalName.OmittedFields, "name_prefix")
 		r.References = config.References{
 			"security_groups": {
-				Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup",
+				TerraformName:     "aws_security_group",
 				RefFieldName:      "SecurityGroupRefs",
 				SelectorFieldName: "SecurityGroupSelector",
 			},
 			"subnets": {
-				Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+				TerraformName:     "aws_subnet",
 				RefFieldName:      "SubnetRefs",
 				SelectorFieldName: "SubnetSelector",
 			},
 			"access_logs.bucket": {
-				Type: "github.com/upbound/provider-aws/apis/s3/v1beta1.Bucket",
+				TerraformName: "aws_s3_bucket",
 			},
 			"subnet_mapping.subnet_id": {
-				Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+				TerraformName: "aws_subnet",
 			},
 		}
 		r.UseAsync = true
@@ -35,13 +35,13 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_lb_listener", func(r *config.Resource) {
 		r.References = config.References{
 			"load_balancer_arn": {
-				Type: "LB",
+				TerraformName: "aws_lb",
 			},
 			"default_action.target_group_arn": {
-				Type: "LBTargetGroup",
+				TerraformName: "aws_lb_target_group",
 			},
 			"default_action.forward.target_group.arn": {
-				Type: "LBTargetGroup",
+				TerraformName: "aws_lb_target_group",
 			},
 		}
 	})
@@ -59,7 +59,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_lb_target_group_attachment", func(r *config.Resource) {
 		r.References = config.References{
 			"target_group_arn": {
-				Type: "LBTargetGroup",
+				TerraformName: "aws_lb_target_group",
 			},
 		}
 		r.UseAsync = true

--- a/config/fsx/config.go
+++ b/config/fsx/config.go
@@ -14,8 +14,8 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_fsx_windows_file_system", func(r *config.Resource) {
 		r.References["kms_key_id"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_kms_key",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 }

--- a/config/gamelift/config.go
+++ b/config/gamelift/config.go
@@ -14,17 +14,17 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_gamelift_build", func(r *config.Resource) {
 		r.References["storage_location.role_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_role",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.References["storage_location.bucket"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/s3/v1beta1.Bucket",
+			TerraformName: "aws_s3_bucket",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_gamelift_fleet", func(r *config.Resource) {
 		r.References["build_id"] = config.Reference{
-			Type: "Build",
+			TerraformName: "aws_gamelift_build",
 		}
 		r.UseAsync = true
 		r.Path = "fleet"
@@ -32,29 +32,29 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_gamelift_game_server_group", func(r *config.Resource) {
 		r.References["role_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_role",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.References["launch_template.id"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/ec2/v1beta1.LaunchTemplate",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_launch_template",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 
 	p.AddResourceConfigurator("aws_gamelift_game_session_queue", func(r *config.Resource) {
 		r.References["notification_target"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/sns/v1beta1.Topic",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_sns_topic",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 
 	p.AddResourceConfigurator("aws_gamelift_script", func(r *config.Resource) {
 		r.References["storage_location.role_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_role",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.References["storage_location.bucket"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/s3/v1beta1.Bucket",
+			TerraformName: "aws_s3_bucket",
 		}
 	})
 }

--- a/config/globalaccelerator/config.go
+++ b/config/globalaccelerator/config.go
@@ -13,7 +13,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_globalaccelerator_endpoint_group", func(r *config.Resource) {
 		r.References = config.References{
 			"listener_arn": {
-				Type: "Listener",
+				TerraformName: "aws_globalaccelerator_listener",
 			},
 		}
 	})
@@ -21,7 +21,7 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_globalaccelerator_listener", func(r *config.Resource) {
 		r.References = config.References{
 			"accelerator_arn": {
-				Type: "Accelerator",
+				TerraformName: "aws_globalaccelerator_accelerator",
 			},
 		}
 	})

--- a/config/glue/config.go
+++ b/config/glue/config.go
@@ -52,19 +52,19 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_glue_crawler", func(r *config.Resource) {
 		r.References["role"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_role",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 
 	p.AddResourceConfigurator("aws_glue_data_catalog_encryption_settings", func(r *config.Resource) {
 		r.References["data_catalog_encryption_settings.connection_password_encryption.aws_kms_key_id"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_kms_key",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.References["data_catalog_encryption_settings.encryption_at_rest.sse_aws_kms_key_id"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_kms_key",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 
@@ -80,18 +80,18 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_glue_security_configuration", func(r *config.Resource) {
 		r.References["encryption_configuration.cloudwatch_encryption.kms_key_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_kms_key",
+			Extractor:     common.PathARNExtractor,
 		}
 
 		r.References["encryption_configuration.job_bookmarks_encryption.kms_key_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_kms_key",
+			Extractor:     common.PathARNExtractor,
 		}
 
 		r.References["encryption_configuration.s3_encryption.kms_key_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_kms_key",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -14,21 +14,21 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_grafana_workspace", func(r *config.Resource) {
 		r.References["role_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_role",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.UseAsync = true
 	})
 
 	p.AddResourceConfigurator("aws_grafana_role_association", func(r *config.Resource) {
 		r.References["workspace_id"] = config.Reference{
-			Type: "Workspace",
+			TerraformName: "aws_grafana_workspace",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_grafana_workspace_saml_configuration", func(r *config.Resource) {
 		r.References["workspace_id"] = config.Reference{
-			Type: "Workspace",
+			TerraformName: "aws_grafana_workspace",
 		}
 	})
 

--- a/config/iam/config.go
+++ b/config/iam/config.go
@@ -88,24 +88,24 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_iam_group_membership", func(r *config.Resource) {
 		r.References["users"] = config.Reference{
-			Type:              "User",
+			TerraformName:     "aws_iam_user",
 			RefFieldName:      "UserRefs",
 			SelectorFieldName: "UserSelector",
 		}
 		r.References["group"] = config.Reference{
-			Type: "Group",
+			TerraformName: "aws_iam_group",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_iam_service_specific_credential", func(r *config.Resource) {
 		r.References["user_name"] = config.Reference{
-			Type: "User",
+			TerraformName: "aws_iam_user",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_iam_user_login_profile", func(r *config.Resource) {
 		r.References["user"] = config.Reference{
-			Type: "User",
+			TerraformName: "aws_iam_user",
 		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"password_reset_required", "password_length", "pgp_key"},
@@ -114,7 +114,7 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_iam_user_ssh_key", func(r *config.Resource) {
 		r.References["username"] = config.Reference{
-			Type: "User",
+			TerraformName: "aws_iam_user",
 		}
 	})
 

--- a/config/kafka/config.go
+++ b/config/kafka/config.go
@@ -227,7 +227,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 	})
 	p.AddResourceConfigurator("aws_msk_scram_secret_association", func(r *config.Resource) {
 		r.References["secret_arn_list"] = config.Reference{
-			Type:              "github.com/upbound/provider-aws/apis/secretsmanager/v1beta1.Secret",
+			TerraformName:     "aws_secretsmanager_secret",
 			RefFieldName:      "SecretArnRefs",
 			SelectorFieldName: "SecretArnSelector",
 		}

--- a/config/kinesisanalytics/config.go
+++ b/config/kinesisanalytics/config.go
@@ -18,8 +18,8 @@ func Configure(p *config.Provider) {
 			Extractor:     common.PathTerraformIDExtractor,
 		}
 		r.References["inputs.kinesis_stream.role_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_role",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 }

--- a/config/kinesisanalyticsv2/config.go
+++ b/config/kinesisanalyticsv2/config.go
@@ -14,16 +14,16 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_kinesisanalyticsv2_application", func(r *config.Resource) {
 		r.References["application_configuration.application_code_configuration.code_content.s3_content_location.bucket_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/s3/v1beta1.Bucket",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_s3_bucket",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.References["service_execution_role"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_role",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.References["application_configuration.sql_application_configuration.reference_data_source.s3_reference_data_source.bucket_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/s3/v1beta1.Bucket",
-			Extractor: `github.com/crossplane/upjet/pkg/resource.ExtractParamPath("arn",true)`,
+			TerraformName: "aws_s3_bucket",
+			Extractor:     `github.com/crossplane/upjet/pkg/resource.ExtractParamPath("arn",true)`,
 		}
 		r.References["application_configuration.sql_application_configuration.input.kinesis_streams_input.resource_arn"] = config.Reference{
 			TerraformName: "aws_kinesis_stream",

--- a/config/kms/config.go
+++ b/config/kms/config.go
@@ -14,36 +14,36 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_kms_alias", func(r *config.Resource) {
 		r.References["target_key_id"] = config.Reference{
-			Type: "Key",
+			TerraformName: "aws_kms_key",
 		}
 		r.UseAsync = true
 	})
 
 	p.AddResourceConfigurator("aws_kms_ciphertext", func(r *config.Resource) {
 		r.References["key_id"] = config.Reference{
-			Type: "Key",
+			TerraformName: "aws_kms_key",
 		}
 		r.UseAsync = true
 	})
 
 	p.AddResourceConfigurator("aws_kms_grant", func(r *config.Resource) {
 		r.References["key_id"] = config.Reference{
-			Type:      "Key",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_kms_key",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 
 	p.AddResourceConfigurator("aws_kms_replica_key", func(r *config.Resource) {
 		r.References["primary_key_arn"] = config.Reference{
-			Type:      "Key",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_kms_key",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 
 	p.AddResourceConfigurator("aws_kms_replica_external_key", func(r *config.Resource) {
 		r.References["primary_key_arn"] = config.Reference{
-			Type:      "ExternalKey",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_kms_external_key",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 }

--- a/config/lambda/config.go
+++ b/config/lambda/config.go
@@ -14,21 +14,21 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_lambda_alias", func(r *config.Resource) {
 		r.References["function_name"] = config.Reference{
-			Type: "Function",
+			TerraformName: "aws_lambda_function",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_lambda_code_signing_config", func(r *config.Resource) {
 		r.References["allowed_publishers.signing_profile_version_arns"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/signer/v1beta1.SigningProfile",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_signer_signing_profile",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 
 	p.AddResourceConfigurator("aws_lambda_event_source_mapping", func(r *config.Resource) {
 		r.References["function_name"] = config.Reference{
-			Type:      "Function",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_lambda_function",
+			Extractor:     common.PathARNExtractor,
 		}
 		delete(r.References, "event_source_arn")
 		// It can be fulfilled by multiple types.
@@ -44,19 +44,19 @@ func Configure(p *config.Provider) {
 	// a future PR.
 	p.AddResourceConfigurator("aws_lambda_function", func(r *config.Resource) {
 		r.References["s3_bucket"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/s3/v1beta1.Bucket",
+			TerraformName: "aws_s3_bucket",
 		}
 		r.References["role"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_role",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.References["vpc_config.security_group_ids"] = config.Reference{
-			Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup",
+			TerraformName:     "aws_security_group",
 			RefFieldName:      "SecurityGroupIDRefs",
 			SelectorFieldName: "SecurityGroupIDSelector",
 		}
 		r.References["vpc_config.subnet_ids"] = config.Reference{
-			Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+			TerraformName:     "aws_subnet",
 			RefFieldName:      "SubnetIDRefs",
 			SelectorFieldName: "SubnetIDSelector",
 		}
@@ -72,12 +72,12 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_lambda_function_event_invoke_config", func(r *config.Resource) {
 		r.References["destination_config.on_failure.destination"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/sqs/v1beta1.Queue",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_sqs_queue",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.References["destination_config.on_success.destination"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/sns/v1beta1.Topic",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_sns_topic",
+			Extractor:     common.PathARNExtractor,
 		}
 		delete(r.References, "function_name")
 		delete(r.References, "qualifier")
@@ -85,13 +85,13 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_lambda_function_url", func(r *config.Resource) {
 		r.References["function_name"] = config.Reference{
-			Type: "Function",
+			TerraformName: "aws_lambda_function",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_lambda_invocation", func(r *config.Resource) {
 		r.References["function_name"] = config.Reference{
-			Type: "Function",
+			TerraformName: "aws_lambda_function",
 		}
 	})
 
@@ -100,10 +100,10 @@ func Configure(p *config.Provider) {
 			IgnoredFields: []string{"statement_id_prefix"},
 		}
 		r.References["function_name"] = config.Reference{
-			Type: "Function",
+			TerraformName: "aws_lambda_function",
 		}
 		r.References["qualifier"] = config.Reference{
-			Type: "Alias",
+			TerraformName: "aws_lambda_alias",
 		}
 		delete(r.References, "source_arn")
 	})

--- a/config/licensemanager/config.go
+++ b/config/licensemanager/config.go
@@ -14,8 +14,8 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_licensemanager_association", func(r *config.Resource) {
 		r.References["license_configuration_arn"] = config.Reference{
-			Type:      "LicenseConfiguration",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_licensemanager_license_configuration",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 }

--- a/config/mq/config.go
+++ b/config/mq/config.go
@@ -14,7 +14,7 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_mq_broker", func(r *config.Resource) {
 		r.References["security_groups"] = config.Reference{
-			Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup",
+			TerraformName:     "aws_security_group",
 			RefFieldName:      "SecurityGroupRefs",
 			SelectorFieldName: "SecurityGroupSelector",
 		}

--- a/config/neptune/config.go
+++ b/config/neptune/config.go
@@ -13,39 +13,39 @@ func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_neptune_cluster", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["snapshot_identifier"] = config.Reference{
-			Type: "ClusterSnapshot",
+			TerraformName: "aws_neptune_cluster_snapshot",
 		}
 		r.References["replication_source_identifier"] = config.Reference{
-			Type: "Cluster",
+			TerraformName: "aws_neptune_cluster",
 		}
 		r.References["neptune_subnet_group_name"] = config.Reference{
-			Type: "SubnetGroup",
+			TerraformName: "aws_neptune_subnet_group",
 		}
 		r.References["neptune_cluster_parameter_group_name"] = config.Reference{
-			Type: "ClusterParameterGroup",
+			TerraformName: "aws_neptune_cluster_parameter_group",
 		}
 	})
 	p.AddResourceConfigurator("aws_neptune_cluster_endpoint", func(r *config.Resource) {
 		r.References["cluster_identifier"] = config.Reference{
-			Type: "Cluster",
+			TerraformName: "aws_neptune_cluster",
 		}
 	})
 	p.AddResourceConfigurator("aws_neptune_cluster_instance", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["cluster_identifier"] = config.Reference{
-			Type: "Cluster",
+			TerraformName: "aws_neptune_cluster",
 		}
 		r.References["neptune_parameter_group_name"] = config.Reference{
-			Type: "ParameterGroup",
+			TerraformName: "aws_neptune_parameter_group",
 		}
 		r.References["neptune_subnet_group_name"] = config.Reference{
-			Type: "SubnetGroup",
+			TerraformName: "aws_neptune_subnet_group",
 		}
 	})
 	p.AddResourceConfigurator("aws_neptune_cluster_snapshot", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["db_cluster_identifier"] = config.Reference{
-			Type: "Cluster",
+			TerraformName: "aws_neptune_cluster",
 		}
 	})
 }

--- a/config/networkmanager/config.go
+++ b/config/networkmanager/config.go
@@ -14,26 +14,26 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_networkmanager_link", func(r *config.Resource) {
 		r.References["site_id"] = config.Reference{
-			Type: "Site",
+			TerraformName: "aws_networkmanager_site",
 		}
 	})
 	p.AddResourceConfigurator("aws_networkmanager_link_association", func(r *config.Resource) {
 		r.References["device_id"] = config.Reference{
-			Type: "Device",
+			TerraformName: "aws_networkmanager_device",
 		}
 	})
 	p.AddResourceConfigurator("aws_networkmanager_vpc_attachment", func(r *config.Resource) {
 		r.References["subnet_arns"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_subnet",
+			Extractor:     common.PathARNExtractor,
 		}
 		r.References["core_network_id"] = config.Reference{
-			Type: "CoreNetwork",
+			TerraformName: "aws_networkmanager_core_network",
 		}
 	})
 	p.AddResourceConfigurator("aws_networkmanager_connect_attachment", func(r *config.Resource) {
 		r.References["core_network_id"] = config.Reference{
-			Type: "CoreNetwork",
+			TerraformName: "aws_networkmanager_core_network",
 		}
 	})
 }

--- a/config/networkmanager/config.go
+++ b/config/networkmanager/config.go
@@ -22,11 +22,6 @@ func Configure(p *config.Provider) {
 			Type: "Device",
 		}
 	})
-	p.AddResourceConfigurator("aws_networkmanager_site_to_site_vpn_attachment", func(r *config.Resource) {
-		r.References["core_network_id"] = config.Reference{
-			Type: "CoreNetwork",
-		}
-	})
 	p.AddResourceConfigurator("aws_networkmanager_vpc_attachment", func(r *config.Resource) {
 		r.References["subnet_arns"] = config.Reference{
 			Type:      "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",

--- a/config/opensearch/config.go
+++ b/config/opensearch/config.go
@@ -15,7 +15,7 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_opensearch_domain_policy", func(r *config.Resource) {
 		r.References["domain_name"] = config.Reference{
-			Type: "Domain",
+			TerraformName: "aws_opensearch_domain",
 		}
 		r.UseAsync = true
 	})

--- a/config/opsworks/config.go
+++ b/config/opsworks/config.go
@@ -10,13 +10,13 @@ import "github.com/crossplane/upjet/pkg/config"
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_opsworks_stack", func(r *config.Resource) {
 		r.References["default_subnet_id"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+			TerraformName: "aws_subnet",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_opsworks_instance", func(r *config.Resource) {
 		r.References["layer_ids"] = config.Reference{
-			Type: "CustomLayer",
+			TerraformName: "aws_opsworks_custom_layer",
 		}
 	})
 }

--- a/config/organization/config.go
+++ b/config/organization/config.go
@@ -17,7 +17,7 @@ func Configure(p *config.Provider) {
 	})
 	p.AddResourceConfigurator("aws_organizations_delegated_administrator", func(r *config.Resource) {
 		r.References["account_id"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/organizations/v1beta1.Account",
+			TerraformName: "aws_organizations_account",
 		}
 	})
 	// We are deleting this reference as we have three different types: Organization Account,

--- a/config/overrides.go
+++ b/config/overrides.go
@@ -111,56 +111,56 @@ func KnownReferencers() config.ResourceOption { //nolint:gocyclo
 			switch {
 			case strings.HasSuffix(k, "role_arn"):
 				r.References[k] = config.Reference{
-					Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-					Extractor: common.PathARNExtractor,
+					TerraformName: "aws_iam_role",
+					Extractor:     common.PathARNExtractor,
 				}
 			case strings.HasSuffix(k, "security_group_ids"):
 				r.References[k] = config.Reference{
-					Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup",
+					TerraformName:     "aws_security_group",
 					RefFieldName:      name.NewFromSnake(strings.TrimSuffix(k, "s")).Camel + "Refs",
 					SelectorFieldName: name.NewFromSnake(strings.TrimSuffix(k, "s")).Camel + "Selector",
 				}
 			case r.ShortGroup == "glue" && k == "database_name":
 				r.References["database_name"] = config.Reference{
-					Type: "github.com/upbound/provider-aws/apis/glue/v1beta1.CatalogDatabase",
+					TerraformName: "aws_glue_catalog_database",
 				}
 			}
 			switch k {
 			case "vpc_id":
 				r.References["vpc_id"] = config.Reference{
-					Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.VPC",
+					TerraformName: "aws_vpc",
 				}
 			case "subnet_ids":
 				r.References["subnet_ids"] = config.Reference{
-					Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+					TerraformName:     "aws_subnet",
 					RefFieldName:      "SubnetIDRefs",
 					SelectorFieldName: "SubnetIDSelector",
 				}
 			case "subnet_id":
 				r.References["subnet_id"] = config.Reference{
-					Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.Subnet",
+					TerraformName: "aws_subnet",
 				}
 			case "iam_roles":
 				r.References["iam_roles"] = config.Reference{
-					Type:              "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
+					TerraformName:     "aws_iam_role",
 					RefFieldName:      "IAMRoleRefs",
 					SelectorFieldName: "IAMRoleSelector",
 				}
 			case "security_group_id":
 				r.References["security_group_id"] = config.Reference{
-					Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup",
+					TerraformName: "aws_security_group",
 				}
 			case "kms_key_id":
 				r.References["kms_key_id"] = config.Reference{
-					Type: "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
+					TerraformName: "aws_kms_key",
 				}
 			case "kms_key_arn":
 				r.References["kms_key_arn"] = config.Reference{
-					Type: "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
+					TerraformName: "aws_kms_key",
 				}
 			case "kms_key":
 				r.References["kms_key"] = config.Reference{
-					Type: "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
+					TerraformName: "aws_kms_key",
 				}
 			}
 		}

--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -84,7 +84,7 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_rds_cluster_instance", func(r *config.Resource) {
 		r.References["restore_to_point_in_time.source_db_instance_identifier"] = config.Reference{
-			Type: "Instance",
+			TerraformName: "aws_db_instance",
 		}
 		r.References["s3_import.bucket_name"] = config.Reference{
 			Type: "github.com/upbound/provider-aws/apis/s3/v1beta1.Bucket",

--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -21,13 +21,13 @@ func Configure(p *config.Provider) {
 		// Mutually exclusive with aws_rds_cluster_role_association
 		config.MoveToStatus(r.TerraformResource, "iam_roles")
 		r.References["s3_import.bucket_name"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/s3/v1beta1.Bucket",
+			TerraformName: "aws_s3_bucket",
 		}
 		r.References["restore_to_point_in_time.source_cluster_identifier"] = config.Reference{
-			Type: "Cluster",
+			TerraformName: "aws_rds_cluster",
 		}
 		r.References["db_subnet_group_name"] = config.Reference{
-			Type: "SubnetGroup",
+			TerraformName: "aws_db_subnet_group",
 		}
 		r.References["db_cluster_parameter_group_name"] = config.Reference{
 			TerraformName: "aws_rds_cluster_parameter_group",
@@ -87,19 +87,19 @@ func Configure(p *config.Provider) {
 			TerraformName: "aws_db_instance",
 		}
 		r.References["s3_import.bucket_name"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/s3/v1beta1.Bucket",
+			TerraformName: "aws_s3_bucket",
 		}
 		r.References["kms_key_id"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
+			TerraformName: "aws_kms_key",
 		}
 		r.References["performance_insights_kms_key_id"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
+			TerraformName: "aws_kms_key",
 		}
 		r.References["restore_to_point_in_time.source_cluster_identifier"] = config.Reference{
-			Type: "Cluster",
+			TerraformName: "aws_rds_cluster",
 		}
 		r.References["security_group_names"] = config.Reference{
-			Type:              "github.com/upbound/provider-aws/apis/ec2/v1beta1.SecurityGroup",
+			TerraformName:     "aws_security_group",
 			RefFieldName:      "SecurityGroupNameRefs",
 			SelectorFieldName: "SecurityGroupNameSelector",
 		}
@@ -107,7 +107,7 @@ func Configure(p *config.Provider) {
 			TerraformName: "aws_db_parameter_group",
 		}
 		r.References["db_subnet_group_name"] = config.Reference{
-			Type: "SubnetGroup",
+			TerraformName: "aws_db_subnet_group",
 		}
 		delete(r.References, "engine")
 		delete(r.References, "engine_version")

--- a/config/rolesanywhere/config.go
+++ b/config/rolesanywhere/config.go
@@ -14,8 +14,8 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_rolesanywhere_profile", func(r *config.Resource) {
 		r.References["role_arns"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_role",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 }

--- a/config/route53/config.go
+++ b/config/route53/config.go
@@ -12,35 +12,35 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_route53_traffic_policy_instance", func(r *config.Resource) {
 		r.References["hosted_zone_id"] = config.Reference{
-			Type: "Zone",
+			TerraformName: "aws_route53_zone",
 		}
 		r.References["traffic_policy_id"] = config.Reference{
-			Type: "TrafficPolicy",
+			TerraformName: "aws_route53_traffic_policy",
 		}
 	})
 	p.AddResourceConfigurator("aws_route53_hosted_zone_dnssec", func(r *config.Resource) {
 		r.References["hosted_zone_id"] = config.Reference{
-			Type: "Zone",
+			TerraformName: "aws_route53_zone",
 		}
 	})
 	p.AddResourceConfigurator("aws_route53_record", func(r *config.Resource) {
 		r.References["zone_id"] = config.Reference{
-			Type: "Zone",
+			TerraformName: "aws_route53_zone",
 		}
 		r.References["health_check_id"] = config.Reference{
-			Type: "HealthCheck",
+			TerraformName: "aws_route53_health_check",
 		}
 		delete(r.References, "alias.name")
 		delete(r.References, "alias.zone_id")
 	})
 	p.AddResourceConfigurator("aws_route53_vpc_association_authorization", func(r *config.Resource) {
 		r.References["zone_id"] = config.Reference{
-			Type: "Zone",
+			TerraformName: "aws_route53_zone",
 		}
 	})
 	p.AddResourceConfigurator("aws_route53_zone", func(r *config.Resource) {
 		r.References["delegation_set_id"] = config.Reference{
-			Type: "DelegationSet",
+			TerraformName: "aws_route53_delegation_set",
 		}
 		r.UseAsync = true
 	})

--- a/config/route53/config.go
+++ b/config/route53/config.go
@@ -23,20 +23,6 @@ func Configure(p *config.Provider) {
 			Type: "Zone",
 		}
 	})
-	p.AddResourceConfigurator("aws_route53_key_signing_key", func(r *config.Resource) {
-		r.References["hosted_zone_id"] = config.Reference{
-			Type: "Zone",
-		}
-		r.References["key_management_service_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
-			Extractor: "github.com/upbound/provider-aws/apis/kms/v1beta1.KMSKeyARN()",
-		}
-	})
-	p.AddResourceConfigurator("aws_route53_query_log", func(r *config.Resource) {
-		r.References["hosted_zone_id"] = config.Reference{
-			Type: "Zone",
-		}
-	})
 	p.AddResourceConfigurator("aws_route53_record", func(r *config.Resource) {
 		r.References["zone_id"] = config.Reference{
 			Type: "Zone",

--- a/config/s3/config.go
+++ b/config/s3/config.go
@@ -96,25 +96,25 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_s3_bucket_analytics_configuration", func(r *config.Resource) {
 		r.References["storage_class_analysis.data_export.destination.s3_bucket_destination.bucket_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/s3/v1beta1.Bucket",
-			Extractor: `github.com/crossplane/upjet/pkg/resource.ExtractParamPath("arn",true)`,
+			TerraformName: "aws_s3_bucket",
+			Extractor:     `github.com/crossplane/upjet/pkg/resource.ExtractParamPath("arn",true)`,
 		}
 	})
 
 	p.AddResourceConfigurator("aws_s3_bucket_replication_configuration", func(r *config.Resource) {
 		r.References["rule.destination.bucket"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/s3/v1beta1.Bucket",
-			Extractor: `github.com/crossplane/upjet/pkg/resource.ExtractParamPath("arn",true)`,
+			TerraformName: "aws_s3_bucket",
+			Extractor:     `github.com/crossplane/upjet/pkg/resource.ExtractParamPath("arn",true)`,
 		}
 		r.References["rule.destination.encryption_configuration.replica_kms_key_id"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/kms/v1beta1.Key",
+			TerraformName: "aws_kms_key",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_s3_bucket_inventory", func(r *config.Resource) {
 		r.References["destination.bucket.bucket_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/s3/v1beta1.Bucket",
-			Extractor: `github.com/crossplane/upjet/pkg/resource.ExtractParamPath("arn",true)`,
+			TerraformName: "aws_s3_bucket",
+			Extractor:     `github.com/crossplane/upjet/pkg/resource.ExtractParamPath("arn",true)`,
 		}
 	})
 }

--- a/config/servicecatalog/config.go
+++ b/config/servicecatalog/config.go
@@ -28,38 +28,38 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_servicecatalog_tag_option_resource_association", func(r *config.Resource) {
 		r.References["resource_id"] = config.Reference{
-			Type: "Product",
+			TerraformName: "aws_servicecatalog_product",
 		}
 		r.References["tag_option_id"] = config.Reference{
-			Type: "TagOption",
+			TerraformName: "aws_servicecatalog_tag_option",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_servicecatalog_product_portfolio_association", func(r *config.Resource) {
 		r.References["product_id"] = config.Reference{
-			Type: "Product",
+			TerraformName: "aws_servicecatalog_product",
 		}
 		r.References["portfolio_id"] = config.Reference{
-			Type: "Portfolio",
+			TerraformName: "aws_servicecatalog_portfolio",
 		}
 	})
 
 	p.AddResourceConfigurator("aws_servicecatalog_principal_portfolio_association", func(r *config.Resource) {
 		r.References["portfolio_id"] = config.Reference{
-			Type: "Portfolio",
+			TerraformName: "aws_servicecatalog_portfolio",
 		}
 		r.References["principal_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.User",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_user",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 
 	p.AddResourceConfigurator("aws_servicecatalog_budget_resource_association", func(r *config.Resource) {
 		r.References["resource_id"] = config.Reference{
-			Type: "Product",
+			TerraformName: "aws_servicecatalog_product",
 		}
 		r.References["budget_name"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/budgets/v1beta1.Budget",
+			TerraformName: "aws_budgets_budget",
 		}
 	})
 }

--- a/config/servicediscovery/config.go
+++ b/config/servicediscovery/config.go
@@ -10,7 +10,7 @@ import "github.com/crossplane/upjet/pkg/config"
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_service_discovery_private_dns_namespace", func(r *config.Resource) {
 		r.References["vpc"] = config.Reference{
-			Type: "github.com/upbound/provider-aws/apis/ec2/v1beta1.VPC",
+			TerraformName: "aws_vpc",
 		}
 	})
 }

--- a/config/sfn/config.go
+++ b/config/sfn/config.go
@@ -14,8 +14,8 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_sfn_state_machine", func(r *config.Resource) {
 		r.References["role_arn"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_role",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 }

--- a/config/sqs/config.go
+++ b/config/sqs/config.go
@@ -14,8 +14,8 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_sqs_queue_policy", func(r *config.Resource) {
 		r.References["queue_url"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/sqs/v1beta1.Queue",
-			Extractor: common.PathTerraformIDExtractor,
+			TerraformName: "aws_sqs_queue",
+			Extractor:     common.PathTerraformIDExtractor,
 		}
 	})
 
@@ -34,15 +34,15 @@ func Configure(p *config.Provider) {
 
 	p.AddResourceConfigurator("aws_sqs_queue_redrive_policy", func(r *config.Resource) {
 		r.References["queue_url"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/sqs/v1beta1.Queue",
-			Extractor: common.PathTerraformIDExtractor,
+			TerraformName: "aws_sqs_queue",
+			Extractor:     common.PathTerraformIDExtractor,
 		}
 	})
 
 	p.AddResourceConfigurator("aws_sqs_queue_redrive_allow_policy", func(r *config.Resource) {
 		r.References["queue_url"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/sqs/v1beta1.Queue",
-			Extractor: common.PathTerraformIDExtractor,
+			TerraformName: "aws_sqs_queue",
+			Extractor:     common.PathTerraformIDExtractor,
 		}
 	})
 }

--- a/config/transfer/config.go
+++ b/config/transfer/config.go
@@ -14,11 +14,11 @@ import (
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_transfer_user", func(r *config.Resource) {
 		r.References["server_id"] = config.Reference{
-			Type: "Server",
+			TerraformName: "aws_transfer_server",
 		}
 		r.References["role"] = config.Reference{
-			Type:      "github.com/upbound/provider-aws/apis/iam/v1beta1.Role",
-			Extractor: common.PathARNExtractor,
+			TerraformName: "aws_iam_role",
+			Extractor:     common.PathARNExtractor,
 		}
 	})
 }

--- a/package/crds/acm.aws.upbound.io_certificatevalidations.yaml
+++ b/package/crds/acm.aws.upbound.io_certificatevalidations.yaml
@@ -77,7 +77,7 @@ spec:
                     description: ARN of the certificate that is being validated.
                     type: string
                   certificateArnRef:
-                    description: Reference to a Certificate to populate certificateArn.
+                    description: Reference to a Certificate in acm to populate certificateArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +111,7 @@ spec:
                     - name
                     type: object
                   certificateArnSelector:
-                    description: Selector for a Certificate to populate certificateArn.
+                    description: Selector for a Certificate in acm to populate certificateArn.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -184,7 +184,7 @@ spec:
                     description: ARN of the certificate that is being validated.
                     type: string
                   certificateArnRef:
-                    description: Reference to a Certificate to populate certificateArn.
+                    description: Reference to a Certificate in acm to populate certificateArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -218,7 +218,7 @@ spec:
                     - name
                     type: object
                   certificateArnSelector:
-                    description: Selector for a Certificate to populate certificateArn.
+                    description: Selector for a Certificate in acm to populate certificateArn.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/acmpca.aws.upbound.io_certificateauthoritycertificates.yaml
+++ b/package/crds/acmpca.aws.upbound.io_certificateauthoritycertificates.yaml
@@ -79,7 +79,8 @@ spec:
                     description: ARN of the Certificate Authority.
                     type: string
                   certificateAuthorityArnRef:
-                    description: Reference to a CertificateAuthority to populate certificateAuthorityArn.
+                    description: Reference to a CertificateAuthority in acmpca to
+                      populate certificateAuthorityArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +114,8 @@ spec:
                     - name
                     type: object
                   certificateAuthorityArnSelector:
-                    description: Selector for a CertificateAuthority to populate certificateAuthorityArn.
+                    description: Selector for a CertificateAuthority in acmpca to
+                      populate certificateAuthorityArn.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -212,7 +214,8 @@ spec:
                     description: ARN of the Certificate Authority.
                     type: string
                   certificateAuthorityArnRef:
-                    description: Reference to a CertificateAuthority to populate certificateAuthorityArn.
+                    description: Reference to a CertificateAuthority in acmpca to
+                      populate certificateAuthorityArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -246,7 +249,8 @@ spec:
                     - name
                     type: object
                   certificateAuthorityArnSelector:
-                    description: Selector for a CertificateAuthority to populate certificateAuthorityArn.
+                    description: Selector for a CertificateAuthority in acmpca to
+                      populate certificateAuthorityArn.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/acmpca.aws.upbound.io_certificates.yaml
+++ b/package/crds/acmpca.aws.upbound.io_certificates.yaml
@@ -82,7 +82,8 @@ spec:
                     description: ARN of the certificate authority.
                     type: string
                   certificateAuthorityArnRef:
-                    description: Reference to a CertificateAuthority to populate certificateAuthorityArn.
+                    description: Reference to a CertificateAuthority in acmpca to
+                      populate certificateAuthorityArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -116,7 +117,8 @@ spec:
                     - name
                     type: object
                   certificateAuthorityArnSelector:
-                    description: Selector for a CertificateAuthority to populate certificateAuthorityArn.
+                    description: Selector for a CertificateAuthority in acmpca to
+                      populate certificateAuthorityArn.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -227,7 +229,8 @@ spec:
                     description: ARN of the certificate authority.
                     type: string
                   certificateAuthorityArnRef:
-                    description: Reference to a CertificateAuthority to populate certificateAuthorityArn.
+                    description: Reference to a CertificateAuthority in acmpca to
+                      populate certificateAuthorityArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -261,7 +264,8 @@ spec:
                     - name
                     type: object
                   certificateAuthorityArnSelector:
-                    description: Selector for a CertificateAuthority to populate certificateAuthorityArn.
+                    description: Selector for a CertificateAuthority in acmpca to
+                      populate certificateAuthorityArn.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apigatewayv2.aws.upbound.io_apimappings.yaml
+++ b/package/crds/apigatewayv2.aws.upbound.io_apimappings.yaml
@@ -77,7 +77,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +111,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -159,7 +159,8 @@ spec:
                       resource to configure a domain name.
                     type: string
                   domainNameRef:
-                    description: Reference to a DomainName to populate domainName.
+                    description: Reference to a DomainName in apigatewayv2 to populate
+                      domainName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -193,7 +194,8 @@ spec:
                     - name
                     type: object
                   domainNameSelector:
-                    description: Selector for a DomainName to populate domainName.
+                    description: Selector for a DomainName in apigatewayv2 to populate
+                      domainName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -241,7 +243,8 @@ spec:
                       to configure an API stage.
                     type: string
                   stageRef:
-                    description: Reference to a Stage to populate stage.
+                    description: Reference to a Stage in apigatewayv2 to populate
+                      stage.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -275,7 +278,8 @@ spec:
                     - name
                     type: object
                   stageSelector:
-                    description: Selector for a Stage to populate stage.
+                    description: Selector for a Stage in apigatewayv2 to populate
+                      stage.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -334,7 +338,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -368,7 +372,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -416,7 +420,8 @@ spec:
                       resource to configure a domain name.
                     type: string
                   domainNameRef:
-                    description: Reference to a DomainName to populate domainName.
+                    description: Reference to a DomainName in apigatewayv2 to populate
+                      domainName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -450,7 +455,8 @@ spec:
                     - name
                     type: object
                   domainNameSelector:
-                    description: Selector for a DomainName to populate domainName.
+                    description: Selector for a DomainName in apigatewayv2 to populate
+                      domainName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -494,7 +500,8 @@ spec:
                       to configure an API stage.
                     type: string
                   stageRef:
-                    description: Reference to a Stage to populate stage.
+                    description: Reference to a Stage in apigatewayv2 to populate
+                      stage.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -528,7 +535,8 @@ spec:
                     - name
                     type: object
                   stageSelector:
-                    description: Selector for a Stage to populate stage.
+                    description: Selector for a Stage in apigatewayv2 to populate
+                      stage.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apigatewayv2.aws.upbound.io_authorizers.yaml
+++ b/package/crds/apigatewayv2.aws.upbound.io_authorizers.yaml
@@ -77,7 +77,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +111,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -315,7 +315,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -349,7 +349,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apigatewayv2.aws.upbound.io_deployments.yaml
+++ b/package/crds/apigatewayv2.aws.upbound.io_deployments.yaml
@@ -77,7 +77,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +111,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -178,7 +178,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -212,7 +212,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apigatewayv2.aws.upbound.io_integrationresponses.yaml
+++ b/package/crds/apigatewayv2.aws.upbound.io_integrationresponses.yaml
@@ -77,7 +77,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +111,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -158,7 +158,8 @@ spec:
                     description: Identifier of the aws_apigatewayv2_integration.
                     type: string
                   integrationIdRef:
-                    description: Reference to a Integration to populate integrationId.
+                    description: Reference to a Integration in apigatewayv2 to populate
+                      integrationId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -192,7 +193,8 @@ spec:
                     - name
                     type: object
                   integrationIdSelector:
-                    description: Selector for a Integration to populate integrationId.
+                    description: Selector for a Integration in apigatewayv2 to populate
+                      integrationId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -270,7 +272,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -304,7 +306,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -351,7 +353,8 @@ spec:
                     description: Identifier of the aws_apigatewayv2_integration.
                     type: string
                   integrationIdRef:
-                    description: Reference to a Integration to populate integrationId.
+                    description: Reference to a Integration in apigatewayv2 to populate
+                      integrationId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -385,7 +388,8 @@ spec:
                     - name
                     type: object
                   integrationIdSelector:
-                    description: Selector for a Integration to populate integrationId.
+                    description: Selector for a Integration in apigatewayv2 to populate
+                      integrationId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apigatewayv2.aws.upbound.io_integrations.yaml
+++ b/package/crds/apigatewayv2.aws.upbound.io_integrations.yaml
@@ -77,7 +77,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +111,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -505,7 +505,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -539,7 +539,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apigatewayv2.aws.upbound.io_models.yaml
+++ b/package/crds/apigatewayv2.aws.upbound.io_models.yaml
@@ -77,7 +77,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +111,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -191,7 +191,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -225,7 +225,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apigatewayv2.aws.upbound.io_routeresponses.yaml
+++ b/package/crds/apigatewayv2.aws.upbound.io_routeresponses.yaml
@@ -77,7 +77,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +111,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -167,7 +167,8 @@ spec:
                     description: Identifier of the aws_apigatewayv2_route.
                     type: string
                   routeIdRef:
-                    description: Reference to a Route to populate routeId.
+                    description: Reference to a Route in apigatewayv2 to populate
+                      routeId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -201,7 +202,8 @@ spec:
                     - name
                     type: object
                   routeIdSelector:
-                    description: Selector for a Route to populate routeId.
+                    description: Selector for a Route in apigatewayv2 to populate
+                      routeId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -263,7 +265,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -297,7 +299,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -349,7 +351,8 @@ spec:
                     description: Identifier of the aws_apigatewayv2_route.
                     type: string
                   routeIdRef:
-                    description: Reference to a Route to populate routeId.
+                    description: Reference to a Route in apigatewayv2 to populate
+                      routeId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -383,7 +386,8 @@ spec:
                     - name
                     type: object
                   routeIdSelector:
-                    description: Selector for a Route to populate routeId.
+                    description: Selector for a Route in apigatewayv2 to populate
+                      routeId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apigatewayv2.aws.upbound.io_routes.yaml
+++ b/package/crds/apigatewayv2.aws.upbound.io_routes.yaml
@@ -77,7 +77,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +111,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -174,7 +174,8 @@ spec:
                       to be associated with this route.
                     type: string
                   authorizerIdRef:
-                    description: Reference to a Authorizer to populate authorizerId.
+                    description: Reference to a Authorizer in apigatewayv2 to populate
+                      authorizerId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -208,7 +209,8 @@ spec:
                     - name
                     type: object
                   authorizerIdSelector:
-                    description: Selector for a Authorizer to populate authorizerId.
+                    description: Selector for a Authorizer in apigatewayv2 to populate
+                      authorizerId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -390,7 +392,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -424,7 +426,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -487,7 +489,8 @@ spec:
                       to be associated with this route.
                     type: string
                   authorizerIdRef:
-                    description: Reference to a Authorizer to populate authorizerId.
+                    description: Reference to a Authorizer in apigatewayv2 to populate
+                      authorizerId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -521,7 +524,8 @@ spec:
                     - name
                     type: object
                   authorizerIdSelector:
-                    description: Selector for a Authorizer to populate authorizerId.
+                    description: Selector for a Authorizer in apigatewayv2 to populate
+                      authorizerId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/apigatewayv2.aws.upbound.io_stages.yaml
+++ b/package/crds/apigatewayv2.aws.upbound.io_stages.yaml
@@ -93,7 +93,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -127,7 +127,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -206,7 +206,8 @@ spec:
                       resource to configure a deployment.
                     type: string
                   deploymentIdRef:
-                    description: Reference to a Deployment to populate deploymentId.
+                    description: Reference to a Deployment in apigatewayv2 to populate
+                      deploymentId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -240,7 +241,8 @@ spec:
                     - name
                     type: object
                   deploymentIdSelector:
-                    description: Selector for a Deployment to populate deploymentId.
+                    description: Selector for a Deployment in apigatewayv2 to populate
+                      deploymentId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -364,7 +366,7 @@ spec:
                     description: API identifier.
                     type: string
                   apiIdRef:
-                    description: Reference to a API to populate apiId.
+                    description: Reference to a API in apigatewayv2 to populate apiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -398,7 +400,7 @@ spec:
                     - name
                     type: object
                   apiIdSelector:
-                    description: Selector for a API to populate apiId.
+                    description: Selector for a API in apigatewayv2 to populate apiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -477,7 +479,8 @@ spec:
                       resource to configure a deployment.
                     type: string
                   deploymentIdRef:
-                    description: Reference to a Deployment to populate deploymentId.
+                    description: Reference to a Deployment in apigatewayv2 to populate
+                      deploymentId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -511,7 +514,8 @@ spec:
                     - name
                     type: object
                   deploymentIdSelector:
-                    description: Selector for a Deployment to populate deploymentId.
+                    description: Selector for a Deployment in apigatewayv2 to populate
+                      deploymentId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/autoscaling.aws.upbound.io_attachments.yaml
+++ b/package/crds/autoscaling.aws.upbound.io_attachments.yaml
@@ -1024,7 +1024,8 @@ spec:
                     description: Name of ASG to associate with the ELB.
                     type: string
                   autoscalingGroupNameRef:
-                    description: Reference to a AutoscalingGroup to populate autoscalingGroupName.
+                    description: Reference to a AutoscalingGroup in autoscaling to
+                      populate autoscalingGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1058,7 +1059,8 @@ spec:
                     - name
                     type: object
                   autoscalingGroupNameSelector:
-                    description: Selector for a AutoscalingGroup to populate autoscalingGroupName.
+                    description: Selector for a AutoscalingGroup in autoscaling to
+                      populate autoscalingGroupName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -1277,7 +1279,8 @@ spec:
                     description: Name of ASG to associate with the ELB.
                     type: string
                   autoscalingGroupNameRef:
-                    description: Reference to a AutoscalingGroup to populate autoscalingGroupName.
+                    description: Reference to a AutoscalingGroup in autoscaling to
+                      populate autoscalingGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1311,7 +1314,8 @@ spec:
                     - name
                     type: object
                   autoscalingGroupNameSelector:
-                    description: Selector for a AutoscalingGroup to populate autoscalingGroupName.
+                    description: Selector for a AutoscalingGroup in autoscaling to
+                      populate autoscalingGroupName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/backup.aws.upbound.io_selections.yaml
+++ b/package/crds/backup.aws.upbound.io_selections.yaml
@@ -221,7 +221,7 @@ spec:
                       of resources.
                     type: string
                   planIdRef:
-                    description: Reference to a Plan to populate planId.
+                    description: Reference to a Plan in backup to populate planId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -255,7 +255,7 @@ spec:
                     - name
                     type: object
                   planIdSelector:
-                    description: Selector for a Plan to populate planId.
+                    description: Selector for a Plan in backup to populate planId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -488,7 +488,7 @@ spec:
                       of resources.
                     type: string
                   planIdRef:
-                    description: Reference to a Plan to populate planId.
+                    description: Reference to a Plan in backup to populate planId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -522,7 +522,7 @@ spec:
                     - name
                     type: object
                   planIdSelector:
-                    description: Selector for a Plan to populate planId.
+                    description: Selector for a Plan in backup to populate planId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/backup.aws.upbound.io_vaultlockconfigurations.yaml
+++ b/package/crds/backup.aws.upbound.io_vaultlockconfigurations.yaml
@@ -78,7 +78,7 @@ spec:
                       for.
                     type: string
                   backupVaultNameRef:
-                    description: Reference to a Vault to populate backupVaultName.
+                    description: Reference to a Vault in backup to populate backupVaultName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +112,7 @@ spec:
                     - name
                     type: object
                   backupVaultNameSelector:
-                    description: Selector for a Vault to populate backupVaultName.
+                    description: Selector for a Vault in backup to populate backupVaultName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -189,7 +189,7 @@ spec:
                       for.
                     type: string
                   backupVaultNameRef:
-                    description: Reference to a Vault to populate backupVaultName.
+                    description: Reference to a Vault in backup to populate backupVaultName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -223,7 +223,7 @@ spec:
                     - name
                     type: object
                   backupVaultNameSelector:
-                    description: Selector for a Vault to populate backupVaultName.
+                    description: Selector for a Vault in backup to populate backupVaultName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/backup.aws.upbound.io_vaultnotifications.yaml
+++ b/package/crds/backup.aws.upbound.io_vaultnotifications.yaml
@@ -84,7 +84,7 @@ spec:
                     description: Name of the backup vault to add notifications for.
                     type: string
                   backupVaultNameRef:
-                    description: Reference to a Vault to populate backupVaultName.
+                    description: Reference to a Vault in backup to populate backupVaultName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -118,7 +118,7 @@ spec:
                     - name
                     type: object
                   backupVaultNameSelector:
-                    description: Selector for a Vault to populate backupVaultName.
+                    description: Selector for a Vault in backup to populate backupVaultName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -266,7 +266,7 @@ spec:
                     description: Name of the backup vault to add notifications for.
                     type: string
                   backupVaultNameRef:
-                    description: Reference to a Vault to populate backupVaultName.
+                    description: Reference to a Vault in backup to populate backupVaultName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -300,7 +300,7 @@ spec:
                     - name
                     type: object
                   backupVaultNameSelector:
-                    description: Selector for a Vault to populate backupVaultName.
+                    description: Selector for a Vault in backup to populate backupVaultName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cloudfront.aws.upbound.io_keygroups.yaml
+++ b/package/crds/cloudfront.aws.upbound.io_keygroups.yaml
@@ -77,7 +77,8 @@ spec:
                     description: A comment to describe the key group..
                     type: string
                   itemRefs:
-                    description: References to PublicKey to populate items.
+                    description: References to PublicKey in cloudfront to populate
+                      items.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -114,7 +115,8 @@ spec:
                       type: object
                     type: array
                   itemSelector:
-                    description: Selector for a list of PublicKey to populate items.
+                    description: Selector for a list of PublicKey in cloudfront to
+                      populate items.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -187,7 +189,8 @@ spec:
                     description: A comment to describe the key group..
                     type: string
                   itemRefs:
-                    description: References to PublicKey to populate items.
+                    description: References to PublicKey in cloudfront to populate
+                      items.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -224,7 +227,8 @@ spec:
                       type: object
                     type: array
                   itemSelector:
-                    description: Selector for a list of PublicKey to populate items.
+                    description: Selector for a list of PublicKey in cloudfront to
+                      populate items.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cloudwatchevents.aws.upbound.io_permissions.yaml
+++ b/package/crds/cloudwatchevents.aws.upbound.io_permissions.yaml
@@ -177,7 +177,8 @@ spec:
                       If you omit this, the permissions are set on the default event bus.
                     type: string
                   eventBusNameRef:
-                    description: Reference to a Bus to populate eventBusName.
+                    description: Reference to a Bus in cloudwatchevents to populate
+                      eventBusName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -211,7 +212,8 @@ spec:
                     - name
                     type: object
                   eventBusNameSelector:
-                    description: Selector for a Bus to populate eventBusName.
+                    description: Selector for a Bus in cloudwatchevents to populate
+                      eventBusName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -383,7 +385,8 @@ spec:
                       If you omit this, the permissions are set on the default event bus.
                     type: string
                   eventBusNameRef:
-                    description: Reference to a Bus to populate eventBusName.
+                    description: Reference to a Bus in cloudwatchevents to populate
+                      eventBusName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -417,7 +420,8 @@ spec:
                     - name
                     type: object
                   eventBusNameSelector:
-                    description: Selector for a Bus to populate eventBusName.
+                    description: Selector for a Bus in cloudwatchevents to populate
+                      eventBusName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cloudwatchevents.aws.upbound.io_rules.yaml
+++ b/package/crds/cloudwatchevents.aws.upbound.io_rules.yaml
@@ -82,7 +82,8 @@ spec:
                       If you omit this, the default event bus is used.
                     type: string
                   eventBusNameRef:
-                    description: Reference to a Bus to populate eventBusName.
+                    description: Reference to a Bus in cloudwatchevents to populate
+                      eventBusName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -116,7 +117,8 @@ spec:
                     - name
                     type: object
                   eventBusNameSelector:
-                    description: Selector for a Bus to populate eventBusName.
+                    description: Selector for a Bus in cloudwatchevents to populate
+                      eventBusName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -298,7 +300,8 @@ spec:
                       If you omit this, the default event bus is used.
                     type: string
                   eventBusNameRef:
-                    description: Reference to a Bus to populate eventBusName.
+                    description: Reference to a Bus in cloudwatchevents to populate
+                      eventBusName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -332,7 +335,8 @@ spec:
                     - name
                     type: object
                   eventBusNameSelector:
-                    description: Selector for a Bus to populate eventBusName.
+                    description: Selector for a Bus in cloudwatchevents to populate
+                      eventBusName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cloudwatchevents.aws.upbound.io_targets.yaml
+++ b/package/crds/cloudwatchevents.aws.upbound.io_targets.yaml
@@ -350,7 +350,8 @@ spec:
                       If you omit this, the default event bus is used.
                     type: string
                   eventBusNameRef:
-                    description: Reference to a Bus to populate eventBusName.
+                    description: Reference to a Bus in cloudwatchevents to populate
+                      eventBusName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -384,7 +385,8 @@ spec:
                     - name
                     type: object
                   eventBusNameSelector:
-                    description: Selector for a Bus to populate eventBusName.
+                    description: Selector for a Bus in cloudwatchevents to populate
+                      eventBusName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -1049,7 +1051,8 @@ spec:
                       If you omit this, the default event bus is used.
                     type: string
                   eventBusNameRef:
-                    description: Reference to a Bus to populate eventBusName.
+                    description: Reference to a Bus in cloudwatchevents to populate
+                      eventBusName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1083,7 +1086,8 @@ spec:
                     - name
                     type: object
                   eventBusNameSelector:
-                    description: Selector for a Bus to populate eventBusName.
+                    description: Selector for a Bus in cloudwatchevents to populate
+                      eventBusName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cognitoidp.aws.upbound.io_identityproviders.yaml
+++ b/package/crds/cognitoidp.aws.upbound.io_identityproviders.yaml
@@ -105,7 +105,8 @@ spec:
                     description: The user pool id
                     type: string
                   userPoolIdRef:
-                    description: Reference to a UserPool to populate userPoolId.
+                    description: Reference to a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -139,7 +140,8 @@ spec:
                     - name
                     type: object
                   userPoolIdSelector:
-                    description: Selector for a UserPool to populate userPoolId.
+                    description: Selector for a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -222,7 +224,8 @@ spec:
                     description: The user pool id
                     type: string
                   userPoolIdRef:
-                    description: Reference to a UserPool to populate userPoolId.
+                    description: Reference to a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -256,7 +259,8 @@ spec:
                     - name
                     type: object
                   userPoolIdSelector:
-                    description: Selector for a UserPool to populate userPoolId.
+                    description: Selector for a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cognitoidp.aws.upbound.io_resourceservers.yaml
+++ b/package/crds/cognitoidp.aws.upbound.io_resourceservers.yaml
@@ -98,7 +98,8 @@ spec:
                   userPoolId:
                     type: string
                   userPoolIdRef:
-                    description: Reference to a UserPool to populate userPoolId.
+                    description: Reference to a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -132,7 +133,8 @@ spec:
                     - name
                     type: object
                   userPoolIdSelector:
-                    description: Selector for a UserPool to populate userPoolId.
+                    description: Selector for a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -208,7 +210,8 @@ spec:
                   userPoolId:
                     type: string
                   userPoolIdRef:
-                    description: Reference to a UserPool to populate userPoolId.
+                    description: Reference to a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -242,7 +245,8 @@ spec:
                     - name
                     type: object
                   userPoolIdSelector:
-                    description: Selector for a UserPool to populate userPoolId.
+                    description: Selector for a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cognitoidp.aws.upbound.io_usergroups.yaml
+++ b/package/crds/cognitoidp.aws.upbound.io_usergroups.yaml
@@ -168,7 +168,8 @@ spec:
                     description: The user pool ID.
                     type: string
                   userPoolIdRef:
-                    description: Reference to a UserPool to populate userPoolId.
+                    description: Reference to a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -202,7 +203,8 @@ spec:
                     - name
                     type: object
                   userPoolIdSelector:
-                    description: Selector for a UserPool to populate userPoolId.
+                    description: Selector for a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -348,7 +350,8 @@ spec:
                     description: The user pool ID.
                     type: string
                   userPoolIdRef:
-                    description: Reference to a UserPool to populate userPoolId.
+                    description: Reference to a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -382,7 +385,8 @@ spec:
                     - name
                     type: object
                   userPoolIdSelector:
-                    description: Selector for a UserPool to populate userPoolId.
+                    description: Selector for a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cognitoidp.aws.upbound.io_userpoolclients.yaml
+++ b/package/crds/cognitoidp.aws.upbound.io_userpoolclients.yaml
@@ -386,7 +386,8 @@ spec:
                     description: User pool the client belongs to.
                     type: string
                   userPoolIdRef:
-                    description: Reference to a UserPool to populate userPoolId.
+                    description: Reference to a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -420,7 +421,8 @@ spec:
                     - name
                     type: object
                   userPoolIdSelector:
-                    description: Selector for a UserPool to populate userPoolId.
+                    description: Selector for a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -791,7 +793,8 @@ spec:
                     description: User pool the client belongs to.
                     type: string
                   userPoolIdRef:
-                    description: Reference to a UserPool to populate userPoolId.
+                    description: Reference to a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -825,7 +828,8 @@ spec:
                     - name
                     type: object
                   userPoolIdSelector:
-                    description: Selector for a UserPool to populate userPoolId.
+                    description: Selector for a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cognitoidp.aws.upbound.io_userpooldomains.yaml
+++ b/package/crds/cognitoidp.aws.upbound.io_userpooldomains.yaml
@@ -164,7 +164,8 @@ spec:
                     description: The user pool ID.
                     type: string
                   userPoolIdRef:
-                    description: Reference to a UserPool to populate userPoolId.
+                    description: Reference to a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -198,7 +199,8 @@ spec:
                     - name
                     type: object
                   userPoolIdSelector:
-                    description: Selector for a UserPool to populate userPoolId.
+                    description: Selector for a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -340,7 +342,8 @@ spec:
                     description: The user pool ID.
                     type: string
                   userPoolIdRef:
-                    description: Reference to a UserPool to populate userPoolId.
+                    description: Reference to a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -374,7 +377,8 @@ spec:
                     - name
                     type: object
                   userPoolIdSelector:
-                    description: Selector for a UserPool to populate userPoolId.
+                    description: Selector for a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/cognitoidp.aws.upbound.io_userpooluicustomizations.yaml
+++ b/package/crds/cognitoidp.aws.upbound.io_userpooluicustomizations.yaml
@@ -80,7 +80,8 @@ spec:
                       be used for every client that has no UI customization set previously.
                     type: string
                   clientIdRef:
-                    description: Reference to a UserPoolClient to populate clientId.
+                    description: Reference to a UserPoolClient in cognitoidp to populate
+                      clientId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -114,7 +115,8 @@ spec:
                     - name
                     type: object
                   clientIdSelector:
-                    description: Selector for a UserPoolClient to populate clientId.
+                    description: Selector for a UserPoolClient in cognitoidp to populate
+                      clientId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -171,7 +173,8 @@ spec:
                     description: The user pool ID for the user pool.
                     type: string
                   userPoolIdRef:
-                    description: Reference to a UserPool to populate userPoolId.
+                    description: Reference to a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -205,7 +208,8 @@ spec:
                     - name
                     type: object
                   userPoolIdSelector:
-                    description: Selector for a UserPool to populate userPoolId.
+                    description: Selector for a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -266,7 +270,8 @@ spec:
                       be used for every client that has no UI customization set previously.
                     type: string
                   clientIdRef:
-                    description: Reference to a UserPoolClient to populate clientId.
+                    description: Reference to a UserPoolClient in cognitoidp to populate
+                      clientId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -300,7 +305,8 @@ spec:
                     - name
                     type: object
                   clientIdSelector:
-                    description: Selector for a UserPoolClient to populate clientId.
+                    description: Selector for a UserPoolClient in cognitoidp to populate
+                      clientId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -353,7 +359,8 @@ spec:
                     description: The user pool ID for the user pool.
                     type: string
                   userPoolIdRef:
-                    description: Reference to a UserPool to populate userPoolId.
+                    description: Reference to a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -387,7 +394,8 @@ spec:
                     - name
                     type: object
                   userPoolIdSelector:
-                    description: Selector for a UserPool to populate userPoolId.
+                    description: Selector for a UserPool in cognitoidp to populate
+                      userPoolId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/datasync.aws.upbound.io_tasks.yaml
+++ b/package/crds/datasync.aws.upbound.io_tasks.yaml
@@ -158,7 +158,8 @@ spec:
                       Location.
                     type: string
                   destinationLocationArnRef:
-                    description: Reference to a LocationS3 to populate destinationLocationArn.
+                    description: Reference to a LocationS3 in datasync to populate
+                      destinationLocationArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -192,7 +193,8 @@ spec:
                     - name
                     type: object
                   destinationLocationArnSelector:
-                    description: Selector for a LocationS3 to populate destinationLocationArn.
+                    description: Selector for a LocationS3 in datasync to populate
+                      destinationLocationArn.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -390,7 +392,8 @@ spec:
                     description: Amazon Resource Name (ARN) of source DataSync Location.
                     type: string
                   sourceLocationArnRef:
-                    description: Reference to a LocationS3 to populate sourceLocationArn.
+                    description: Reference to a LocationS3 in datasync to populate
+                      sourceLocationArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -424,7 +427,8 @@ spec:
                     - name
                     type: object
                   sourceLocationArnSelector:
-                    description: Selector for a LocationS3 to populate sourceLocationArn.
+                    description: Selector for a LocationS3 in datasync to populate
+                      sourceLocationArn.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -649,7 +653,8 @@ spec:
                       Location.
                     type: string
                   destinationLocationArnRef:
-                    description: Reference to a LocationS3 to populate destinationLocationArn.
+                    description: Reference to a LocationS3 in datasync to populate
+                      destinationLocationArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -683,7 +688,8 @@ spec:
                     - name
                     type: object
                   destinationLocationArnSelector:
-                    description: Selector for a LocationS3 to populate destinationLocationArn.
+                    description: Selector for a LocationS3 in datasync to populate
+                      destinationLocationArn.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -877,7 +883,8 @@ spec:
                     description: Amazon Resource Name (ARN) of source DataSync Location.
                     type: string
                   sourceLocationArnRef:
-                    description: Reference to a LocationS3 to populate sourceLocationArn.
+                    description: Reference to a LocationS3 in datasync to populate
+                      sourceLocationArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -911,7 +918,8 @@ spec:
                     - name
                     type: object
                   sourceLocationArnSelector:
-                    description: Selector for a LocationS3 to populate sourceLocationArn.
+                    description: Selector for a LocationS3 in datasync to populate
+                      sourceLocationArn.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/directconnect.aws.upbound.io_hostedprivatevirtualinterfaceaccepters.yaml
+++ b/package/crds/directconnect.aws.upbound.io_hostedprivatevirtualinterfaceaccepters.yaml
@@ -94,8 +94,8 @@ spec:
                       accept.
                     type: string
                   virtualInterfaceIdRef:
-                    description: Reference to a HostedPrivateVirtualInterface to populate
-                      virtualInterfaceId.
+                    description: Reference to a HostedPrivateVirtualInterface in directconnect
+                      to populate virtualInterfaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -129,8 +129,8 @@ spec:
                     - name
                     type: object
                   virtualInterfaceIdSelector:
-                    description: Selector for a HostedPrivateVirtualInterface to populate
-                      virtualInterfaceId.
+                    description: Selector for a HostedPrivateVirtualInterface in directconnect
+                      to populate virtualInterfaceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -278,8 +278,8 @@ spec:
                       accept.
                     type: string
                   virtualInterfaceIdRef:
-                    description: Reference to a HostedPrivateVirtualInterface to populate
-                      virtualInterfaceId.
+                    description: Reference to a HostedPrivateVirtualInterface in directconnect
+                      to populate virtualInterfaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -313,8 +313,8 @@ spec:
                     - name
                     type: object
                   virtualInterfaceIdSelector:
-                    description: Selector for a HostedPrivateVirtualInterface to populate
-                      virtualInterfaceId.
+                    description: Selector for a HostedPrivateVirtualInterface in directconnect
+                      to populate virtualInterfaceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/directconnect.aws.upbound.io_hostedprivatevirtualinterfaces.yaml
+++ b/package/crds/directconnect.aws.upbound.io_hostedprivatevirtualinterfaces.yaml
@@ -93,7 +93,8 @@ spec:
                       on which to create the virtual interface.
                     type: string
                   connectionIdRef:
-                    description: Reference to a Connection to populate connectionId.
+                    description: Reference to a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -127,7 +128,8 @@ spec:
                     - name
                     type: object
                   connectionIdSelector:
-                    description: Selector for a Connection to populate connectionId.
+                    description: Selector for a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -224,7 +226,8 @@ spec:
                       on which to create the virtual interface.
                     type: string
                   connectionIdRef:
-                    description: Reference to a Connection to populate connectionId.
+                    description: Reference to a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -258,7 +261,8 @@ spec:
                     - name
                     type: object
                   connectionIdSelector:
-                    description: Selector for a Connection to populate connectionId.
+                    description: Selector for a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/directconnect.aws.upbound.io_hostedpublicvirtualinterfaceaccepters.yaml
+++ b/package/crds/directconnect.aws.upbound.io_hostedpublicvirtualinterfaceaccepters.yaml
@@ -90,8 +90,8 @@ spec:
                       accept.
                     type: string
                   virtualInterfaceIdRef:
-                    description: Reference to a HostedPublicVirtualInterface to populate
-                      virtualInterfaceId.
+                    description: Reference to a HostedPublicVirtualInterface in directconnect
+                      to populate virtualInterfaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -125,8 +125,8 @@ spec:
                     - name
                     type: object
                   virtualInterfaceIdSelector:
-                    description: Selector for a HostedPublicVirtualInterface to populate
-                      virtualInterfaceId.
+                    description: Selector for a HostedPublicVirtualInterface in directconnect
+                      to populate virtualInterfaceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -192,8 +192,8 @@ spec:
                       accept.
                     type: string
                   virtualInterfaceIdRef:
-                    description: Reference to a HostedPublicVirtualInterface to populate
-                      virtualInterfaceId.
+                    description: Reference to a HostedPublicVirtualInterface in directconnect
+                      to populate virtualInterfaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -227,8 +227,8 @@ spec:
                     - name
                     type: object
                   virtualInterfaceIdSelector:
-                    description: Selector for a HostedPublicVirtualInterface to populate
-                      virtualInterfaceId.
+                    description: Selector for a HostedPublicVirtualInterface in directconnect
+                      to populate virtualInterfaceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/directconnect.aws.upbound.io_hostedpublicvirtualinterfaces.yaml
+++ b/package/crds/directconnect.aws.upbound.io_hostedpublicvirtualinterfaces.yaml
@@ -93,7 +93,8 @@ spec:
                       on which to create the virtual interface.
                     type: string
                   connectionIdRef:
-                    description: Reference to a Connection to populate connectionId.
+                    description: Reference to a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -127,7 +128,8 @@ spec:
                     - name
                     type: object
                   connectionIdSelector:
-                    description: Selector for a Connection to populate connectionId.
+                    description: Selector for a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -225,7 +227,8 @@ spec:
                       on which to create the virtual interface.
                     type: string
                   connectionIdRef:
-                    description: Reference to a Connection to populate connectionId.
+                    description: Reference to a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -259,7 +262,8 @@ spec:
                     - name
                     type: object
                   connectionIdSelector:
-                    description: Selector for a Connection to populate connectionId.
+                    description: Selector for a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/directconnect.aws.upbound.io_hostedtransitvirtualinterfaceaccepters.yaml
+++ b/package/crds/directconnect.aws.upbound.io_hostedtransitvirtualinterfaceaccepters.yaml
@@ -170,8 +170,8 @@ spec:
                       accept.
                     type: string
                   virtualInterfaceIdRef:
-                    description: Reference to a HostedTransitVirtualInterface to populate
-                      virtualInterfaceId.
+                    description: Reference to a HostedTransitVirtualInterface in directconnect
+                      to populate virtualInterfaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -205,8 +205,8 @@ spec:
                     - name
                     type: object
                   virtualInterfaceIdSelector:
-                    description: Selector for a HostedTransitVirtualInterface to populate
-                      virtualInterfaceId.
+                    description: Selector for a HostedTransitVirtualInterface in directconnect
+                      to populate virtualInterfaceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -352,8 +352,8 @@ spec:
                       accept.
                     type: string
                   virtualInterfaceIdRef:
-                    description: Reference to a HostedTransitVirtualInterface to populate
-                      virtualInterfaceId.
+                    description: Reference to a HostedTransitVirtualInterface in directconnect
+                      to populate virtualInterfaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -387,8 +387,8 @@ spec:
                     - name
                     type: object
                   virtualInterfaceIdSelector:
-                    description: Selector for a HostedTransitVirtualInterface to populate
-                      virtualInterfaceId.
+                    description: Selector for a HostedTransitVirtualInterface in directconnect
+                      to populate virtualInterfaceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/directconnect.aws.upbound.io_hostedtransitvirtualinterfaces.yaml
+++ b/package/crds/directconnect.aws.upbound.io_hostedtransitvirtualinterfaces.yaml
@@ -93,7 +93,8 @@ spec:
                       on which to create the virtual interface.
                     type: string
                   connectionIdRef:
-                    description: Reference to a Connection to populate connectionId.
+                    description: Reference to a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -127,7 +128,8 @@ spec:
                     - name
                     type: object
                   connectionIdSelector:
-                    description: Selector for a Connection to populate connectionId.
+                    description: Selector for a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -224,7 +226,8 @@ spec:
                       on which to create the virtual interface.
                     type: string
                   connectionIdRef:
-                    description: Reference to a Connection to populate connectionId.
+                    description: Reference to a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -258,7 +261,8 @@ spec:
                     - name
                     type: object
                   connectionIdSelector:
-                    description: Selector for a Connection to populate connectionId.
+                    description: Selector for a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/directconnect.aws.upbound.io_privatevirtualinterfaces.yaml
+++ b/package/crds/directconnect.aws.upbound.io_privatevirtualinterfaces.yaml
@@ -93,7 +93,8 @@ spec:
                       on which to create the virtual interface.
                     type: string
                   connectionIdRef:
-                    description: Reference to a Connection to populate connectionId.
+                    description: Reference to a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -127,7 +128,8 @@ spec:
                     - name
                     type: object
                   connectionIdSelector:
-                    description: Selector for a Connection to populate connectionId.
+                    description: Selector for a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -311,7 +313,8 @@ spec:
                       on which to create the virtual interface.
                     type: string
                   connectionIdRef:
-                    description: Reference to a Connection to populate connectionId.
+                    description: Reference to a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -345,7 +348,8 @@ spec:
                     - name
                     type: object
                   connectionIdSelector:
-                    description: Selector for a Connection to populate connectionId.
+                    description: Selector for a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/directconnect.aws.upbound.io_publicvirtualinterfaces.yaml
+++ b/package/crds/directconnect.aws.upbound.io_publicvirtualinterfaces.yaml
@@ -92,7 +92,8 @@ spec:
                       on which to create the virtual interface.
                     type: string
                   connectionIdRef:
-                    description: Reference to a Connection to populate connectionId.
+                    description: Reference to a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -126,7 +127,8 @@ spec:
                     - name
                     type: object
                   connectionIdSelector:
-                    description: Selector for a Connection to populate connectionId.
+                    description: Selector for a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -227,7 +229,8 @@ spec:
                       on which to create the virtual interface.
                     type: string
                   connectionIdRef:
-                    description: Reference to a Connection to populate connectionId.
+                    description: Reference to a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -261,7 +264,8 @@ spec:
                     - name
                     type: object
                   connectionIdSelector:
-                    description: Selector for a Connection to populate connectionId.
+                    description: Selector for a Connection in directconnect to populate
+                      connectionId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/docdb.aws.upbound.io_clusterinstances.yaml
+++ b/package/crds/docdb.aws.upbound.io_clusterinstances.yaml
@@ -95,7 +95,7 @@ spec:
                       to launch this instance.
                     type: string
                   clusterIdentifierRef:
-                    description: Reference to a Cluster to populate clusterIdentifier.
+                    description: Reference to a Cluster in docdb to populate clusterIdentifier.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -129,7 +129,7 @@ spec:
                     - name
                     type: object
                   clusterIdentifierSelector:
-                    description: Selector for a Cluster to populate clusterIdentifier.
+                    description: Selector for a Cluster in docdb to populate clusterIdentifier.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -251,7 +251,7 @@ spec:
                       to launch this instance.
                     type: string
                   clusterIdentifierRef:
-                    description: Reference to a Cluster to populate clusterIdentifier.
+                    description: Reference to a Cluster in docdb to populate clusterIdentifier.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -285,7 +285,7 @@ spec:
                     - name
                     type: object
                   clusterIdentifierSelector:
-                    description: Selector for a Cluster to populate clusterIdentifier.
+                    description: Selector for a Cluster in docdb to populate clusterIdentifier.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dynamodb.aws.upbound.io_contributorinsights.yaml
+++ b/package/crds/dynamodb.aws.upbound.io_contributorinsights.yaml
@@ -84,7 +84,7 @@ spec:
                     description: The name of the table to enable contributor insights
                     type: string
                   tableNameRef:
-                    description: Reference to a Table to populate tableName.
+                    description: Reference to a Table in dynamodb to populate tableName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -118,7 +118,7 @@ spec:
                     - name
                     type: object
                   tableNameSelector:
-                    description: Selector for a Table to populate tableName.
+                    description: Selector for a Table in dynamodb to populate tableName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -180,7 +180,7 @@ spec:
                     description: The name of the table to enable contributor insights
                     type: string
                   tableNameRef:
-                    description: Reference to a Table to populate tableName.
+                    description: Reference to a Table in dynamodb to populate tableName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -214,7 +214,7 @@ spec:
                     - name
                     type: object
                   tableNameSelector:
-                    description: Selector for a Table to populate tableName.
+                    description: Selector for a Table in dynamodb to populate tableName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dynamodb.aws.upbound.io_kinesisstreamingdestinations.yaml
+++ b/package/crds/dynamodb.aws.upbound.io_kinesisstreamingdestinations.yaml
@@ -162,7 +162,7 @@ spec:
                       can only be one Kinesis streaming destination for a given DynamoDB table.
                     type: string
                   tableNameRef:
-                    description: Reference to a Table to populate tableName.
+                    description: Reference to a Table in dynamodb to populate tableName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -196,7 +196,7 @@ spec:
                     - name
                     type: object
                   tableNameSelector:
-                    description: Selector for a Table to populate tableName.
+                    description: Selector for a Table in dynamodb to populate tableName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -335,7 +335,7 @@ spec:
                       can only be one Kinesis streaming destination for a given DynamoDB table.
                     type: string
                   tableNameRef:
-                    description: Reference to a Table to populate tableName.
+                    description: Reference to a Table in dynamodb to populate tableName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -369,7 +369,7 @@ spec:
                     - name
                     type: object
                   tableNameSelector:
-                    description: Selector for a Table to populate tableName.
+                    description: Selector for a Table in dynamodb to populate tableName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/dynamodb.aws.upbound.io_tableitems.yaml
+++ b/package/crds/dynamodb.aws.upbound.io_tableitems.yaml
@@ -95,7 +95,7 @@ spec:
                     description: Name of the table to contain the item.
                     type: string
                   tableNameRef:
-                    description: Reference to a Table to populate tableName.
+                    description: Reference to a Table in dynamodb to populate tableName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -129,7 +129,7 @@ spec:
                     - name
                     type: object
                   tableNameSelector:
-                    description: Selector for a Table to populate tableName.
+                    description: Selector for a Table in dynamodb to populate tableName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -202,7 +202,7 @@ spec:
                     description: Name of the table to contain the item.
                     type: string
                   tableNameRef:
-                    description: Reference to a Table to populate tableName.
+                    description: Reference to a Table in dynamodb to populate tableName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -236,7 +236,7 @@ spec:
                     - name
                     type: object
                   tableNameSelector:
-                    description: Selector for a Table to populate tableName.
+                    description: Selector for a Table in dynamodb to populate tableName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_amicopies.yaml
+++ b/package/crds/ec2.aws.upbound.io_amicopies.yaml
@@ -186,7 +186,7 @@ spec:
                       given by source_ami_region.
                     type: string
                   sourceAmiIdRef:
-                    description: Reference to a AMI to populate sourceAmiId.
+                    description: Reference to a AMI in ec2 to populate sourceAmiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -220,7 +220,7 @@ spec:
                     - name
                     type: object
                   sourceAmiIdSelector:
-                    description: Selector for a AMI to populate sourceAmiId.
+                    description: Selector for a AMI in ec2 to populate sourceAmiId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -395,7 +395,7 @@ spec:
                       given by source_ami_region.
                     type: string
                   sourceAmiIdRef:
-                    description: Reference to a AMI to populate sourceAmiId.
+                    description: Reference to a AMI in ec2 to populate sourceAmiId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -429,7 +429,7 @@ spec:
                     - name
                     type: object
                   sourceAmiIdSelector:
-                    description: Selector for a AMI to populate sourceAmiId.
+                    description: Selector for a AMI in ec2 to populate sourceAmiId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_amilaunchpermissions.yaml
+++ b/package/crds/ec2.aws.upbound.io_amilaunchpermissions.yaml
@@ -84,7 +84,7 @@ spec:
                     description: ID of the AMI.
                     type: string
                   imageIdRef:
-                    description: Reference to a AMI to populate imageId.
+                    description: Reference to a AMI in ec2 to populate imageId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -118,7 +118,7 @@ spec:
                     - name
                     type: object
                   imageIdSelector:
-                    description: Selector for a AMI to populate imageId.
+                    description: Selector for a AMI in ec2 to populate imageId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -194,7 +194,7 @@ spec:
                     description: ID of the AMI.
                     type: string
                   imageIdRef:
-                    description: Reference to a AMI to populate imageId.
+                    description: Reference to a AMI in ec2 to populate imageId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -228,7 +228,7 @@ spec:
                     - name
                     type: object
                   imageIdSelector:
-                    description: Selector for a AMI to populate imageId.
+                    description: Selector for a AMI in ec2 to populate imageId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_amis.yaml
+++ b/package/crds/ec2.aws.upbound.io_amis.yaml
@@ -124,7 +124,8 @@ spec:
                             snapshot.
                           type: string
                         snapshotIdRef:
-                          description: Reference to a EBSSnapshot to populate snapshotId.
+                          description: Reference to a EBSSnapshot in ec2 to populate
+                            snapshotId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -158,7 +159,8 @@ spec:
                           - name
                           type: object
                         snapshotIdSelector:
-                          description: Selector for a EBSSnapshot to populate snapshotId.
+                          description: Selector for a EBSSnapshot in ec2 to populate
+                            snapshotId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -355,7 +357,8 @@ spec:
                             snapshot.
                           type: string
                         snapshotIdRef:
-                          description: Reference to a EBSSnapshot to populate snapshotId.
+                          description: Reference to a EBSSnapshot in ec2 to populate
+                            snapshotId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -389,7 +392,8 @@ spec:
                           - name
                           type: object
                         snapshotIdSelector:
-                          description: Selector for a EBSSnapshot to populate snapshotId.
+                          description: Selector for a EBSSnapshot in ec2 to populate
+                            snapshotId.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/ec2.aws.upbound.io_eips.yaml
+++ b/package/crds/ec2.aws.upbound.io_eips.yaml
@@ -94,7 +94,7 @@ spec:
                     description: EC2 instance ID.
                     type: string
                   instanceRef:
-                    description: Reference to a Instance to populate instance.
+                    description: Reference to a Instance in ec2 to populate instance.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -128,7 +128,7 @@ spec:
                     - name
                     type: object
                   instanceSelector:
-                    description: Selector for a Instance to populate instance.
+                    description: Selector for a Instance in ec2 to populate instance.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -175,7 +175,8 @@ spec:
                     description: Network interface ID to associate with.
                     type: string
                   networkInterfaceRef:
-                    description: Reference to a NetworkInterface to populate networkInterface.
+                    description: Reference to a NetworkInterface in ec2 to populate
+                      networkInterface.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -209,7 +210,8 @@ spec:
                     - name
                     type: object
                   networkInterfaceSelector:
-                    description: Selector for a NetworkInterface to populate networkInterface.
+                    description: Selector for a NetworkInterface in ec2 to populate
+                      networkInterface.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -306,7 +308,7 @@ spec:
                     description: EC2 instance ID.
                     type: string
                   instanceRef:
-                    description: Reference to a Instance to populate instance.
+                    description: Reference to a Instance in ec2 to populate instance.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -340,7 +342,7 @@ spec:
                     - name
                     type: object
                   instanceSelector:
-                    description: Selector for a Instance to populate instance.
+                    description: Selector for a Instance in ec2 to populate instance.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -387,7 +389,8 @@ spec:
                     description: Network interface ID to associate with.
                     type: string
                   networkInterfaceRef:
-                    description: Reference to a NetworkInterface to populate networkInterface.
+                    description: Reference to a NetworkInterface in ec2 to populate
+                      networkInterface.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -421,7 +424,8 @@ spec:
                     - name
                     type: object
                   networkInterfaceSelector:
-                    description: Selector for a NetworkInterface to populate networkInterface.
+                    description: Selector for a NetworkInterface in ec2 to populate
+                      networkInterface.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_instances.yaml
+++ b/package/crds/ec2.aws.upbound.io_instances.yaml
@@ -524,7 +524,7 @@ spec:
                           description: ID of the network interface to attach.
                           type: string
                         networkInterfaceIdRef:
-                          description: Reference to a NetworkInterface to populate
+                          description: Reference to a NetworkInterface in ec2 to populate
                             networkInterfaceId.
                           properties:
                             name:
@@ -559,7 +559,7 @@ spec:
                           - name
                           type: object
                         networkInterfaceIdSelector:
-                          description: Selector for a NetworkInterface to populate
+                          description: Selector for a NetworkInterface in ec2 to populate
                             networkInterfaceId.
                           properties:
                             matchControllerRef:
@@ -781,7 +781,7 @@ spec:
                     description: VPC Subnet ID to launch in.
                     type: string
                   subnetIdRef:
-                    description: Reference to a Subnet to populate subnetId.
+                    description: Reference to a Subnet in ec2 to populate subnetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -815,7 +815,7 @@ spec:
                     - name
                     type: object
                   subnetIdSelector:
-                    description: Selector for a Subnet to populate subnetId.
+                    description: Selector for a Subnet in ec2 to populate subnetId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -897,7 +897,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: granular
                   vpcSecurityGroupIdRefs:
-                    description: References to SecurityGroup to populate vpcSecurityGroupIds.
+                    description: References to SecurityGroup in ec2 to populate vpcSecurityGroupIds.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -934,7 +934,7 @@ spec:
                       type: object
                     type: array
                   vpcSecurityGroupIdSelector:
-                    description: Selector for a list of SecurityGroup to populate
+                    description: Selector for a list of SecurityGroup in ec2 to populate
                       vpcSecurityGroupIds.
                     properties:
                       matchControllerRef:
@@ -1446,7 +1446,7 @@ spec:
                           description: ID of the network interface to attach.
                           type: string
                         networkInterfaceIdRef:
-                          description: Reference to a NetworkInterface to populate
+                          description: Reference to a NetworkInterface in ec2 to populate
                             networkInterfaceId.
                           properties:
                             name:
@@ -1481,7 +1481,7 @@ spec:
                           - name
                           type: object
                         networkInterfaceIdSelector:
-                          description: Selector for a NetworkInterface to populate
+                          description: Selector for a NetworkInterface in ec2 to populate
                             networkInterfaceId.
                           properties:
                             matchControllerRef:
@@ -1699,7 +1699,7 @@ spec:
                     description: VPC Subnet ID to launch in.
                     type: string
                   subnetIdRef:
-                    description: Reference to a Subnet to populate subnetId.
+                    description: Reference to a Subnet in ec2 to populate subnetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1733,7 +1733,7 @@ spec:
                     - name
                     type: object
                   subnetIdSelector:
-                    description: Selector for a Subnet to populate subnetId.
+                    description: Selector for a Subnet in ec2 to populate subnetId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -1815,7 +1815,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: granular
                   vpcSecurityGroupIdRefs:
-                    description: References to SecurityGroup to populate vpcSecurityGroupIds.
+                    description: References to SecurityGroup in ec2 to populate vpcSecurityGroupIds.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -1852,7 +1852,7 @@ spec:
                       type: object
                     type: array
                   vpcSecurityGroupIdSelector:
-                    description: Selector for a list of SecurityGroup to populate
+                    description: Selector for a list of SecurityGroup in ec2 to populate
                       vpcSecurityGroupIds.
                     properties:
                       matchControllerRef:

--- a/package/crds/ec2.aws.upbound.io_launchtemplates.yaml
+++ b/package/crds/ec2.aws.upbound.io_launchtemplates.yaml
@@ -955,7 +955,7 @@ spec:
                           description: The ID of the network interface to attach.
                           type: string
                         networkInterfaceIdRef:
-                          description: Reference to a NetworkInterface to populate
+                          description: Reference to a NetworkInterface in ec2 to populate
                             networkInterfaceId.
                           properties:
                             name:
@@ -990,7 +990,7 @@ spec:
                           - name
                           type: object
                         networkInterfaceIdSelector:
-                          description: Selector for a NetworkInterface to populate
+                          description: Selector for a NetworkInterface in ec2 to populate
                             networkInterfaceId.
                           properties:
                             matchControllerRef:
@@ -1034,7 +1034,8 @@ spec:
                           description: The primary private IPv4 address.
                           type: string
                         securityGroupRefs:
-                          description: References to SecurityGroup to populate securityGroups.
+                          description: References to SecurityGroup in ec2 to populate
+                            securityGroups.
                           items:
                             description: A Reference to a named object.
                             properties:
@@ -1071,8 +1072,8 @@ spec:
                             type: object
                           type: array
                         securityGroupSelector:
-                          description: Selector for a list of SecurityGroup to populate
-                            securityGroups.
+                          description: Selector for a list of SecurityGroup in ec2
+                            to populate securityGroups.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -1121,7 +1122,7 @@ spec:
                           description: The VPC Subnet ID to associate.
                           type: string
                         subnetIdRef:
-                          description: Reference to a Subnet to populate subnetId.
+                          description: Reference to a Subnet in ec2 to populate subnetId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -1155,7 +1156,7 @@ spec:
                           - name
                           type: object
                         subnetIdSelector:
-                          description: Selector for a Subnet to populate subnetId.
+                          description: Selector for a Subnet in ec2 to populate subnetId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -1265,7 +1266,7 @@ spec:
                       be created in.
                     type: string
                   securityGroupNameRefs:
-                    description: References to SecurityGroup to populate securityGroupNames.
+                    description: References to SecurityGroup in ec2 to populate securityGroupNames.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -1302,7 +1303,7 @@ spec:
                       type: object
                     type: array
                   securityGroupNameSelector:
-                    description: Selector for a list of SecurityGroup to populate
+                    description: Selector for a list of SecurityGroup in ec2 to populate
                       securityGroupNames.
                     properties:
                       matchControllerRef:
@@ -2362,7 +2363,7 @@ spec:
                           description: The ID of the network interface to attach.
                           type: string
                         networkInterfaceIdRef:
-                          description: Reference to a NetworkInterface to populate
+                          description: Reference to a NetworkInterface in ec2 to populate
                             networkInterfaceId.
                           properties:
                             name:
@@ -2397,7 +2398,7 @@ spec:
                           - name
                           type: object
                         networkInterfaceIdSelector:
-                          description: Selector for a NetworkInterface to populate
+                          description: Selector for a NetworkInterface in ec2 to populate
                             networkInterfaceId.
                           properties:
                             matchControllerRef:
@@ -2441,7 +2442,8 @@ spec:
                           description: The primary private IPv4 address.
                           type: string
                         securityGroupRefs:
-                          description: References to SecurityGroup to populate securityGroups.
+                          description: References to SecurityGroup in ec2 to populate
+                            securityGroups.
                           items:
                             description: A Reference to a named object.
                             properties:
@@ -2478,8 +2480,8 @@ spec:
                             type: object
                           type: array
                         securityGroupSelector:
-                          description: Selector for a list of SecurityGroup to populate
-                            securityGroups.
+                          description: Selector for a list of SecurityGroup in ec2
+                            to populate securityGroups.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -2528,7 +2530,7 @@ spec:
                           description: The VPC Subnet ID to associate.
                           type: string
                         subnetIdRef:
-                          description: Reference to a Subnet to populate subnetId.
+                          description: Reference to a Subnet in ec2 to populate subnetId.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -2562,7 +2564,7 @@ spec:
                           - name
                           type: object
                         subnetIdSelector:
-                          description: Selector for a Subnet to populate subnetId.
+                          description: Selector for a Subnet in ec2 to populate subnetId.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -2668,7 +2670,7 @@ spec:
                     description: The ID of the RAM disk.
                     type: string
                   securityGroupNameRefs:
-                    description: References to SecurityGroup to populate securityGroupNames.
+                    description: References to SecurityGroup in ec2 to populate securityGroupNames.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -2705,7 +2707,7 @@ spec:
                       type: object
                     type: array
                   securityGroupNameSelector:
-                    description: Selector for a list of SecurityGroup to populate
+                    description: Selector for a list of SecurityGroup in ec2 to populate
                       securityGroupNames.
                     properties:
                       matchControllerRef:

--- a/package/crds/ec2.aws.upbound.io_mainroutetableassociations.yaml
+++ b/package/crds/ec2.aws.upbound.io_mainroutetableassociations.yaml
@@ -84,7 +84,7 @@ spec:
                       main route table for the target VPC
                     type: string
                   routeTableIdRef:
-                    description: Reference to a RouteTable to populate routeTableId.
+                    description: Reference to a RouteTable in ec2 to populate routeTableId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -118,7 +118,7 @@ spec:
                     - name
                     type: object
                   routeTableIdSelector:
-                    description: Selector for a RouteTable to populate routeTableId.
+                    description: Selector for a RouteTable in ec2 to populate routeTableId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -257,7 +257,7 @@ spec:
                       main route table for the target VPC
                     type: string
                   routeTableIdRef:
-                    description: Reference to a RouteTable to populate routeTableId.
+                    description: Reference to a RouteTable in ec2 to populate routeTableId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -291,7 +291,7 @@ spec:
                     - name
                     type: object
                   routeTableIdSelector:
-                    description: Selector for a RouteTable to populate routeTableId.
+                    description: Selector for a RouteTable in ec2 to populate routeTableId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_natgateways.yaml
+++ b/package/crds/ec2.aws.upbound.io_natgateways.yaml
@@ -187,7 +187,7 @@ spec:
                       NAT Gateway.
                     type: string
                   subnetIdRef:
-                    description: Reference to a Subnet to populate subnetId.
+                    description: Reference to a Subnet in ec2 to populate subnetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -221,7 +221,7 @@ spec:
                     - name
                     type: object
                   subnetIdSelector:
-                    description: Selector for a Subnet to populate subnetId.
+                    description: Selector for a Subnet in ec2 to populate subnetId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -392,7 +392,7 @@ spec:
                       NAT Gateway.
                     type: string
                   subnetIdRef:
-                    description: Reference to a Subnet to populate subnetId.
+                    description: Reference to a Subnet in ec2 to populate subnetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -426,7 +426,7 @@ spec:
                     - name
                     type: object
                   subnetIdSelector:
-                    description: Selector for a Subnet to populate subnetId.
+                    description: Selector for a Subnet in ec2 to populate subnetId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_networkinterfaces.yaml
+++ b/package/crds/ec2.aws.upbound.io_networkinterfaces.yaml
@@ -159,7 +159,7 @@ spec:
                       be created in.
                     type: string
                   securityGroupRefs:
-                    description: References to SecurityGroup to populate securityGroups.
+                    description: References to SecurityGroup in ec2 to populate securityGroups.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -196,7 +196,7 @@ spec:
                       type: object
                     type: array
                   securityGroupSelector:
-                    description: Selector for a list of SecurityGroup to populate
+                    description: Selector for a list of SecurityGroup in ec2 to populate
                       securityGroups.
                     properties:
                       matchControllerRef:
@@ -250,7 +250,7 @@ spec:
                     description: Subnet ID to create the ENI in.
                     type: string
                   subnetIdRef:
-                    description: Reference to a Subnet to populate subnetId.
+                    description: Reference to a Subnet in ec2 to populate subnetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -284,7 +284,7 @@ spec:
                     - name
                     type: object
                   subnetIdSelector:
-                    description: Selector for a Subnet to populate subnetId.
+                    description: Selector for a Subnet in ec2 to populate subnetId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -427,7 +427,7 @@ spec:
                       as a primary private IP will be assiged to an ENI by default.
                     type: number
                   securityGroupRefs:
-                    description: References to SecurityGroup to populate securityGroups.
+                    description: References to SecurityGroup in ec2 to populate securityGroups.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -464,7 +464,7 @@ spec:
                       type: object
                     type: array
                   securityGroupSelector:
-                    description: Selector for a list of SecurityGroup to populate
+                    description: Selector for a list of SecurityGroup in ec2 to populate
                       securityGroups.
                     properties:
                       matchControllerRef:
@@ -518,7 +518,7 @@ spec:
                     description: Subnet ID to create the ENI in.
                     type: string
                   subnetIdRef:
-                    description: Reference to a Subnet to populate subnetId.
+                    description: Reference to a Subnet in ec2 to populate subnetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -552,7 +552,7 @@ spec:
                     - name
                     type: object
                   subnetIdSelector:
-                    description: Selector for a Subnet to populate subnetId.
+                    description: Selector for a Subnet in ec2 to populate subnetId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_routetableassociations.yaml
+++ b/package/crds/ec2.aws.upbound.io_routetableassociations.yaml
@@ -163,7 +163,7 @@ spec:
                     description: The ID of the routing table to associate with.
                     type: string
                   routeTableIdRef:
-                    description: Reference to a RouteTable to populate routeTableId.
+                    description: Reference to a RouteTable in ec2 to populate routeTableId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -197,7 +197,7 @@ spec:
                     - name
                     type: object
                   routeTableIdSelector:
-                    description: Selector for a RouteTable to populate routeTableId.
+                    description: Selector for a RouteTable in ec2 to populate routeTableId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -241,7 +241,7 @@ spec:
                       with gateway_id.
                     type: string
                   subnetIdRef:
-                    description: Reference to a Subnet to populate subnetId.
+                    description: Reference to a Subnet in ec2 to populate subnetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -275,7 +275,7 @@ spec:
                     - name
                     type: object
                   subnetIdSelector:
-                    description: Selector for a Subnet to populate subnetId.
+                    description: Selector for a Subnet in ec2 to populate subnetId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -414,7 +414,7 @@ spec:
                     description: The ID of the routing table to associate with.
                     type: string
                   routeTableIdRef:
-                    description: Reference to a RouteTable to populate routeTableId.
+                    description: Reference to a RouteTable in ec2 to populate routeTableId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -448,7 +448,7 @@ spec:
                     - name
                     type: object
                   routeTableIdSelector:
-                    description: Selector for a RouteTable to populate routeTableId.
+                    description: Selector for a RouteTable in ec2 to populate routeTableId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -492,7 +492,7 @@ spec:
                       with gateway_id.
                     type: string
                   subnetIdRef:
-                    description: Reference to a Subnet to populate subnetId.
+                    description: Reference to a Subnet in ec2 to populate subnetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -526,7 +526,7 @@ spec:
                     - name
                     type: object
                   subnetIdSelector:
-                    description: Selector for a Subnet to populate subnetId.
+                    description: Selector for a Subnet in ec2 to populate subnetId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_securitygrouprules.yaml
+++ b/package/crds/ec2.aws.upbound.io_securitygrouprules.yaml
@@ -188,7 +188,7 @@ spec:
                     description: Security group to apply this rule to.
                     type: string
                   securityGroupIdRef:
-                    description: Reference to a SecurityGroup to populate securityGroupId.
+                    description: Reference to a SecurityGroup in ec2 to populate securityGroupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -222,7 +222,7 @@ spec:
                     - name
                     type: object
                   securityGroupIdSelector:
-                    description: Selector for a SecurityGroup to populate securityGroupId.
+                    description: Selector for a SecurityGroup in ec2 to populate securityGroupId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -272,7 +272,7 @@ spec:
                       or self.
                     type: string
                   sourceSecurityGroupIdRef:
-                    description: Reference to a SecurityGroup to populate sourceSecurityGroupId.
+                    description: Reference to a SecurityGroup in ec2 to populate sourceSecurityGroupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -306,7 +306,7 @@ spec:
                     - name
                     type: object
                   sourceSecurityGroupIdSelector:
-                    description: Selector for a SecurityGroup to populate sourceSecurityGroupId.
+                    description: Selector for a SecurityGroup in ec2 to populate sourceSecurityGroupId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -480,7 +480,7 @@ spec:
                     description: Security group to apply this rule to.
                     type: string
                   securityGroupIdRef:
-                    description: Reference to a SecurityGroup to populate securityGroupId.
+                    description: Reference to a SecurityGroup in ec2 to populate securityGroupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -514,7 +514,7 @@ spec:
                     - name
                     type: object
                   securityGroupIdSelector:
-                    description: Selector for a SecurityGroup to populate securityGroupId.
+                    description: Selector for a SecurityGroup in ec2 to populate securityGroupId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -564,7 +564,7 @@ spec:
                       or self.
                     type: string
                   sourceSecurityGroupIdRef:
-                    description: Reference to a SecurityGroup to populate sourceSecurityGroupId.
+                    description: Reference to a SecurityGroup in ec2 to populate sourceSecurityGroupId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -598,7 +598,7 @@ spec:
                     - name
                     type: object
                   sourceSecurityGroupIdSelector:
-                    description: Selector for a SecurityGroup to populate sourceSecurityGroupId.
+                    description: Selector for a SecurityGroup in ec2 to populate sourceSecurityGroupId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_transitgatewaymulticastdomains.yaml
+++ b/package/crds/ec2.aws.upbound.io_transitgatewaymulticastdomains.yaml
@@ -105,7 +105,8 @@ spec:
                       must have multicast_support enabled.
                     type: string
                   transitGatewayIdRef:
-                    description: Reference to a TransitGateway to populate transitGatewayId.
+                    description: Reference to a TransitGateway in ec2 to populate
+                      transitGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -139,7 +140,8 @@ spec:
                     - name
                     type: object
                   transitGatewayIdSelector:
-                    description: Selector for a TransitGateway to populate transitGatewayId.
+                    description: Selector for a TransitGateway in ec2 to populate
+                      transitGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -221,7 +223,8 @@ spec:
                       must have multicast_support enabled.
                     type: string
                   transitGatewayIdRef:
-                    description: Reference to a TransitGateway to populate transitGatewayId.
+                    description: Reference to a TransitGateway in ec2 to populate
+                      transitGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -255,7 +258,8 @@ spec:
                     - name
                     type: object
                   transitGatewayIdSelector:
-                    description: Selector for a TransitGateway to populate transitGatewayId.
+                    description: Selector for a TransitGateway in ec2 to populate
+                      transitGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_transitgatewayroutes.yaml
+++ b/package/crds/ec2.aws.upbound.io_transitgatewayroutes.yaml
@@ -89,8 +89,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway Attachment .
                     type: string
                   transitGatewayAttachmentIdRef:
-                    description: Reference to a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Reference to a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -124,8 +124,8 @@ spec:
                     - name
                     type: object
                   transitGatewayAttachmentIdSelector:
-                    description: Selector for a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Selector for a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -168,8 +168,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway Route Table.
                     type: string
                   transitGatewayRouteTableIdRef:
-                    description: Reference to a TransitGatewayRouteTable to populate
-                      transitGatewayRouteTableId.
+                    description: Reference to a TransitGatewayRouteTable in ec2 to
+                      populate transitGatewayRouteTableId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -203,8 +203,8 @@ spec:
                     - name
                     type: object
                   transitGatewayRouteTableIdSelector:
-                    description: Selector for a TransitGatewayRouteTable to populate
-                      transitGatewayRouteTableId.
+                    description: Selector for a TransitGatewayRouteTable in ec2 to
+                      populate transitGatewayRouteTableId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -271,8 +271,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway Attachment .
                     type: string
                   transitGatewayAttachmentIdRef:
-                    description: Reference to a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Reference to a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -306,8 +306,8 @@ spec:
                     - name
                     type: object
                   transitGatewayAttachmentIdSelector:
-                    description: Selector for a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Selector for a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -350,8 +350,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway Route Table.
                     type: string
                   transitGatewayRouteTableIdRef:
-                    description: Reference to a TransitGatewayRouteTable to populate
-                      transitGatewayRouteTableId.
+                    description: Reference to a TransitGatewayRouteTable in ec2 to
+                      populate transitGatewayRouteTableId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -385,8 +385,8 @@ spec:
                     - name
                     type: object
                   transitGatewayRouteTableIdSelector:
-                    description: Selector for a TransitGatewayRouteTable to populate
-                      transitGatewayRouteTableId.
+                    description: Selector for a TransitGatewayRouteTable in ec2 to
+                      populate transitGatewayRouteTableId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_transitgatewayroutetableassociations.yaml
+++ b/package/crds/ec2.aws.upbound.io_transitgatewayroutetableassociations.yaml
@@ -91,8 +91,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway Attachment.
                     type: string
                   transitGatewayAttachmentIdRef:
-                    description: Reference to a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Reference to a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -126,8 +126,8 @@ spec:
                     - name
                     type: object
                   transitGatewayAttachmentIdSelector:
-                    description: Selector for a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Selector for a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -170,8 +170,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway Route Table.
                     type: string
                   transitGatewayRouteTableIdRef:
-                    description: Reference to a TransitGatewayRouteTable to populate
-                      transitGatewayRouteTableId.
+                    description: Reference to a TransitGatewayRouteTable in ec2 to
+                      populate transitGatewayRouteTableId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -205,8 +205,8 @@ spec:
                     - name
                     type: object
                   transitGatewayRouteTableIdSelector:
-                    description: Selector for a TransitGatewayRouteTable to populate
-                      transitGatewayRouteTableId.
+                    description: Selector for a TransitGatewayRouteTable in ec2 to
+                      populate transitGatewayRouteTableId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -274,8 +274,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway Attachment.
                     type: string
                   transitGatewayAttachmentIdRef:
-                    description: Reference to a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Reference to a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -309,8 +309,8 @@ spec:
                     - name
                     type: object
                   transitGatewayAttachmentIdSelector:
-                    description: Selector for a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Selector for a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -353,8 +353,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway Route Table.
                     type: string
                   transitGatewayRouteTableIdRef:
-                    description: Reference to a TransitGatewayRouteTable to populate
-                      transitGatewayRouteTableId.
+                    description: Reference to a TransitGatewayRouteTable in ec2 to
+                      populate transitGatewayRouteTableId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -388,8 +388,8 @@ spec:
                     - name
                     type: object
                   transitGatewayRouteTableIdSelector:
-                    description: Selector for a TransitGatewayRouteTable to populate
-                      transitGatewayRouteTableId.
+                    description: Selector for a TransitGatewayRouteTable in ec2 to
+                      populate transitGatewayRouteTableId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_transitgatewayroutetablepropagations.yaml
+++ b/package/crds/ec2.aws.upbound.io_transitgatewayroutetablepropagations.yaml
@@ -82,8 +82,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway Attachment.
                     type: string
                   transitGatewayAttachmentIdRef:
-                    description: Reference to a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Reference to a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -117,8 +117,8 @@ spec:
                     - name
                     type: object
                   transitGatewayAttachmentIdSelector:
-                    description: Selector for a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Selector for a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -161,8 +161,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway Route Table.
                     type: string
                   transitGatewayRouteTableIdRef:
-                    description: Reference to a TransitGatewayRouteTable to populate
-                      transitGatewayRouteTableId.
+                    description: Reference to a TransitGatewayRouteTable in ec2 to
+                      populate transitGatewayRouteTableId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -196,8 +196,8 @@ spec:
                     - name
                     type: object
                   transitGatewayRouteTableIdSelector:
-                    description: Selector for a TransitGatewayRouteTable to populate
-                      transitGatewayRouteTableId.
+                    description: Selector for a TransitGatewayRouteTable in ec2 to
+                      populate transitGatewayRouteTableId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -256,8 +256,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway Attachment.
                     type: string
                   transitGatewayAttachmentIdRef:
-                    description: Reference to a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Reference to a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -291,8 +291,8 @@ spec:
                     - name
                     type: object
                   transitGatewayAttachmentIdSelector:
-                    description: Selector for a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Selector for a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -335,8 +335,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway Route Table.
                     type: string
                   transitGatewayRouteTableIdRef:
-                    description: Reference to a TransitGatewayRouteTable to populate
-                      transitGatewayRouteTableId.
+                    description: Reference to a TransitGatewayRouteTable in ec2 to
+                      populate transitGatewayRouteTableId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -370,8 +370,8 @@ spec:
                     - name
                     type: object
                   transitGatewayRouteTableIdSelector:
-                    description: Selector for a TransitGatewayRouteTable to populate
-                      transitGatewayRouteTableId.
+                    description: Selector for a TransitGatewayRouteTable in ec2 to
+                      populate transitGatewayRouteTableId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_transitgatewayroutetables.yaml
+++ b/package/crds/ec2.aws.upbound.io_transitgatewayroutetables.yaml
@@ -88,7 +88,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway.
                     type: string
                   transitGatewayIdRef:
-                    description: Reference to a TransitGateway to populate transitGatewayId.
+                    description: Reference to a TransitGateway in ec2 to populate
+                      transitGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -122,7 +123,8 @@ spec:
                     - name
                     type: object
                   transitGatewayIdSelector:
-                    description: Selector for a TransitGateway to populate transitGatewayId.
+                    description: Selector for a TransitGateway in ec2 to populate
+                      transitGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -187,7 +189,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway.
                     type: string
                   transitGatewayIdRef:
-                    description: Reference to a TransitGateway to populate transitGatewayId.
+                    description: Reference to a TransitGateway in ec2 to populate
+                      transitGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -221,7 +224,8 @@ spec:
                     - name
                     type: object
                   transitGatewayIdSelector:
-                    description: Selector for a TransitGateway to populate transitGatewayId.
+                    description: Selector for a TransitGateway in ec2 to populate
+                      transitGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_transitgatewayvpcattachmentaccepters.yaml
+++ b/package/crds/ec2.aws.upbound.io_transitgatewayvpcattachmentaccepters.yaml
@@ -88,8 +88,8 @@ spec:
                     description: The ID of the EC2 Transit Gateway Attachment to manage.
                     type: string
                   transitGatewayAttachmentIdRef:
-                    description: Reference to a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Reference to a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -123,8 +123,8 @@ spec:
                     - name
                     type: object
                   transitGatewayAttachmentIdSelector:
-                    description: Selector for a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Selector for a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -199,8 +199,8 @@ spec:
                     description: The ID of the EC2 Transit Gateway Attachment to manage.
                     type: string
                   transitGatewayAttachmentIdRef:
-                    description: Reference to a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Reference to a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -234,8 +234,8 @@ spec:
                     - name
                     type: object
                   transitGatewayAttachmentIdSelector:
-                    description: Selector for a TransitGatewayVPCAttachment to populate
-                      transitGatewayAttachmentId.
+                    description: Selector for a TransitGatewayVPCAttachment in ec2
+                      to populate transitGatewayAttachmentId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_transitgatewayvpcattachments.yaml
+++ b/package/crds/ec2.aws.upbound.io_transitgatewayvpcattachments.yaml
@@ -199,7 +199,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway.
                     type: string
                   transitGatewayIdRef:
-                    description: Reference to a TransitGateway to populate transitGatewayId.
+                    description: Reference to a TransitGateway in ec2 to populate
+                      transitGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -233,7 +234,8 @@ spec:
                     - name
                     type: object
                   transitGatewayIdSelector:
-                    description: Selector for a TransitGateway to populate transitGatewayId.
+                    description: Selector for a TransitGateway in ec2 to populate
+                      transitGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -486,7 +488,8 @@ spec:
                     description: Identifier of EC2 Transit Gateway.
                     type: string
                   transitGatewayIdRef:
-                    description: Reference to a TransitGateway to populate transitGatewayId.
+                    description: Reference to a TransitGateway in ec2 to populate
+                      transitGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -520,7 +523,8 @@ spec:
                     - name
                     type: object
                   transitGatewayIdSelector:
-                    description: Selector for a TransitGateway to populate transitGatewayId.
+                    description: Selector for a TransitGateway in ec2 to populate
+                      transitGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_vpcipampools.yaml
+++ b/package/crds/ec2.aws.upbound.io_vpcipampools.yaml
@@ -120,7 +120,7 @@ spec:
                       the IPAM pool.
                     type: string
                   ipamScopeIdRef:
-                    description: Reference to a VPCIpamScope to populate ipamScopeId.
+                    description: Reference to a VPCIpamScope in ec2 to populate ipamScopeId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -154,7 +154,7 @@ spec:
                     - name
                     type: object
                   ipamScopeIdSelector:
-                    description: Selector for a VPCIpamScope to populate ipamScopeId.
+                    description: Selector for a VPCIpamScope in ec2 to populate ipamScopeId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -364,7 +364,7 @@ spec:
                       the IPAM pool.
                     type: string
                   ipamScopeIdRef:
-                    description: Reference to a VPCIpamScope to populate ipamScopeId.
+                    description: Reference to a VPCIpamScope in ec2 to populate ipamScopeId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -398,7 +398,7 @@ spec:
                     - name
                     type: object
                   ipamScopeIdSelector:
-                    description: Selector for a VPCIpamScope to populate ipamScopeId.
+                    description: Selector for a VPCIpamScope in ec2 to populate ipamScopeId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_vpcipamscopes.yaml
+++ b/package/crds/ec2.aws.upbound.io_vpcipamscopes.yaml
@@ -81,7 +81,7 @@ spec:
                       scope.
                     type: string
                   ipamIdRef:
-                    description: Reference to a VPCIpam to populate ipamId.
+                    description: Reference to a VPCIpam in ec2 to populate ipamId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -115,7 +115,7 @@ spec:
                     - name
                     type: object
                   ipamIdSelector:
-                    description: Selector for a VPCIpam to populate ipamId.
+                    description: Selector for a VPCIpam in ec2 to populate ipamId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -188,7 +188,7 @@ spec:
                       scope.
                     type: string
                   ipamIdRef:
-                    description: Reference to a VPCIpam to populate ipamId.
+                    description: Reference to a VPCIpam in ec2 to populate ipamId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -222,7 +222,7 @@ spec:
                     - name
                     type: object
                   ipamIdSelector:
-                    description: Selector for a VPCIpam to populate ipamId.
+                    description: Selector for a VPCIpam in ec2 to populate ipamId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_vpcpeeringconnections.yaml
+++ b/package/crds/ec2.aws.upbound.io_vpcpeeringconnections.yaml
@@ -92,7 +92,7 @@ spec:
                       VPC Peering Connection.
                     type: string
                   peerVpcIdRef:
-                    description: Reference to a VPC to populate peerVpcId.
+                    description: Reference to a VPC in ec2 to populate peerVpcId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -126,7 +126,7 @@ spec:
                     - name
                     type: object
                   peerVpcIdSelector:
-                    description: Selector for a VPC to populate peerVpcId.
+                    description: Selector for a VPC in ec2 to populate peerVpcId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -287,7 +287,7 @@ spec:
                       VPC Peering Connection.
                     type: string
                   peerVpcIdRef:
-                    description: Reference to a VPC to populate peerVpcId.
+                    description: Reference to a VPC in ec2 to populate peerVpcId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -321,7 +321,7 @@ spec:
                     - name
                     type: object
                   peerVpcIdSelector:
-                    description: Selector for a VPC to populate peerVpcId.
+                    description: Selector for a VPC in ec2 to populate peerVpcId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ec2.aws.upbound.io_vpnconnections.yaml
+++ b/package/crds/ec2.aws.upbound.io_vpnconnections.yaml
@@ -690,7 +690,7 @@ spec:
                     description: The ID of the Virtual Private Gateway.
                     type: string
                   vpnGatewayIdRef:
-                    description: Reference to a VPNGateway to populate vpnGatewayId.
+                    description: Reference to a VPNGateway in ec2 to populate vpnGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -724,7 +724,7 @@ spec:
                     - name
                     type: object
                   vpnGatewayIdSelector:
-                    description: Selector for a VPNGateway to populate vpnGatewayId.
+                    description: Selector for a VPNGateway in ec2 to populate vpnGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -1350,7 +1350,7 @@ spec:
                     description: The ID of the Virtual Private Gateway.
                     type: string
                   vpnGatewayIdRef:
-                    description: Reference to a VPNGateway to populate vpnGatewayId.
+                    description: Reference to a VPNGateway in ec2 to populate vpnGatewayId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1384,7 +1384,7 @@ spec:
                     - name
                     type: object
                   vpnGatewayIdSelector:
-                    description: Selector for a VPNGateway to populate vpnGatewayId.
+                    description: Selector for a VPNGateway in ec2 to populate vpnGatewayId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/ecs.aws.upbound.io_services.yaml
+++ b/package/crds/ecs.aws.upbound.io_services.yaml
@@ -122,7 +122,7 @@ spec:
                     description: Name of an ECS cluster.
                     type: string
                   clusterRef:
-                    description: Reference to a Cluster to populate cluster.
+                    description: Reference to a Cluster in ecs to populate cluster.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -156,7 +156,7 @@ spec:
                     - name
                     type: object
                   clusterSelector:
-                    description: Selector for a Cluster to populate cluster.
+                    description: Selector for a Cluster in ecs to populate cluster.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -823,7 +823,8 @@ spec:
                       a revision is not specified, the latest ACTIVE revision is used.
                     type: string
                   taskDefinitionRef:
-                    description: Reference to a TaskDefinition to populate taskDefinition.
+                    description: Reference to a TaskDefinition in ecs to populate
+                      taskDefinition.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -857,7 +858,8 @@ spec:
                     - name
                     type: object
                   taskDefinitionSelector:
-                    description: Selector for a TaskDefinition to populate taskDefinition.
+                    description: Selector for a TaskDefinition in ecs to populate
+                      taskDefinition.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -973,7 +975,7 @@ spec:
                     description: Name of an ECS cluster.
                     type: string
                   clusterRef:
-                    description: Reference to a Cluster to populate cluster.
+                    description: Reference to a Cluster in ecs to populate cluster.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1007,7 +1009,7 @@ spec:
                     - name
                     type: object
                   clusterSelector:
-                    description: Selector for a Cluster to populate cluster.
+                    description: Selector for a Cluster in ecs to populate cluster.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -1670,7 +1672,8 @@ spec:
                       a revision is not specified, the latest ACTIVE revision is used.
                     type: string
                   taskDefinitionRef:
-                    description: Reference to a TaskDefinition to populate taskDefinition.
+                    description: Reference to a TaskDefinition in ecs to populate
+                      taskDefinition.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1704,7 +1707,8 @@ spec:
                     - name
                     type: object
                   taskDefinitionSelector:
-                    description: Selector for a TaskDefinition to populate taskDefinition.
+                    description: Selector for a TaskDefinition in ecs to populate
+                      taskDefinition.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/efs.aws.upbound.io_accesspoints.yaml
+++ b/package/crds/efs.aws.upbound.io_accesspoints.yaml
@@ -78,7 +78,7 @@ spec:
                       is intended.
                     type: string
                   fileSystemIdRef:
-                    description: Reference to a FileSystem to populate fileSystemId.
+                    description: Reference to a FileSystem in efs to populate fileSystemId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +112,7 @@ spec:
                     - name
                     type: object
                   fileSystemIdSelector:
-                    description: Selector for a FileSystem to populate fileSystemId.
+                    description: Selector for a FileSystem in efs to populate fileSystemId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -236,7 +236,7 @@ spec:
                       is intended.
                     type: string
                   fileSystemIdRef:
-                    description: Reference to a FileSystem to populate fileSystemId.
+                    description: Reference to a FileSystem in efs to populate fileSystemId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -270,7 +270,7 @@ spec:
                     - name
                     type: object
                   fileSystemIdSelector:
-                    description: Selector for a FileSystem to populate fileSystemId.
+                    description: Selector for a FileSystem in efs to populate fileSystemId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/efs.aws.upbound.io_backuppolicies.yaml
+++ b/package/crds/efs.aws.upbound.io_backuppolicies.yaml
@@ -87,7 +87,7 @@ spec:
                     description: The ID of the EFS file system.
                     type: string
                   fileSystemIdRef:
-                    description: Reference to a FileSystem to populate fileSystemId.
+                    description: Reference to a FileSystem in efs to populate fileSystemId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,7 +121,7 @@ spec:
                     - name
                     type: object
                   fileSystemIdSelector:
-                    description: Selector for a FileSystem to populate fileSystemId.
+                    description: Selector for a FileSystem in efs to populate fileSystemId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -194,7 +194,7 @@ spec:
                     description: The ID of the EFS file system.
                     type: string
                   fileSystemIdRef:
-                    description: Reference to a FileSystem to populate fileSystemId.
+                    description: Reference to a FileSystem in efs to populate fileSystemId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -228,7 +228,7 @@ spec:
                     - name
                     type: object
                   fileSystemIdSelector:
-                    description: Selector for a FileSystem to populate fileSystemId.
+                    description: Selector for a FileSystem in efs to populate fileSystemId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/efs.aws.upbound.io_filesystempolicies.yaml
+++ b/package/crds/efs.aws.upbound.io_filesystempolicies.yaml
@@ -87,7 +87,7 @@ spec:
                     description: The ID of the EFS file system.
                     type: string
                   fileSystemIdRef:
-                    description: Reference to a FileSystem to populate fileSystemId.
+                    description: Reference to a FileSystem in efs to populate fileSystemId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,7 +121,7 @@ spec:
                     - name
                     type: object
                   fileSystemIdSelector:
-                    description: Selector for a FileSystem to populate fileSystemId.
+                    description: Selector for a FileSystem in efs to populate fileSystemId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -198,7 +198,7 @@ spec:
                     description: The ID of the EFS file system.
                     type: string
                   fileSystemIdRef:
-                    description: Reference to a FileSystem to populate fileSystemId.
+                    description: Reference to a FileSystem in efs to populate fileSystemId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -232,7 +232,7 @@ spec:
                     - name
                     type: object
                   fileSystemIdSelector:
-                    description: Selector for a FileSystem to populate fileSystemId.
+                    description: Selector for a FileSystem in efs to populate fileSystemId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/efs.aws.upbound.io_mounttargets.yaml
+++ b/package/crds/efs.aws.upbound.io_mounttargets.yaml
@@ -78,7 +78,7 @@ spec:
                       is intended.
                     type: string
                   fileSystemIdRef:
-                    description: Reference to a FileSystem to populate fileSystemId.
+                    description: Reference to a FileSystem in efs to populate fileSystemId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +112,7 @@ spec:
                     - name
                     type: object
                   fileSystemIdSelector:
-                    description: Selector for a FileSystem to populate fileSystemId.
+                    description: Selector for a FileSystem in efs to populate fileSystemId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -344,7 +344,7 @@ spec:
                       is intended.
                     type: string
                   fileSystemIdRef:
-                    description: Reference to a FileSystem to populate fileSystemId.
+                    description: Reference to a FileSystem in efs to populate fileSystemId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -378,7 +378,7 @@ spec:
                     - name
                     type: object
                   fileSystemIdSelector:
-                    description: Selector for a FileSystem to populate fileSystemId.
+                    description: Selector for a FileSystem in efs to populate fileSystemId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/eks.aws.upbound.io_addons.yaml
+++ b/package/crds/eks.aws.upbound.io_addons.yaml
@@ -88,7 +88,7 @@ spec:
                       and underscores (^[0-9A-Za-z][A-Za-z0-9\-_]+$).
                     type: string
                   clusterNameRef:
-                    description: Reference to a Cluster to populate clusterName.
+                    description: Reference to a Cluster in eks to populate clusterName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -122,7 +122,7 @@ spec:
                     - name
                     type: object
                   clusterNameSelector:
-                    description: Selector for a Cluster to populate clusterName.
+                    description: Selector for a Cluster in eks to populate clusterName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -318,7 +318,7 @@ spec:
                       and underscores (^[0-9A-Za-z][A-Za-z0-9\-_]+$).
                     type: string
                   clusterNameRef:
-                    description: Reference to a Cluster to populate clusterName.
+                    description: Reference to a Cluster in eks to populate clusterName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -352,7 +352,7 @@ spec:
                     - name
                     type: object
                   clusterNameSelector:
-                    description: Selector for a Cluster to populate clusterName.
+                    description: Selector for a Cluster in eks to populate clusterName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/eks.aws.upbound.io_fargateprofiles.yaml
+++ b/package/crds/eks.aws.upbound.io_fargateprofiles.yaml
@@ -79,7 +79,7 @@ spec:
                       and underscores (^[0-9A-Za-z][A-Za-z0-9\-_]+$).
                     type: string
                   clusterNameRef:
-                    description: Reference to a Cluster to populate clusterName.
+                    description: Reference to a Cluster in eks to populate clusterName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +113,7 @@ spec:
                     - name
                     type: object
                   clusterNameSelector:
-                    description: Selector for a Cluster to populate clusterName.
+                    description: Selector for a Cluster in eks to populate clusterName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -365,7 +365,7 @@ spec:
                       and underscores (^[0-9A-Za-z][A-Za-z0-9\-_]+$).
                     type: string
                   clusterNameRef:
-                    description: Reference to a Cluster to populate clusterName.
+                    description: Reference to a Cluster in eks to populate clusterName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -399,7 +399,7 @@ spec:
                     - name
                     type: object
                   clusterNameSelector:
-                    description: Selector for a Cluster to populate clusterName.
+                    description: Selector for a Cluster in eks to populate clusterName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/eks.aws.upbound.io_identityproviderconfigs.yaml
+++ b/package/crds/eks.aws.upbound.io_identityproviderconfigs.yaml
@@ -77,7 +77,7 @@ spec:
                     description: –  Name of the EKS Cluster.
                     type: string
                   clusterNameRef:
-                    description: Reference to a Cluster to populate clusterName.
+                    description: Reference to a Cluster in eks to populate clusterName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +111,7 @@ spec:
                     - name
                     type: object
                   clusterNameSelector:
-                    description: Selector for a Cluster to populate clusterName.
+                    description: Selector for a Cluster in eks to populate clusterName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -217,7 +217,7 @@ spec:
                     description: –  Name of the EKS Cluster.
                     type: string
                   clusterNameRef:
-                    description: Reference to a Cluster to populate clusterName.
+                    description: Reference to a Cluster in eks to populate clusterName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -251,7 +251,7 @@ spec:
                     - name
                     type: object
                   clusterNameSelector:
-                    description: Selector for a Cluster to populate clusterName.
+                    description: Selector for a Cluster in eks to populate clusterName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/eks.aws.upbound.io_nodegroups.yaml
+++ b/package/crds/eks.aws.upbound.io_nodegroups.yaml
@@ -87,7 +87,7 @@ spec:
                       and underscores (^[0-9A-Za-z][A-Za-z0-9\-_]+$).
                     type: string
                   clusterNameRef:
-                    description: Reference to a Cluster to populate clusterName.
+                    description: Reference to a Cluster in eks to populate clusterName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -121,7 +121,7 @@ spec:
                     - name
                     type: object
                   clusterNameSelector:
-                    description: Selector for a Cluster to populate clusterName.
+                    description: Selector for a Cluster in eks to populate clusterName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/elasticache.aws.upbound.io_usergroups.yaml
+++ b/package/crds/elasticache.aws.upbound.io_usergroups.yaml
@@ -87,7 +87,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: granular
                   userIdRefs:
-                    description: References to User to populate userIds.
+                    description: References to User in elasticache to populate userIds.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -124,7 +124,8 @@ spec:
                       type: object
                     type: array
                   userIdSelector:
-                    description: Selector for a list of User to populate userIds.
+                    description: Selector for a list of User in elasticache to populate
+                      userIds.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -195,7 +196,7 @@ spec:
                     type: object
                     x-kubernetes-map-type: granular
                   userIdRefs:
-                    description: References to User to populate userIds.
+                    description: References to User in elasticache to populate userIds.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -232,7 +233,8 @@ spec:
                       type: object
                     type: array
                   userIdSelector:
-                    description: Selector for a list of User to populate userIds.
+                    description: Selector for a list of User in elasticache to populate
+                      userIds.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/elb.aws.upbound.io_attachments.yaml
+++ b/package/crds/elb.aws.upbound.io_attachments.yaml
@@ -77,7 +77,7 @@ spec:
                     description: The name of the ELB.
                     type: string
                   elbRef:
-                    description: Reference to a ELB to populate elb.
+                    description: Reference to a ELB in elb to populate elb.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +111,7 @@ spec:
                     - name
                     type: object
                   elbSelector:
-                    description: Selector for a ELB to populate elb.
+                    description: Selector for a ELB in elb to populate elb.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -251,7 +251,7 @@ spec:
                     description: The name of the ELB.
                     type: string
                   elbRef:
-                    description: Reference to a ELB to populate elb.
+                    description: Reference to a ELB in elb to populate elb.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -285,7 +285,7 @@ spec:
                     - name
                     type: object
                   elbSelector:
-                    description: Selector for a ELB to populate elb.
+                    description: Selector for a ELB in elb to populate elb.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/elbv2.aws.upbound.io_lblisteners.yaml
+++ b/package/crds/elbv2.aws.upbound.io_lblisteners.yaml
@@ -251,8 +251,8 @@ spec:
                                       description: ARN of the target group.
                                       type: string
                                     arnRef:
-                                      description: Reference to a LBTargetGroup to
-                                        populate arn.
+                                      description: Reference to a LBTargetGroup in
+                                        elbv2 to populate arn.
                                       properties:
                                         name:
                                           description: Name of the referenced object.
@@ -286,8 +286,8 @@ spec:
                                       - name
                                       type: object
                                     arnSelector:
-                                      description: Selector for a LBTargetGroup to
-                                        populate arn.
+                                      description: Selector for a LBTargetGroup in
+                                        elbv2 to populate arn.
                                       properties:
                                         matchControllerRef:
                                           description: |-
@@ -380,7 +380,8 @@ spec:
                             groups, use a forward block instead.
                           type: string
                         targetGroupArnRef:
-                          description: Reference to a LBTargetGroup to populate targetGroupArn.
+                          description: Reference to a LBTargetGroup in elbv2 to populate
+                            targetGroupArn.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -414,7 +415,8 @@ spec:
                           - name
                           type: object
                         targetGroupArnSelector:
-                          description: Selector for a LBTargetGroup to populate targetGroupArn.
+                          description: Selector for a LBTargetGroup in elbv2 to populate
+                            targetGroupArn.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -463,7 +465,7 @@ spec:
                     description: ARN of the load balancer.
                     type: string
                   loadBalancerArnRef:
-                    description: Reference to a LB to populate loadBalancerArn.
+                    description: Reference to a LB in elbv2 to populate loadBalancerArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -497,7 +499,7 @@ spec:
                     - name
                     type: object
                   loadBalancerArnSelector:
-                    description: Selector for a LB to populate loadBalancerArn.
+                    description: Selector for a LB in elbv2 to populate loadBalancerArn.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -754,8 +756,8 @@ spec:
                                       description: ARN of the target group.
                                       type: string
                                     arnRef:
-                                      description: Reference to a LBTargetGroup to
-                                        populate arn.
+                                      description: Reference to a LBTargetGroup in
+                                        elbv2 to populate arn.
                                       properties:
                                         name:
                                           description: Name of the referenced object.
@@ -789,8 +791,8 @@ spec:
                                       - name
                                       type: object
                                     arnSelector:
-                                      description: Selector for a LBTargetGroup to
-                                        populate arn.
+                                      description: Selector for a LBTargetGroup in
+                                        elbv2 to populate arn.
                                       properties:
                                         matchControllerRef:
                                           description: |-
@@ -883,7 +885,8 @@ spec:
                             groups, use a forward block instead.
                           type: string
                         targetGroupArnRef:
-                          description: Reference to a LBTargetGroup to populate targetGroupArn.
+                          description: Reference to a LBTargetGroup in elbv2 to populate
+                            targetGroupArn.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -917,7 +920,8 @@ spec:
                           - name
                           type: object
                         targetGroupArnSelector:
-                          description: Selector for a LBTargetGroup to populate targetGroupArn.
+                          description: Selector for a LBTargetGroup in elbv2 to populate
+                            targetGroupArn.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -966,7 +970,7 @@ spec:
                     description: ARN of the load balancer.
                     type: string
                   loadBalancerArnRef:
-                    description: Reference to a LB to populate loadBalancerArn.
+                    description: Reference to a LB in elbv2 to populate loadBalancerArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1000,7 +1004,7 @@ spec:
                     - name
                     type: object
                   loadBalancerArnSelector:
-                    description: Selector for a LB to populate loadBalancerArn.
+                    description: Selector for a LB in elbv2 to populate loadBalancerArn.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/elbv2.aws.upbound.io_lbtargetgroupattachments.yaml
+++ b/package/crds/elbv2.aws.upbound.io_lbtargetgroupattachments.yaml
@@ -92,7 +92,8 @@ spec:
                       targets.
                     type: string
                   targetGroupArnRef:
-                    description: Reference to a LBTargetGroup to populate targetGroupArn.
+                    description: Reference to a LBTargetGroup in elbv2 to populate
+                      targetGroupArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -126,7 +127,8 @@ spec:
                     - name
                     type: object
                   targetGroupArnSelector:
-                    description: Selector for a LBTargetGroup to populate targetGroupArn.
+                    description: Selector for a LBTargetGroup in elbv2 to populate
+                      targetGroupArn.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -201,7 +203,8 @@ spec:
                       targets.
                     type: string
                   targetGroupArnRef:
-                    description: Reference to a LBTargetGroup to populate targetGroupArn.
+                    description: Reference to a LBTargetGroup in elbv2 to populate
+                      targetGroupArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -235,7 +238,8 @@ spec:
                     - name
                     type: object
                   targetGroupArnSelector:
-                    description: Selector for a LBTargetGroup to populate targetGroupArn.
+                    description: Selector for a LBTargetGroup in elbv2 to populate
+                      targetGroupArn.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/gamelift.aws.upbound.io_fleet.yaml
+++ b/package/crds/gamelift.aws.upbound.io_fleet.yaml
@@ -77,7 +77,7 @@ spec:
                     description: ID of the GameLift Build to be deployed on the fleet.
                     type: string
                   buildIdRef:
-                    description: Reference to a Build to populate buildId.
+                    description: Reference to a Build in gamelift to populate buildId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +111,7 @@ spec:
                     - name
                     type: object
                   buildIdSelector:
-                    description: Selector for a Build to populate buildId.
+                    description: Selector for a Build in gamelift to populate buildId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -376,7 +376,7 @@ spec:
                     description: ID of the GameLift Build to be deployed on the fleet.
                     type: string
                   buildIdRef:
-                    description: Reference to a Build to populate buildId.
+                    description: Reference to a Build in gamelift to populate buildId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -410,7 +410,7 @@ spec:
                     - name
                     type: object
                   buildIdSelector:
-                    description: Selector for a Build to populate buildId.
+                    description: Selector for a Build in gamelift to populate buildId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/globalaccelerator.aws.upbound.io_endpointgroups.yaml
+++ b/package/crds/globalaccelerator.aws.upbound.io_endpointgroups.yaml
@@ -127,7 +127,8 @@ spec:
                     description: The Amazon Resource Name (ARN) of the listener.
                     type: string
                   listenerArnRef:
-                    description: Reference to a Listener to populate listenerArn.
+                    description: Reference to a Listener in globalaccelerator to populate
+                      listenerArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -161,7 +162,8 @@ spec:
                     - name
                     type: object
                   listenerArnSelector:
-                    description: Selector for a Listener to populate listenerArn.
+                    description: Selector for a Listener in globalaccelerator to populate
+                      listenerArn.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -302,7 +304,8 @@ spec:
                     description: The Amazon Resource Name (ARN) of the listener.
                     type: string
                   listenerArnRef:
-                    description: Reference to a Listener to populate listenerArn.
+                    description: Reference to a Listener in globalaccelerator to populate
+                      listenerArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -336,7 +339,8 @@ spec:
                     - name
                     type: object
                   listenerArnSelector:
-                    description: Selector for a Listener to populate listenerArn.
+                    description: Selector for a Listener in globalaccelerator to populate
+                      listenerArn.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/globalaccelerator.aws.upbound.io_listeners.yaml
+++ b/package/crds/globalaccelerator.aws.upbound.io_listeners.yaml
@@ -77,7 +77,8 @@ spec:
                     description: The Amazon Resource Name (ARN) of your accelerator.
                     type: string
                   acceleratorArnRef:
-                    description: Reference to a Accelerator to populate acceleratorArn.
+                    description: Reference to a Accelerator in globalaccelerator to
+                      populate acceleratorArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +112,8 @@ spec:
                     - name
                     type: object
                   acceleratorArnSelector:
-                    description: Selector for a Accelerator to populate acceleratorArn.
+                    description: Selector for a Accelerator in globalaccelerator to
+                      populate acceleratorArn.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -200,7 +202,8 @@ spec:
                     description: The Amazon Resource Name (ARN) of your accelerator.
                     type: string
                   acceleratorArnRef:
-                    description: Reference to a Accelerator to populate acceleratorArn.
+                    description: Reference to a Accelerator in globalaccelerator to
+                      populate acceleratorArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -234,7 +237,8 @@ spec:
                     - name
                     type: object
                   acceleratorArnSelector:
-                    description: Selector for a Accelerator to populate acceleratorArn.
+                    description: Selector for a Accelerator in globalaccelerator to
+                      populate acceleratorArn.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/grafana.aws.upbound.io_roleassociations.yaml
+++ b/package/crds/grafana.aws.upbound.io_roleassociations.yaml
@@ -98,7 +98,7 @@ spec:
                     description: The workspace id.
                     type: string
                   workspaceIdRef:
-                    description: Reference to a Workspace to populate workspaceId.
+                    description: Reference to a Workspace in grafana to populate workspaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -132,7 +132,7 @@ spec:
                     - name
                     type: object
                   workspaceIdSelector:
-                    description: Selector for a Workspace to populate workspaceId.
+                    description: Selector for a Workspace in grafana to populate workspaceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -208,7 +208,7 @@ spec:
                     description: The workspace id.
                     type: string
                   workspaceIdRef:
-                    description: Reference to a Workspace to populate workspaceId.
+                    description: Reference to a Workspace in grafana to populate workspaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -242,7 +242,7 @@ spec:
                     - name
                     type: object
                   workspaceIdSelector:
-                    description: Selector for a Workspace to populate workspaceId.
+                    description: Selector for a Workspace in grafana to populate workspaceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/grafana.aws.upbound.io_workspacesamlconfigurations.yaml
+++ b/package/crds/grafana.aws.upbound.io_workspacesamlconfigurations.yaml
@@ -126,7 +126,7 @@ spec:
                     description: The workspace id.
                     type: string
                   workspaceIdRef:
-                    description: Reference to a Workspace to populate workspaceId.
+                    description: Reference to a Workspace in grafana to populate workspaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -160,7 +160,7 @@ spec:
                     - name
                     type: object
                   workspaceIdSelector:
-                    description: Selector for a Workspace to populate workspaceId.
+                    description: Selector for a Workspace in grafana to populate workspaceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -263,7 +263,7 @@ spec:
                     description: The workspace id.
                     type: string
                   workspaceIdRef:
-                    description: Reference to a Workspace to populate workspaceId.
+                    description: Reference to a Workspace in grafana to populate workspaceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -297,7 +297,7 @@ spec:
                     - name
                     type: object
                   workspaceIdSelector:
-                    description: Selector for a Workspace to populate workspaceId.
+                    description: Selector for a Workspace in grafana to populate workspaceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/iam.aws.upbound.io_groupmemberships.yaml
+++ b/package/crds/iam.aws.upbound.io_groupmemberships.yaml
@@ -78,7 +78,7 @@ spec:
                       to
                     type: string
                   groupRef:
-                    description: Reference to a Group to populate group.
+                    description: Reference to a Group in iam to populate group.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +112,7 @@ spec:
                     - name
                     type: object
                   groupSelector:
-                    description: Selector for a Group to populate group.
+                    description: Selector for a Group in iam to populate group.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -155,7 +155,7 @@ spec:
                     description: The name to identify the Group Membership
                     type: string
                   userRefs:
-                    description: References to User to populate users.
+                    description: References to User in iam to populate users.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -192,7 +192,7 @@ spec:
                       type: object
                     type: array
                   userSelector:
-                    description: Selector for a list of User to populate users.
+                    description: Selector for a list of User in iam to populate users.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -256,7 +256,7 @@ spec:
                       to
                     type: string
                   groupRef:
-                    description: Reference to a Group to populate group.
+                    description: Reference to a Group in iam to populate group.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -290,7 +290,7 @@ spec:
                     - name
                     type: object
                   groupSelector:
-                    description: Selector for a Group to populate group.
+                    description: Selector for a Group in iam to populate group.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -333,7 +333,7 @@ spec:
                     description: The name to identify the Group Membership
                     type: string
                   userRefs:
-                    description: References to User to populate users.
+                    description: References to User in iam to populate users.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -370,7 +370,7 @@ spec:
                       type: object
                     type: array
                   userSelector:
-                    description: Selector for a list of User to populate users.
+                    description: Selector for a list of User in iam to populate users.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/iam.aws.upbound.io_servicespecificcredentials.yaml
+++ b/package/crds/iam.aws.upbound.io_servicespecificcredentials.yaml
@@ -91,7 +91,7 @@ spec:
                       can be used only to access the specified service.
                     type: string
                   userNameRef:
-                    description: Reference to a User to populate userName.
+                    description: Reference to a User in iam to populate userName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -125,7 +125,7 @@ spec:
                     - name
                     type: object
                   userNameSelector:
-                    description: Selector for a User to populate userName.
+                    description: Selector for a User in iam to populate userName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -195,7 +195,7 @@ spec:
                       can be used only to access the specified service.
                     type: string
                   userNameRef:
-                    description: Reference to a User to populate userName.
+                    description: Reference to a User in iam to populate userName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -229,7 +229,7 @@ spec:
                     - name
                     type: object
                   userNameSelector:
-                    description: Selector for a User to populate userName.
+                    description: Selector for a User in iam to populate userName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/iam.aws.upbound.io_userloginprofiles.yaml
+++ b/package/crds/iam.aws.upbound.io_userloginprofiles.yaml
@@ -91,7 +91,7 @@ spec:
                     description: The IAM user's name.
                     type: string
                   userRef:
-                    description: Reference to a User to populate user.
+                    description: Reference to a User in iam to populate user.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -125,7 +125,7 @@ spec:
                     - name
                     type: object
                   userSelector:
-                    description: Selector for a User to populate user.
+                    description: Selector for a User in iam to populate user.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -196,7 +196,7 @@ spec:
                     description: The IAM user's name.
                     type: string
                   userRef:
-                    description: Reference to a User to populate user.
+                    description: Reference to a User in iam to populate user.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -230,7 +230,7 @@ spec:
                     - name
                     type: object
                   userSelector:
-                    description: Selector for a User to populate user.
+                    description: Selector for a User in iam to populate user.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/iam.aws.upbound.io_usersshkeys.yaml
+++ b/package/crds/iam.aws.upbound.io_usersshkeys.yaml
@@ -93,7 +93,7 @@ spec:
                       key with.
                     type: string
                   usernameRef:
-                    description: Reference to a User to populate username.
+                    description: Reference to a User in iam to populate username.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -127,7 +127,7 @@ spec:
                     - name
                     type: object
                   usernameSelector:
-                    description: Selector for a User to populate username.
+                    description: Selector for a User in iam to populate username.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -200,7 +200,7 @@ spec:
                       key with.
                     type: string
                   usernameRef:
-                    description: Reference to a User to populate username.
+                    description: Reference to a User in iam to populate username.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -234,7 +234,7 @@ spec:
                     - name
                     type: object
                   usernameSelector:
-                    description: Selector for a User to populate username.
+                    description: Selector for a User in iam to populate username.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/kms.aws.upbound.io_aliases.yaml
+++ b/package/crds/kms.aws.upbound.io_aliases.yaml
@@ -82,7 +82,7 @@ spec:
                       can be either an ARN or key_id.
                     type: string
                   targetKeyIdRef:
-                    description: Reference to a Key to populate targetKeyId.
+                    description: Reference to a Key in kms to populate targetKeyId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -116,7 +116,7 @@ spec:
                     - name
                     type: object
                   targetKeyIdSelector:
-                    description: Selector for a Key to populate targetKeyId.
+                    description: Selector for a Key in kms to populate targetKeyId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -176,7 +176,7 @@ spec:
                       can be either an ARN or key_id.
                     type: string
                   targetKeyIdRef:
-                    description: Reference to a Key to populate targetKeyId.
+                    description: Reference to a Key in kms to populate targetKeyId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -210,7 +210,7 @@ spec:
                     - name
                     type: object
                   targetKeyIdSelector:
-                    description: Selector for a Key to populate targetKeyId.
+                    description: Selector for a Key in kms to populate targetKeyId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/kms.aws.upbound.io_ciphertexts.yaml
+++ b/package/crds/kms.aws.upbound.io_ciphertexts.yaml
@@ -84,7 +84,7 @@ spec:
                     description: Globally unique key ID for the customer master key.
                     type: string
                   keyIdRef:
-                    description: Reference to a Key to populate keyId.
+                    description: Reference to a Key in kms to populate keyId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -118,7 +118,7 @@ spec:
                     - name
                     type: object
                   keyIdSelector:
-                    description: Selector for a Key to populate keyId.
+                    description: Selector for a Key in kms to populate keyId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -206,7 +206,7 @@ spec:
                     description: Globally unique key ID for the customer master key.
                     type: string
                   keyIdRef:
-                    description: Reference to a Key to populate keyId.
+                    description: Reference to a Key in kms to populate keyId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -240,7 +240,7 @@ spec:
                     - name
                     type: object
                   keyIdSelector:
-                    description: Selector for a Key to populate keyId.
+                    description: Selector for a Key in kms to populate keyId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/kms.aws.upbound.io_grants.yaml
+++ b/package/crds/kms.aws.upbound.io_grants.yaml
@@ -196,7 +196,7 @@ spec:
                       AWS account, you must use the key ARN.
                     type: string
                   keyIdRef:
-                    description: Reference to a Key to populate keyId.
+                    description: Reference to a Key in kms to populate keyId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -230,7 +230,7 @@ spec:
                     - name
                     type: object
                   keyIdSelector:
-                    description: Selector for a Key to populate keyId.
+                    description: Selector for a Key in kms to populate keyId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -433,7 +433,7 @@ spec:
                       AWS account, you must use the key ARN.
                     type: string
                   keyIdRef:
-                    description: Reference to a Key to populate keyId.
+                    description: Reference to a Key in kms to populate keyId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -467,7 +467,7 @@ spec:
                     - name
                     type: object
                   keyIdSelector:
-                    description: Selector for a Key to populate keyId.
+                    description: Selector for a Key in kms to populate keyId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/kms.aws.upbound.io_replicaexternalkeys.yaml
+++ b/package/crds/kms.aws.upbound.io_replicaexternalkeys.yaml
@@ -126,7 +126,7 @@ spec:
                       key in each AWS Region.
                     type: string
                   primaryKeyArnRef:
-                    description: Reference to a ExternalKey to populate primaryKeyArn.
+                    description: Reference to a ExternalKey in kms to populate primaryKeyArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -160,7 +160,7 @@ spec:
                     - name
                     type: object
                   primaryKeyArnSelector:
-                    description: Selector for a ExternalKey to populate primaryKeyArn.
+                    description: Selector for a ExternalKey in kms to populate primaryKeyArn.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -264,7 +264,7 @@ spec:
                       key in each AWS Region.
                     type: string
                   primaryKeyArnRef:
-                    description: Reference to a ExternalKey to populate primaryKeyArn.
+                    description: Reference to a ExternalKey in kms to populate primaryKeyArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -298,7 +298,7 @@ spec:
                     - name
                     type: object
                   primaryKeyArnSelector:
-                    description: Selector for a ExternalKey to populate primaryKeyArn.
+                    description: Selector for a ExternalKey in kms to populate primaryKeyArn.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/kms.aws.upbound.io_replicakeys.yaml
+++ b/package/crds/kms.aws.upbound.io_replicakeys.yaml
@@ -105,7 +105,7 @@ spec:
                       key in each AWS Region.
                     type: string
                   primaryKeyArnRef:
-                    description: Reference to a Key to populate primaryKeyArn.
+                    description: Reference to a Key in kms to populate primaryKeyArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -139,7 +139,7 @@ spec:
                     - name
                     type: object
                   primaryKeyArnSelector:
-                    description: Selector for a Key to populate primaryKeyArn.
+                    description: Selector for a Key in kms to populate primaryKeyArn.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -236,7 +236,7 @@ spec:
                       key in each AWS Region.
                     type: string
                   primaryKeyArnRef:
-                    description: Reference to a Key to populate primaryKeyArn.
+                    description: Reference to a Key in kms to populate primaryKeyArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -270,7 +270,7 @@ spec:
                     - name
                     type: object
                   primaryKeyArnSelector:
-                    description: Selector for a Key to populate primaryKeyArn.
+                    description: Selector for a Key in kms to populate primaryKeyArn.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/lambda.aws.upbound.io_aliases.yaml
+++ b/package/crds/lambda.aws.upbound.io_aliases.yaml
@@ -80,7 +80,7 @@ spec:
                     description: Lambda Function name or ARN.
                     type: string
                   functionNameRef:
-                    description: Reference to a Function to populate functionName.
+                    description: Reference to a Function in lambda to populate functionName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -114,7 +114,7 @@ spec:
                     - name
                     type: object
                   functionNameSelector:
-                    description: Selector for a Function to populate functionName.
+                    description: Selector for a Function in lambda to populate functionName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/lambda.aws.upbound.io_eventsourcemappings.yaml
+++ b/package/crds/lambda.aws.upbound.io_eventsourcemappings.yaml
@@ -176,7 +176,7 @@ spec:
                       be subscribing to events.
                     type: string
                   functionNameRef:
-                    description: Reference to a Function to populate functionName.
+                    description: Reference to a Function in lambda to populate functionName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -210,7 +210,7 @@ spec:
                     - name
                     type: object
                   functionNameSelector:
-                    description: Selector for a Function to populate functionName.
+                    description: Selector for a Function in lambda to populate functionName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -509,7 +509,7 @@ spec:
                       be subscribing to events.
                     type: string
                   functionNameRef:
-                    description: Reference to a Function to populate functionName.
+                    description: Reference to a Function in lambda to populate functionName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -543,7 +543,7 @@ spec:
                     - name
                     type: object
                   functionNameSelector:
-                    description: Selector for a Function to populate functionName.
+                    description: Selector for a Function in lambda to populate functionName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/lambda.aws.upbound.io_functionurls.yaml
+++ b/package/crds/lambda.aws.upbound.io_functionurls.yaml
@@ -133,7 +133,7 @@ spec:
                     description: The name (or ARN) of the Lambda function.
                     type: string
                   functionNameRef:
-                    description: Reference to a Function to populate functionName.
+                    description: Reference to a Function in lambda to populate functionName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -167,7 +167,7 @@ spec:
                     - name
                     type: object
                   functionNameSelector:
-                    description: Selector for a Function to populate functionName.
+                    description: Selector for a Function in lambda to populate functionName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -294,7 +294,7 @@ spec:
                     description: The name (or ARN) of the Lambda function.
                     type: string
                   functionNameRef:
-                    description: Reference to a Function to populate functionName.
+                    description: Reference to a Function in lambda to populate functionName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -328,7 +328,7 @@ spec:
                     - name
                     type: object
                   functionNameSelector:
-                    description: Selector for a Function to populate functionName.
+                    description: Selector for a Function in lambda to populate functionName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/lambda.aws.upbound.io_invocations.yaml
+++ b/package/crds/lambda.aws.upbound.io_invocations.yaml
@@ -77,7 +77,7 @@ spec:
                     description: Name of the lambda function.
                     type: string
                   functionNameRef:
-                    description: Reference to a Function to populate functionName.
+                    description: Reference to a Function in lambda to populate functionName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +111,7 @@ spec:
                     - name
                     type: object
                   functionNameSelector:
-                    description: Selector for a Function to populate functionName.
+                    description: Selector for a Function in lambda to populate functionName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -200,7 +200,7 @@ spec:
                     description: Name of the lambda function.
                     type: string
                   functionNameRef:
-                    description: Reference to a Function to populate functionName.
+                    description: Reference to a Function in lambda to populate functionName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -234,7 +234,7 @@ spec:
                     - name
                     type: object
                   functionNameSelector:
-                    description: Selector for a Function to populate functionName.
+                    description: Selector for a Function in lambda to populate functionName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/lambda.aws.upbound.io_permissions.yaml
+++ b/package/crds/lambda.aws.upbound.io_permissions.yaml
@@ -86,7 +86,7 @@ spec:
                       you are updating
                     type: string
                   functionNameRef:
-                    description: Reference to a Function to populate functionName.
+                    description: Reference to a Function in lambda to populate functionName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -120,7 +120,7 @@ spec:
                     - name
                     type: object
                   functionNameSelector:
-                    description: Selector for a Function to populate functionName.
+                    description: Selector for a Function in lambda to populate functionName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -180,7 +180,7 @@ spec:
                       ARN e.g., arn:aws:lambda:aws-region:acct-id:function:function-name:2
                     type: string
                   qualifierRef:
-                    description: Reference to a Alias to populate qualifier.
+                    description: Reference to a Alias in lambda to populate qualifier.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -214,7 +214,7 @@ spec:
                     - name
                     type: object
                   qualifierSelector:
-                    description: Selector for a Alias to populate qualifier.
+                    description: Selector for a Alias in lambda to populate qualifier.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -305,7 +305,7 @@ spec:
                       you are updating
                     type: string
                   functionNameRef:
-                    description: Reference to a Function to populate functionName.
+                    description: Reference to a Function in lambda to populate functionName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -339,7 +339,7 @@ spec:
                     - name
                     type: object
                   functionNameSelector:
-                    description: Selector for a Function to populate functionName.
+                    description: Selector for a Function in lambda to populate functionName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -399,7 +399,7 @@ spec:
                       ARN e.g., arn:aws:lambda:aws-region:acct-id:function:function-name:2
                     type: string
                   qualifierRef:
-                    description: Reference to a Alias to populate qualifier.
+                    description: Reference to a Alias in lambda to populate qualifier.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -433,7 +433,7 @@ spec:
                     - name
                     type: object
                   qualifierSelector:
-                    description: Selector for a Alias to populate qualifier.
+                    description: Selector for a Alias in lambda to populate qualifier.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/licensemanager.aws.upbound.io_associations.yaml
+++ b/package/crds/licensemanager.aws.upbound.io_associations.yaml
@@ -77,7 +77,8 @@ spec:
                     description: ARN of the license configuration.
                     type: string
                   licenseConfigurationArnRef:
-                    description: Reference to a LicenseConfiguration to populate licenseConfigurationArn.
+                    description: Reference to a LicenseConfiguration in licensemanager
+                      to populate licenseConfigurationArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +112,8 @@ spec:
                     - name
                     type: object
                   licenseConfigurationArnSelector:
-                    description: Selector for a LicenseConfiguration to populate licenseConfigurationArn.
+                    description: Selector for a LicenseConfiguration in licensemanager
+                      to populate licenseConfigurationArn.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -251,7 +253,8 @@ spec:
                     description: ARN of the license configuration.
                     type: string
                   licenseConfigurationArnRef:
-                    description: Reference to a LicenseConfiguration to populate licenseConfigurationArn.
+                    description: Reference to a LicenseConfiguration in licensemanager
+                      to populate licenseConfigurationArn.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -285,7 +288,8 @@ spec:
                     - name
                     type: object
                   licenseConfigurationArnSelector:
-                    description: Selector for a LicenseConfiguration to populate licenseConfigurationArn.
+                    description: Selector for a LicenseConfiguration in licensemanager
+                      to populate licenseConfigurationArn.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/neptune.aws.upbound.io_clusterendpoints.yaml
+++ b/package/crds/neptune.aws.upbound.io_clusterendpoints.yaml
@@ -78,7 +78,7 @@ spec:
                       with the endpoint.
                     type: string
                   clusterIdentifierRef:
-                    description: Reference to a Cluster to populate clusterIdentifier.
+                    description: Reference to a Cluster in neptune to populate clusterIdentifier.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +112,7 @@ spec:
                     - name
                     type: object
                   clusterIdentifierSelector:
-                    description: Selector for a Cluster to populate clusterIdentifier.
+                    description: Selector for a Cluster in neptune to populate clusterIdentifier.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -202,7 +202,7 @@ spec:
                       with the endpoint.
                     type: string
                   clusterIdentifierRef:
-                    description: Reference to a Cluster to populate clusterIdentifier.
+                    description: Reference to a Cluster in neptune to populate clusterIdentifier.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -236,7 +236,7 @@ spec:
                     - name
                     type: object
                   clusterIdentifierSelector:
-                    description: Selector for a Cluster to populate clusterIdentifier.
+                    description: Selector for a Cluster in neptune to populate clusterIdentifier.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/neptune.aws.upbound.io_clusterinstances.yaml
+++ b/package/crds/neptune.aws.upbound.io_clusterinstances.yaml
@@ -92,7 +92,7 @@ spec:
                       to launch this instance.
                     type: string
                   clusterIdentifierRef:
-                    description: Reference to a Cluster to populate clusterIdentifier.
+                    description: Reference to a Cluster in neptune to populate clusterIdentifier.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -126,7 +126,7 @@ spec:
                     - name
                     type: object
                   clusterIdentifierSelector:
-                    description: Selector for a Cluster to populate clusterIdentifier.
+                    description: Selector for a Cluster in neptune to populate clusterIdentifier.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -181,7 +181,8 @@ spec:
                       with this instance.
                     type: string
                   neptuneParameterGroupNameRef:
-                    description: Reference to a ParameterGroup to populate neptuneParameterGroupName.
+                    description: Reference to a ParameterGroup in neptune to populate
+                      neptuneParameterGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -215,7 +216,8 @@ spec:
                     - name
                     type: object
                   neptuneParameterGroupNameSelector:
-                    description: Selector for a ParameterGroup to populate neptuneParameterGroupName.
+                    description: Selector for a ParameterGroup in neptune to populate
+                      neptuneParameterGroupName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -260,7 +262,8 @@ spec:
                       aws_neptune_cluster.'
                     type: string
                   neptuneSubnetGroupNameRef:
-                    description: Reference to a SubnetGroup to populate neptuneSubnetGroupName.
+                    description: Reference to a SubnetGroup in neptune to populate
+                      neptuneSubnetGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -294,7 +297,8 @@ spec:
                     - name
                     type: object
                   neptuneSubnetGroupNameSelector:
-                    description: Selector for a SubnetGroup to populate neptuneSubnetGroupName.
+                    description: Selector for a SubnetGroup in neptune to populate
+                      neptuneSubnetGroupName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -400,7 +404,7 @@ spec:
                       to launch this instance.
                     type: string
                   clusterIdentifierRef:
-                    description: Reference to a Cluster to populate clusterIdentifier.
+                    description: Reference to a Cluster in neptune to populate clusterIdentifier.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -434,7 +438,7 @@ spec:
                     - name
                     type: object
                   clusterIdentifierSelector:
-                    description: Selector for a Cluster to populate clusterIdentifier.
+                    description: Selector for a Cluster in neptune to populate clusterIdentifier.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -489,7 +493,8 @@ spec:
                       with this instance.
                     type: string
                   neptuneParameterGroupNameRef:
-                    description: Reference to a ParameterGroup to populate neptuneParameterGroupName.
+                    description: Reference to a ParameterGroup in neptune to populate
+                      neptuneParameterGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -523,7 +528,8 @@ spec:
                     - name
                     type: object
                   neptuneParameterGroupNameSelector:
-                    description: Selector for a ParameterGroup to populate neptuneParameterGroupName.
+                    description: Selector for a ParameterGroup in neptune to populate
+                      neptuneParameterGroupName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -568,7 +574,8 @@ spec:
                       aws_neptune_cluster.'
                     type: string
                   neptuneSubnetGroupNameRef:
-                    description: Reference to a SubnetGroup to populate neptuneSubnetGroupName.
+                    description: Reference to a SubnetGroup in neptune to populate
+                      neptuneSubnetGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -602,7 +609,8 @@ spec:
                     - name
                     type: object
                   neptuneSubnetGroupNameSelector:
-                    description: Selector for a SubnetGroup to populate neptuneSubnetGroupName.
+                    description: Selector for a SubnetGroup in neptune to populate
+                      neptuneSubnetGroupName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/neptune.aws.upbound.io_clusters.yaml
+++ b/package/crds/neptune.aws.upbound.io_clusters.yaml
@@ -298,8 +298,8 @@ spec:
                     description: A cluster parameter group to associate with the cluster.
                     type: string
                   neptuneClusterParameterGroupNameRef:
-                    description: Reference to a ClusterParameterGroup to populate
-                      neptuneClusterParameterGroupName.
+                    description: Reference to a ClusterParameterGroup in neptune to
+                      populate neptuneClusterParameterGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -333,8 +333,8 @@ spec:
                     - name
                     type: object
                   neptuneClusterParameterGroupNameSelector:
-                    description: Selector for a ClusterParameterGroup to populate
-                      neptuneClusterParameterGroupName.
+                    description: Selector for a ClusterParameterGroup in neptune to
+                      populate neptuneClusterParameterGroupName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -382,7 +382,8 @@ spec:
                       instance.
                     type: string
                   neptuneSubnetGroupNameRef:
-                    description: Reference to a SubnetGroup to populate neptuneSubnetGroupName.
+                    description: Reference to a SubnetGroup in neptune to populate
+                      neptuneSubnetGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -416,7 +417,8 @@ spec:
                     - name
                     type: object
                   neptuneSubnetGroupNameSelector:
-                    description: Selector for a SubnetGroup to populate neptuneSubnetGroupName.
+                    description: Selector for a SubnetGroup in neptune to populate
+                      neptuneSubnetGroupName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -478,7 +480,7 @@ spec:
                       if this Neptune cluster is to be created as a Read Replica.
                     type: string
                   replicationSourceIdentifierRef:
-                    description: Reference to a Cluster to populate replicationSourceIdentifier.
+                    description: Reference to a Cluster in neptune to populate replicationSourceIdentifier.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -512,7 +514,7 @@ spec:
                     - name
                     type: object
                   replicationSourceIdentifierSelector:
-                    description: Selector for a Cluster to populate replicationSourceIdentifier.
+                    description: Selector for a Cluster in neptune to populate replicationSourceIdentifier.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -584,7 +586,8 @@ spec:
                       as part of cluster destruction when the resource is replaced.
                     type: string
                   snapshotIdentifierRef:
-                    description: Reference to a ClusterSnapshot to populate snapshotIdentifier.
+                    description: Reference to a ClusterSnapshot in neptune to populate
+                      snapshotIdentifier.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -618,7 +621,8 @@ spec:
                     - name
                     type: object
                   snapshotIdentifierSelector:
-                    description: Selector for a ClusterSnapshot to populate snapshotIdentifier.
+                    description: Selector for a ClusterSnapshot in neptune to populate
+                      snapshotIdentifier.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -993,8 +997,8 @@ spec:
                     description: A cluster parameter group to associate with the cluster.
                     type: string
                   neptuneClusterParameterGroupNameRef:
-                    description: Reference to a ClusterParameterGroup to populate
-                      neptuneClusterParameterGroupName.
+                    description: Reference to a ClusterParameterGroup in neptune to
+                      populate neptuneClusterParameterGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1028,8 +1032,8 @@ spec:
                     - name
                     type: object
                   neptuneClusterParameterGroupNameSelector:
-                    description: Selector for a ClusterParameterGroup to populate
-                      neptuneClusterParameterGroupName.
+                    description: Selector for a ClusterParameterGroup in neptune to
+                      populate neptuneClusterParameterGroupName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -1077,7 +1081,8 @@ spec:
                       instance.
                     type: string
                   neptuneSubnetGroupNameRef:
-                    description: Reference to a SubnetGroup to populate neptuneSubnetGroupName.
+                    description: Reference to a SubnetGroup in neptune to populate
+                      neptuneSubnetGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1111,7 +1116,8 @@ spec:
                     - name
                     type: object
                   neptuneSubnetGroupNameSelector:
-                    description: Selector for a SubnetGroup to populate neptuneSubnetGroupName.
+                    description: Selector for a SubnetGroup in neptune to populate
+                      neptuneSubnetGroupName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -1169,7 +1175,7 @@ spec:
                       if this Neptune cluster is to be created as a Read Replica.
                     type: string
                   replicationSourceIdentifierRef:
-                    description: Reference to a Cluster to populate replicationSourceIdentifier.
+                    description: Reference to a Cluster in neptune to populate replicationSourceIdentifier.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1203,7 +1209,7 @@ spec:
                     - name
                     type: object
                   replicationSourceIdentifierSelector:
-                    description: Selector for a Cluster to populate replicationSourceIdentifier.
+                    description: Selector for a Cluster in neptune to populate replicationSourceIdentifier.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -1275,7 +1281,8 @@ spec:
                       as part of cluster destruction when the resource is replaced.
                     type: string
                   snapshotIdentifierRef:
-                    description: Reference to a ClusterSnapshot to populate snapshotIdentifier.
+                    description: Reference to a ClusterSnapshot in neptune to populate
+                      snapshotIdentifier.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1309,7 +1316,8 @@ spec:
                     - name
                     type: object
                   snapshotIdentifierSelector:
-                    description: Selector for a ClusterSnapshot to populate snapshotIdentifier.
+                    description: Selector for a ClusterSnapshot in neptune to populate
+                      snapshotIdentifier.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/neptune.aws.upbound.io_clustersnapshots.yaml
+++ b/package/crds/neptune.aws.upbound.io_clustersnapshots.yaml
@@ -78,7 +78,7 @@ spec:
                       snapshot.
                     type: string
                   dbClusterIdentifierRef:
-                    description: Reference to a Cluster to populate dbClusterIdentifier.
+                    description: Reference to a Cluster in neptune to populate dbClusterIdentifier.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -112,7 +112,7 @@ spec:
                     - name
                     type: object
                   dbClusterIdentifierSelector:
-                    description: Selector for a Cluster to populate dbClusterIdentifier.
+                    description: Selector for a Cluster in neptune to populate dbClusterIdentifier.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -176,7 +176,7 @@ spec:
                       snapshot.
                     type: string
                   dbClusterIdentifierRef:
-                    description: Reference to a Cluster to populate dbClusterIdentifier.
+                    description: Reference to a Cluster in neptune to populate dbClusterIdentifier.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -210,7 +210,7 @@ spec:
                     - name
                     type: object
                   dbClusterIdentifierSelector:
-                    description: Selector for a Cluster to populate dbClusterIdentifier.
+                    description: Selector for a Cluster in neptune to populate dbClusterIdentifier.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/networkmanager.aws.upbound.io_connectattachments.yaml
+++ b/package/crds/networkmanager.aws.upbound.io_connectattachments.yaml
@@ -77,7 +77,8 @@ spec:
                       the attachment.
                     type: string
                   coreNetworkIdRef:
-                    description: Reference to a CoreNetwork to populate coreNetworkId.
+                    description: Reference to a CoreNetwork in networkmanager to populate
+                      coreNetworkId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +112,8 @@ spec:
                     - name
                     type: object
                   coreNetworkIdSelector:
-                    description: Selector for a CoreNetwork to populate coreNetworkId.
+                    description: Selector for a CoreNetwork in networkmanager to populate
+                      coreNetworkId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -349,7 +351,8 @@ spec:
                       the attachment.
                     type: string
                   coreNetworkIdRef:
-                    description: Reference to a CoreNetwork to populate coreNetworkId.
+                    description: Reference to a CoreNetwork in networkmanager to populate
+                      coreNetworkId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -383,7 +386,8 @@ spec:
                     - name
                     type: object
                   coreNetworkIdSelector:
-                    description: Selector for a CoreNetwork to populate coreNetworkId.
+                    description: Selector for a CoreNetwork in networkmanager to populate
+                      coreNetworkId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/networkmanager.aws.upbound.io_linkassociations.yaml
+++ b/package/crds/networkmanager.aws.upbound.io_linkassociations.yaml
@@ -77,7 +77,8 @@ spec:
                     description: The ID of the device.
                     type: string
                   deviceIdRef:
-                    description: Reference to a Device to populate deviceId.
+                    description: Reference to a Device in networkmanager to populate
+                      deviceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +112,8 @@ spec:
                     - name
                     type: object
                   deviceIdSelector:
-                    description: Selector for a Device to populate deviceId.
+                    description: Selector for a Device in networkmanager to populate
+                      deviceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/networkmanager.aws.upbound.io_links.yaml
+++ b/package/crds/networkmanager.aws.upbound.io_links.yaml
@@ -178,7 +178,8 @@ spec:
                     description: The ID of the site.
                     type: string
                   siteIdRef:
-                    description: Reference to a Site to populate siteId.
+                    description: Reference to a Site in networkmanager to populate
+                      siteId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -212,7 +213,8 @@ spec:
                     - name
                     type: object
                   siteIdSelector:
-                    description: Selector for a Site to populate siteId.
+                    description: Selector for a Site in networkmanager to populate
+                      siteId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -378,7 +380,8 @@ spec:
                     description: The ID of the site.
                     type: string
                   siteIdRef:
-                    description: Reference to a Site to populate siteId.
+                    description: Reference to a Site in networkmanager to populate
+                      siteId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -412,7 +415,8 @@ spec:
                     - name
                     type: object
                   siteIdSelector:
-                    description: Selector for a Site to populate siteId.
+                    description: Selector for a Site in networkmanager to populate
+                      siteId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/networkmanager.aws.upbound.io_vpcattachments.yaml
+++ b/package/crds/networkmanager.aws.upbound.io_vpcattachments.yaml
@@ -76,7 +76,8 @@ spec:
                     description: The ID of a core network for the VPC attachment.
                     type: string
                   coreNetworkIdRef:
-                    description: Reference to a CoreNetwork to populate coreNetworkId.
+                    description: Reference to a CoreNetwork in networkmanager to populate
+                      coreNetworkId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -110,7 +111,8 @@ spec:
                     - name
                     type: object
                   coreNetworkIdSelector:
-                    description: Selector for a CoreNetwork to populate coreNetworkId.
+                    description: Selector for a CoreNetwork in networkmanager to populate
+                      coreNetworkId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -357,7 +359,8 @@ spec:
                     description: The ID of a core network for the VPC attachment.
                     type: string
                   coreNetworkIdRef:
-                    description: Reference to a CoreNetwork to populate coreNetworkId.
+                    description: Reference to a CoreNetwork in networkmanager to populate
+                      coreNetworkId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -391,7 +394,8 @@ spec:
                     - name
                     type: object
                   coreNetworkIdSelector:
-                    description: Selector for a CoreNetwork to populate coreNetworkId.
+                    description: Selector for a CoreNetwork in networkmanager to populate
+                      coreNetworkId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/opensearch.aws.upbound.io_domainpolicies.yaml
+++ b/package/crds/opensearch.aws.upbound.io_domainpolicies.yaml
@@ -81,7 +81,7 @@ spec:
                     description: Name of the domain.
                     type: string
                   domainNameRef:
-                    description: Reference to a Domain to populate domainName.
+                    description: Reference to a Domain in opensearch to populate domainName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -115,7 +115,7 @@ spec:
                     - name
                     type: object
                   domainNameSelector:
-                    description: Selector for a Domain to populate domainName.
+                    description: Selector for a Domain in opensearch to populate domainName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -182,7 +182,7 @@ spec:
                     description: Name of the domain.
                     type: string
                   domainNameRef:
-                    description: Reference to a Domain to populate domainName.
+                    description: Reference to a Domain in opensearch to populate domainName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -216,7 +216,7 @@ spec:
                     - name
                     type: object
                   domainNameSelector:
-                    description: Selector for a Domain to populate domainName.
+                    description: Selector for a Domain in opensearch to populate domainName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/opsworks.aws.upbound.io_instances.yaml
+++ b/package/crds/opsworks.aws.upbound.io_instances.yaml
@@ -176,7 +176,8 @@ spec:
                       type: string
                     type: array
                   layerIdsRefs:
-                    description: References to CustomLayer to populate layerIds.
+                    description: References to CustomLayer in opsworks to populate
+                      layerIds.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -213,7 +214,8 @@ spec:
                       type: object
                     type: array
                   layerIdsSelector:
-                    description: Selector for a list of CustomLayer to populate layerIds.
+                    description: Selector for a list of CustomLayer in opsworks to
+                      populate layerIds.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -658,7 +660,8 @@ spec:
                       type: string
                     type: array
                   layerIdsRefs:
-                    description: References to CustomLayer to populate layerIds.
+                    description: References to CustomLayer in opsworks to populate
+                      layerIds.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -695,7 +698,8 @@ spec:
                       type: object
                     type: array
                   layerIdsSelector:
-                    description: Selector for a list of CustomLayer to populate layerIds.
+                    description: Selector for a list of CustomLayer in opsworks to
+                      populate layerIds.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/rds.aws.upbound.io_clusterinstances.yaml
+++ b/package/crds/rds.aws.upbound.io_clusterinstances.yaml
@@ -262,7 +262,7 @@ spec:
                       aws_rds_cluster.'
                     type: string
                   dbSubnetGroupNameRef:
-                    description: Reference to a SubnetGroup to populate dbSubnetGroupName.
+                    description: Reference to a SubnetGroup in rds to populate dbSubnetGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -296,7 +296,7 @@ spec:
                     - name
                     type: object
                   dbSubnetGroupNameSelector:
-                    description: Selector for a SubnetGroup to populate dbSubnetGroupName.
+                    description: Selector for a SubnetGroup in rds to populate dbSubnetGroupName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -759,7 +759,7 @@ spec:
                       aws_rds_cluster.'
                     type: string
                   dbSubnetGroupNameRef:
-                    description: Reference to a SubnetGroup to populate dbSubnetGroupName.
+                    description: Reference to a SubnetGroup in rds to populate dbSubnetGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -793,7 +793,7 @@ spec:
                     - name
                     type: object
                   dbSubnetGroupNameSelector:
-                    description: Selector for a SubnetGroup to populate dbSubnetGroupName.
+                    description: Selector for a SubnetGroup in rds to populate dbSubnetGroupName.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/rds.aws.upbound.io_clusters.yaml
+++ b/package/crds/rds.aws.upbound.io_clusters.yaml
@@ -299,7 +299,7 @@ spec:
                       NOTE: This must match the db_subnet_group_name specified on every aws_rds_cluster_instance in the cluster.
                     type: string
                   dbSubnetGroupNameRef:
-                    description: Reference to a SubnetGroup to populate dbSubnetGroupName.
+                    description: Reference to a SubnetGroup in rds to populate dbSubnetGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -333,7 +333,7 @@ spec:
                     - name
                     type: object
                   dbSubnetGroupNameSelector:
-                    description: Selector for a SubnetGroup to populate dbSubnetGroupName.
+                    description: Selector for a SubnetGroup in rds to populate dbSubnetGroupName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -678,7 +678,7 @@ spec:
                             AWS account, the identifier is the ARN of that cluster.
                           type: string
                         sourceClusterIdentifierRef:
-                          description: Reference to a Cluster to populate sourceClusterIdentifier.
+                          description: Reference to a Cluster in rds to populate sourceClusterIdentifier.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -712,7 +712,7 @@ spec:
                           - name
                           type: object
                         sourceClusterIdentifierSelector:
-                          description: Selector for a Cluster to populate sourceClusterIdentifier.
+                          description: Selector for a Cluster in rds to populate sourceClusterIdentifier.
                           properties:
                             matchControllerRef:
                               description: |-
@@ -1283,7 +1283,7 @@ spec:
                       NOTE: This must match the db_subnet_group_name specified on every aws_rds_cluster_instance in the cluster.
                     type: string
                   dbSubnetGroupNameRef:
-                    description: Reference to a SubnetGroup to populate dbSubnetGroupName.
+                    description: Reference to a SubnetGroup in rds to populate dbSubnetGroupName.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -1317,7 +1317,7 @@ spec:
                     - name
                     type: object
                   dbSubnetGroupNameSelector:
-                    description: Selector for a SubnetGroup to populate dbSubnetGroupName.
+                    description: Selector for a SubnetGroup in rds to populate dbSubnetGroupName.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -1639,7 +1639,7 @@ spec:
                             AWS account, the identifier is the ARN of that cluster.
                           type: string
                         sourceClusterIdentifierRef:
-                          description: Reference to a Cluster to populate sourceClusterIdentifier.
+                          description: Reference to a Cluster in rds to populate sourceClusterIdentifier.
                           properties:
                             name:
                               description: Name of the referenced object.
@@ -1673,7 +1673,7 @@ spec:
                           - name
                           type: object
                         sourceClusterIdentifierSelector:
-                          description: Selector for a Cluster to populate sourceClusterIdentifier.
+                          description: Selector for a Cluster in rds to populate sourceClusterIdentifier.
                           properties:
                             matchControllerRef:
                               description: |-

--- a/package/crds/route53.aws.upbound.io_hostedzonednssecs.yaml
+++ b/package/crds/route53.aws.upbound.io_hostedzonednssecs.yaml
@@ -77,7 +77,7 @@ spec:
                     description: Identifier of the Route 53 Hosted Zone.
                     type: string
                   hostedZoneIdRef:
-                    description: Reference to a Zone to populate hostedZoneId.
+                    description: Reference to a Zone in route53 to populate hostedZoneId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -111,7 +111,7 @@ spec:
                     - name
                     type: object
                   hostedZoneIdSelector:
-                    description: Selector for a Zone to populate hostedZoneId.
+                    description: Selector for a Zone in route53 to populate hostedZoneId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -178,7 +178,7 @@ spec:
                     description: Identifier of the Route 53 Hosted Zone.
                     type: string
                   hostedZoneIdRef:
-                    description: Reference to a Zone to populate hostedZoneId.
+                    description: Reference to a Zone in route53 to populate hostedZoneId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -212,7 +212,7 @@ spec:
                     - name
                     type: object
                   hostedZoneIdSelector:
-                    description: Selector for a Zone to populate hostedZoneId.
+                    description: Selector for a Zone in route53 to populate hostedZoneId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/route53.aws.upbound.io_records.yaml
+++ b/package/crds/route53.aws.upbound.io_records.yaml
@@ -155,7 +155,8 @@ spec:
                       with.
                     type: string
                   healthCheckIdRef:
-                    description: Reference to a HealthCheck to populate healthCheckId.
+                    description: Reference to a HealthCheck in route53 to populate
+                      healthCheckId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -189,7 +190,8 @@ spec:
                     - name
                     type: object
                   healthCheckIdSelector:
-                    description: Selector for a HealthCheck to populate healthCheckId.
+                    description: Selector for a HealthCheck in route53 to populate
+                      healthCheckId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -288,7 +290,7 @@ spec:
                     description: The ID of the hosted zone to contain this record.
                     type: string
                   zoneIdRef:
-                    description: Reference to a Zone to populate zoneId.
+                    description: Reference to a Zone in route53 to populate zoneId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -322,7 +324,7 @@ spec:
                     - name
                     type: object
                   zoneIdSelector:
-                    description: Selector for a Zone to populate zoneId.
+                    description: Selector for a Zone in route53 to populate zoneId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -459,7 +461,8 @@ spec:
                       with.
                     type: string
                   healthCheckIdRef:
-                    description: Reference to a HealthCheck to populate healthCheckId.
+                    description: Reference to a HealthCheck in route53 to populate
+                      healthCheckId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -493,7 +496,8 @@ spec:
                     - name
                     type: object
                   healthCheckIdSelector:
-                    description: Selector for a HealthCheck to populate healthCheckId.
+                    description: Selector for a HealthCheck in route53 to populate
+                      healthCheckId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -580,7 +584,7 @@ spec:
                     description: The ID of the hosted zone to contain this record.
                     type: string
                   zoneIdRef:
-                    description: Reference to a Zone to populate zoneId.
+                    description: Reference to a Zone in route53 to populate zoneId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -614,7 +618,7 @@ spec:
                     - name
                     type: object
                   zoneIdSelector:
-                    description: Selector for a Zone to populate zoneId.
+                    description: Selector for a Zone in route53 to populate zoneId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/route53.aws.upbound.io_trafficpolicyinstances.yaml
+++ b/package/crds/route53.aws.upbound.io_trafficpolicyinstances.yaml
@@ -79,7 +79,7 @@ spec:
                       in a traffic policy.
                     type: string
                   hostedZoneIdRef:
-                    description: Reference to a Zone to populate hostedZoneId.
+                    description: Reference to a Zone in route53 to populate hostedZoneId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -113,7 +113,7 @@ spec:
                     - name
                     type: object
                   hostedZoneIdSelector:
-                    description: Selector for a Zone to populate hostedZoneId.
+                    description: Selector for a Zone in route53 to populate hostedZoneId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -166,7 +166,8 @@ spec:
                       create resource record sets in the specified hosted zone.
                     type: string
                   trafficPolicyIdRef:
-                    description: Reference to a TrafficPolicy to populate trafficPolicyId.
+                    description: Reference to a TrafficPolicy in route53 to populate
+                      trafficPolicyId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -200,7 +201,8 @@ spec:
                     - name
                     type: object
                   trafficPolicyIdSelector:
-                    description: Selector for a TrafficPolicy to populate trafficPolicyId.
+                    description: Selector for a TrafficPolicy in route53 to populate
+                      trafficPolicyId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -269,7 +271,7 @@ spec:
                       in a traffic policy.
                     type: string
                   hostedZoneIdRef:
-                    description: Reference to a Zone to populate hostedZoneId.
+                    description: Reference to a Zone in route53 to populate hostedZoneId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -303,7 +305,7 @@ spec:
                     - name
                     type: object
                   hostedZoneIdSelector:
-                    description: Selector for a Zone to populate hostedZoneId.
+                    description: Selector for a Zone in route53 to populate hostedZoneId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -352,7 +354,8 @@ spec:
                       create resource record sets in the specified hosted zone.
                     type: string
                   trafficPolicyIdRef:
-                    description: Reference to a TrafficPolicy to populate trafficPolicyId.
+                    description: Reference to a TrafficPolicy in route53 to populate
+                      trafficPolicyId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -386,7 +389,8 @@ spec:
                     - name
                     type: object
                   trafficPolicyIdSelector:
-                    description: Selector for a TrafficPolicy to populate trafficPolicyId.
+                    description: Selector for a TrafficPolicy in route53 to populate
+                      trafficPolicyId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/route53.aws.upbound.io_vpcassociationauthorizations.yaml
+++ b/package/crds/route53.aws.upbound.io_vpcassociationauthorizations.yaml
@@ -166,7 +166,7 @@ spec:
                       authorize associating a VPC with.
                     type: string
                   zoneIdRef:
-                    description: Reference to a Zone to populate zoneId.
+                    description: Reference to a Zone in route53 to populate zoneId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -200,7 +200,7 @@ spec:
                     - name
                     type: object
                   zoneIdSelector:
-                    description: Selector for a Zone to populate zoneId.
+                    description: Selector for a Zone in route53 to populate zoneId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -342,7 +342,7 @@ spec:
                       authorize associating a VPC with.
                     type: string
                   zoneIdRef:
-                    description: Reference to a Zone to populate zoneId.
+                    description: Reference to a Zone in route53 to populate zoneId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -376,7 +376,7 @@ spec:
                     - name
                     type: object
                   zoneIdSelector:
-                    description: Selector for a Zone to populate zoneId.
+                    description: Selector for a Zone in route53 to populate zoneId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/route53.aws.upbound.io_zones.yaml
+++ b/package/crds/route53.aws.upbound.io_zones.yaml
@@ -82,7 +82,8 @@ spec:
                       delegation sets can only be used for public zones.
                     type: string
                   delegationSetIdRef:
-                    description: Reference to a DelegationSet to populate delegationSetId.
+                    description: Reference to a DelegationSet in route53 to populate
+                      delegationSetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -116,7 +117,8 @@ spec:
                     - name
                     type: object
                   delegationSetIdSelector:
-                    description: Selector for a DelegationSet to populate delegationSetId.
+                    description: Selector for a DelegationSet in route53 to populate
+                      delegationSetId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -285,7 +287,8 @@ spec:
                       delegation sets can only be used for public zones.
                     type: string
                   delegationSetIdRef:
-                    description: Reference to a DelegationSet to populate delegationSetId.
+                    description: Reference to a DelegationSet in route53 to populate
+                      delegationSetId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -319,7 +322,8 @@ spec:
                     - name
                     type: object
                   delegationSetIdSelector:
-                    description: Selector for a DelegationSet to populate delegationSetId.
+                    description: Selector for a DelegationSet in route53 to populate
+                      delegationSetId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/servicecatalog.aws.upbound.io_budgetresourceassociations.yaml
+++ b/package/crds/servicecatalog.aws.upbound.io_budgetresourceassociations.yaml
@@ -159,7 +159,8 @@ spec:
                     description: Resource identifier.
                     type: string
                   resourceIdRef:
-                    description: Reference to a Product to populate resourceId.
+                    description: Reference to a Product in servicecatalog to populate
+                      resourceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -193,7 +194,8 @@ spec:
                     - name
                     type: object
                   resourceIdSelector:
-                    description: Selector for a Product to populate resourceId.
+                    description: Selector for a Product in servicecatalog to populate
+                      resourceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -329,7 +331,8 @@ spec:
                     description: Resource identifier.
                     type: string
                   resourceIdRef:
-                    description: Reference to a Product to populate resourceId.
+                    description: Reference to a Product in servicecatalog to populate
+                      resourceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -363,7 +366,8 @@ spec:
                     - name
                     type: object
                   resourceIdSelector:
-                    description: Selector for a Product to populate resourceId.
+                    description: Selector for a Product in servicecatalog to populate
+                      resourceId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/servicecatalog.aws.upbound.io_principalportfolioassociations.yaml
+++ b/package/crds/servicecatalog.aws.upbound.io_principalportfolioassociations.yaml
@@ -82,7 +82,8 @@ spec:
                     description: Portfolio identifier.
                     type: string
                   portfolioIdRef:
-                    description: Reference to a Portfolio to populate portfolioId.
+                    description: Reference to a Portfolio in servicecatalog to populate
+                      portfolioId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -116,7 +117,8 @@ spec:
                     - name
                     type: object
                   portfolioIdSelector:
-                    description: Selector for a Portfolio to populate portfolioId.
+                    description: Selector for a Portfolio in servicecatalog to populate
+                      portfolioId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -265,7 +267,8 @@ spec:
                     description: Portfolio identifier.
                     type: string
                   portfolioIdRef:
-                    description: Reference to a Portfolio to populate portfolioId.
+                    description: Reference to a Portfolio in servicecatalog to populate
+                      portfolioId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -299,7 +302,8 @@ spec:
                     - name
                     type: object
                   portfolioIdSelector:
-                    description: Selector for a Portfolio to populate portfolioId.
+                    description: Selector for a Portfolio in servicecatalog to populate
+                      portfolioId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/servicecatalog.aws.upbound.io_productportfolioassociations.yaml
+++ b/package/crds/servicecatalog.aws.upbound.io_productportfolioassociations.yaml
@@ -82,7 +82,8 @@ spec:
                     description: Portfolio identifier.
                     type: string
                   portfolioIdRef:
-                    description: Reference to a Portfolio to populate portfolioId.
+                    description: Reference to a Portfolio in servicecatalog to populate
+                      portfolioId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -116,7 +117,8 @@ spec:
                     - name
                     type: object
                   portfolioIdSelector:
-                    description: Selector for a Portfolio to populate portfolioId.
+                    description: Selector for a Portfolio in servicecatalog to populate
+                      portfolioId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -159,7 +161,8 @@ spec:
                     description: Product identifier.
                     type: string
                   productIdRef:
-                    description: Reference to a Product to populate productId.
+                    description: Reference to a Product in servicecatalog to populate
+                      productId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -193,7 +196,8 @@ spec:
                     - name
                     type: object
                   productIdSelector:
-                    description: Selector for a Product to populate productId.
+                    description: Selector for a Product in servicecatalog to populate
+                      productId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -263,7 +267,8 @@ spec:
                     description: Portfolio identifier.
                     type: string
                   portfolioIdRef:
-                    description: Reference to a Portfolio to populate portfolioId.
+                    description: Reference to a Portfolio in servicecatalog to populate
+                      portfolioId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -297,7 +302,8 @@ spec:
                     - name
                     type: object
                   portfolioIdSelector:
-                    description: Selector for a Portfolio to populate portfolioId.
+                    description: Selector for a Portfolio in servicecatalog to populate
+                      portfolioId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -340,7 +346,8 @@ spec:
                     description: Product identifier.
                     type: string
                   productIdRef:
-                    description: Reference to a Product to populate productId.
+                    description: Reference to a Product in servicecatalog to populate
+                      productId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -374,7 +381,8 @@ spec:
                     - name
                     type: object
                   productIdSelector:
-                    description: Selector for a Product to populate productId.
+                    description: Selector for a Product in servicecatalog to populate
+                      productId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/servicecatalog.aws.upbound.io_tagoptionresourceassociations.yaml
+++ b/package/crds/servicecatalog.aws.upbound.io_tagoptionresourceassociations.yaml
@@ -82,7 +82,8 @@ spec:
                     description: Resource identifier.
                     type: string
                   resourceIdRef:
-                    description: Reference to a Product to populate resourceId.
+                    description: Reference to a Product in servicecatalog to populate
+                      resourceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -116,7 +117,8 @@ spec:
                     - name
                     type: object
                   resourceIdSelector:
-                    description: Selector for a Product to populate resourceId.
+                    description: Selector for a Product in servicecatalog to populate
+                      resourceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -159,7 +161,8 @@ spec:
                     description: Tag Option identifier.
                     type: string
                   tagOptionIdRef:
-                    description: Reference to a TagOption to populate tagOptionId.
+                    description: Reference to a TagOption in servicecatalog to populate
+                      tagOptionId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -193,7 +196,8 @@ spec:
                     - name
                     type: object
                   tagOptionIdSelector:
-                    description: Selector for a TagOption to populate tagOptionId.
+                    description: Selector for a TagOption in servicecatalog to populate
+                      tagOptionId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -252,7 +256,8 @@ spec:
                     description: Resource identifier.
                     type: string
                   resourceIdRef:
-                    description: Reference to a Product to populate resourceId.
+                    description: Reference to a Product in servicecatalog to populate
+                      resourceId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -286,7 +291,8 @@ spec:
                     - name
                     type: object
                   resourceIdSelector:
-                    description: Selector for a Product to populate resourceId.
+                    description: Selector for a Product in servicecatalog to populate
+                      resourceId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -329,7 +335,8 @@ spec:
                     description: Tag Option identifier.
                     type: string
                   tagOptionIdRef:
-                    description: Reference to a TagOption to populate tagOptionId.
+                    description: Reference to a TagOption in servicecatalog to populate
+                      tagOptionId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -363,7 +370,8 @@ spec:
                     - name
                     type: object
                   tagOptionIdSelector:
-                    description: Selector for a TagOption to populate tagOptionId.
+                    description: Selector for a TagOption in servicecatalog to populate
+                      tagOptionId.
                     properties:
                       matchControllerRef:
                         description: |-

--- a/package/crds/transfer.aws.upbound.io_users.yaml
+++ b/package/crds/transfer.aws.upbound.io_users.yaml
@@ -219,7 +219,7 @@ spec:
                     description: The Server ID of the Transfer Server (e.g., s-12345678)
                     type: string
                   serverIdRef:
-                    description: Reference to a Server to populate serverId.
+                    description: Reference to a Server in transfer to populate serverId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -253,7 +253,7 @@ spec:
                     - name
                     type: object
                   serverIdSelector:
-                    description: Selector for a Server to populate serverId.
+                    description: Selector for a Server in transfer to populate serverId.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -456,7 +456,7 @@ spec:
                     description: The Server ID of the Transfer Server (e.g., s-12345678)
                     type: string
                   serverIdRef:
-                    description: Reference to a Server to populate serverId.
+                    description: Reference to a Server in transfer to populate serverId.
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -490,7 +490,7 @@ spec:
                     - name
                     type: object
                   serverIdSelector:
-                    description: Selector for a Server to populate serverId.
+                    description: Selector for a Server in transfer to populate serverId.
                     properties:
                       matchControllerRef:
                         description: |-


### PR DESCRIPTION
<!--
Thank you for helping to improve Official Azure Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official Azure Provider pull request. Find us in https://crossplane.slack.com 
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official Azure Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This PR replaces usages of upjet's `config.Reference.Type` API with `config.Reference.TerraformName`. In https://github.com/crossplane/upjet/pull/400, we are deprecating the `config.Reference.Type` API in favor of `config.Reference.TerraformName`. `config.Reference.TerraformName` is a more stable and less error prone API compared to `config.Reference.Type` because it automatically accounts for the configuration changes affecting the cross-resource reference target's kind name, group or version. We've already been discouraging the `config.Reference.Type` in favor of `config.Reference.TerraformName` since it's been introduced.

This PR is a precursor for converting the singleton list APIs to embedded objects. When the `config.Reference.Type` is used to define the reference target, the API version can be omitted for the targets in the same group and version. In those cases, if the referencing resource has been generated at `v1beta2` whereas the reference target lacks that version, the generated resolver is not valid. Using `config.Reference.TerraformName` instead will help us in future maintenance because it automatically accounts for generating the cross-resource reference resolvers in the generated version. This is also one of the reasons we are deprecating `config.Reference.Type`.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Checked for any unexpected changes in the generated resolvers (`apis/../zz_generated.resolvers.go` files).

[contribution process]: https://git.io/fj2m9
