### PR TITLE
Auth doc: update IRSA example with `DeploymentRuntimeConfig`

### DIFF
--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -16,7 +16,7 @@ configured by means of `aws.upbound.io/v1beta1/ProviderConfig` resources.
 
 The authentication mechanism to be used can be selected by setting the
 `spec.credentials.source` field of the `ProviderConfig` to one of the following
-values: 
+values:
 - `Secret`
 - `IRSA`
 - `WebIdentity`
@@ -24,7 +24,7 @@ to configure long-term credentials, IRSA and authentication with an assumed Web
 identity, respectively.
 
 If no authentication mechanism is specified, the default is to use the
-`Secret` authentication mechanism. 
+`Secret` authentication mechanism.
 
 *Note*: Please note that with Upbound managed control-planes (MCP), we will only support
 the `Secret` authentication mechanism with `provider-aws` until EKS clusters can
@@ -108,30 +108,28 @@ metadata:
 
 Thus, we need to have the `ServiceAccount` under which `provider-aws` is running
 annotated with the key `eks.amazonaws.com/role-arn`, and this can be accomplished
-in a number of ways. One approach is to use a `ControllerConfig` while
+in a number of ways. One approach is to use a `DeploymentRuntimeConfig` while
 installing the provider:
 
 ```yaml
-apiVersion: pkg.crossplane.io/v1alpha1
-kind: ControllerConfig
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
 metadata:
-  name: irsa-controllerconfig
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/iam-role-name
+  name: irsa-drc
 spec:
-  podSecurityContext:
-    fsGroup: 2000
+  serviceAccountTemplate:
+    metadata:
+      annotations:
+        eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/iam-role-name
 ---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
-  name: provider-aws
+  name: upbound-provider-aws-ec2
 spec:
-  package: xpkg.upbound.io/upbound/provider-aws:v0.4.0
-  packagePullSecrets:
-    - name: package-pull-secret
-  controllerConfigRef:
-    name: irsa-controllerconfig
+  package: xpkg.upbound.io/upbound/provider-aws-ec2:v1.4.0
+  runtimeConfigRef:
+    name: irsa-drc
 ```
 
 After the `ServiceAccount` under which `provider-aws` is running is annotated,


### PR DESCRIPTION


<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

* Replace deprecate `ControllerConfig`-based example with `DeploymentRuntimeConfig` instructions to set IRSA annotation on Provider ServiceAccount
* Occasional whitespace busting

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

By applying documented manifests and checking that the annotation was propagated to the provider serviceaccount
```
k get -f examples/deploymentruntimeconfigs/irsa-drc.yaml  -o yaml
apiVersion: pkg.crossplane.io/v1beta1
kind: DeploymentRuntimeConfig
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"pkg.crossplane.io/v1beta1","kind":"DeploymentRuntimeConfig","metadata":{"annotations":{},"name":"irsa-drc"},"spec":{"serviceAccountTemplate":{"metadata":{"annotations":{"eks.amazonaws.com/role-arn":"arn:aws:iam::111122223333:role/iam-role-name"}}}}}
  creationTimestamp: "2024-05-23T11:24:57Z"
  generation: 1
  name: irsa-drc
  resourceVersion: "22282"
  uid: c4b56d1c-c7e7-4f91-af3a-31a26b859614
spec:
  serviceAccountTemplate:
    metadata:
      annotations:
        eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/iam-role-name

k get providers upbound-provider-aws-ec2 -oyaml|k neat
apiVersion: pkg.crossplane.io/v1
kind: Provider
metadata:
  name: upbound-provider-aws-ec2
spec:
  ignoreCrossplaneConstraints: false
  package: xpkg.upbound.io/upbound/provider-aws-ec2:v1.4.0
  packagePullPolicy: IfNotPresent
  revisionActivationPolicy: Automatic
  revisionHistoryLimit: 1
  runtimeConfigRef:
    apiVersion: pkg.crossplane.io/v1beta1
    kind: DeploymentRuntimeConfig
    name: irsa-drc
  skipDependencyResolution: false

k -n upbound-system get sa |grep aws-ec2
upbound-provider-aws-ec2-b040c8e74c2d                          0         6m34s

k -n upbound-system get sa upbound-provider-aws-ec2-b040c8e74c2d -o yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  annotations:
    eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/iam-role-name <--- Annotation is properly set
  creationTimestamp: "2024-05-23T11:25:44Z"
  name: upbound-provider-aws-ec2-b040c8e74c2d
  namespace: upbound-system
  ownerReferences:
  - apiVersion: pkg.crossplane.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: ProviderRevision
    name: upbound-provider-aws-ec2-b040c8e74c2d
    uid: 55b24710-317b-4173-bd1a-9efc14fe2104
  resourceVersion: "22657"
  uid: bd3838aa-f589-4b84-949b-0eb7485960bf

```
