### PR TITLE
ElastiCache ReplicationGroup auth token generation and connection details

### DIFF
--- a/apis/elasticache/v1beta2/zz_generated.deepcopy.go
+++ b/apis/elasticache/v1beta2/zz_generated.deepcopy.go
@@ -775,6 +775,11 @@ func (in *ReplicationGroupParameters) DeepCopyInto(out *ReplicationGroupParamete
 		*out = new(string)
 		**out = **in
 	}
+	if in.AutoGenerateAuthToken != nil {
+		in, out := &in.AutoGenerateAuthToken, &out.AutoGenerateAuthToken
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AutoMinorVersionUpgrade != nil {
 		in, out := &in.AutoMinorVersionUpgrade, &out.AutoMinorVersionUpgrade
 		*out = new(string)

--- a/apis/elasticache/v1beta2/zz_replicationgroup_types.go
+++ b/apis/elasticache/v1beta2/zz_replicationgroup_types.go
@@ -71,6 +71,7 @@ type ReplicationGroupInitParameters struct {
 	AtRestEncryptionEnabled *bool `json:"atRestEncryptionEnabled,omitempty" tf:"at_rest_encryption_enabled,omitempty"`
 
 	// Password used to access a password protected server. Can be specified only if transit_encryption_enabled = true.
+	// If you set autoGenerateAuthToken to true, the Secret referenced here will be created or updated with generated auth token if it does not already contain one.
 	AuthTokenSecretRef *v1.SecretKeySelector `json:"authTokenSecretRef,omitempty" tf:"-"`
 
 	// Strategy to use when updating the auth_token. Valid values are SET, ROTATE, and DELETE. Defaults to ROTATE.
@@ -396,12 +397,19 @@ type ReplicationGroupParameters struct {
 	AtRestEncryptionEnabled *bool `json:"atRestEncryptionEnabled,omitempty" tf:"at_rest_encryption_enabled,omitempty"`
 
 	// Password used to access a password protected server. Can be specified only if transit_encryption_enabled = true.
+	// If you set autoGenerateAuthToken to true, the Secret referenced here will be created or updated with generated auth token if it does not already contain one.
 	// +kubebuilder:validation:Optional
 	AuthTokenSecretRef *v1.SecretKeySelector `json:"authTokenSecretRef,omitempty" tf:"-"`
 
 	// Strategy to use when updating the auth_token. Valid values are SET, ROTATE, and DELETE. Defaults to ROTATE.
 	// +kubebuilder:validation:Optional
 	AuthTokenUpdateStrategy *string `json:"authTokenUpdateStrategy,omitempty" tf:"auth_token_update_strategy,omitempty"`
+
+	// Password used to access a password protected server. Can be specified only if transit_encryption_enabled = true.
+	// If true, the auth token will be auto-generated and stored in the Secret referenced by the authTokenSecretRef field.
+	// +upjet:crd:field:TFTag=-
+	// +kubebuilder:validation:Optional
+	AutoGenerateAuthToken *bool `json:"autoGenerateAuthToken,omitempty" tf:"-"`
 
 	// Specifies whether minor version engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window.
 	// Only supported for engine type "redis" and if the engine version is 6 or higher.

--- a/config/elasticache/config.go
+++ b/config/elasticache/config.go
@@ -7,14 +7,14 @@ package elasticache
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/pkg/errors"
 
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/upjet/pkg/config"
 	"github.com/crossplane/upjet/pkg/config/conversion"
 	"github.com/crossplane/upjet/pkg/types/comments"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/upbound/provider-aws/apis/elasticache/v1beta1"
 	"github.com/upbound/provider-aws/apis/elasticache/v1beta2"
@@ -77,9 +77,13 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		}
 
 		// Auth token generation
-		desc, _ := comments.New("If true, the auth token will be auto-generated and"+
+		desc, err := comments.New("If true, the auth token will be auto-generated and"+
 			" stored in the Secret referenced by the authTokenSecretRef field.",
 			comments.WithTFTag("-"))
+		if err != nil {
+			panic(errors.Wrap(err, "cannot configure the generated comment for the auto_generate_auth_token argument of the aws_elasticache_replication_group resource"))
+		}
+
 		r.TerraformResource.Schema["auto_generate_auth_token"] = &schema.Schema{
 			Type:        schema.TypeBool,
 			Optional:    true,

--- a/examples/elasticache/v1beta2/replicationgroup.yaml
+++ b/examples/elasticache/v1beta2/replicationgroup.yaml
@@ -2,6 +2,60 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
+apiVersion: elasticache.aws.upbound.io/v1beta1
+kind: SubnetGroup
+metadata:
+  labels:
+    testing.upbound.io/example-name: bar
+  name: subnet-group
+spec:
+  forProvider:
+    region: us-east-1
+    subnetIdRefs:
+      - name: foo-1a
+      - name: foo-1b
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: Subnet
+metadata:
+  labels:
+    testing.upbound.io/example-name: foo
+  name: foo-1a
+spec:
+  forProvider:
+    availabilityZone: us-east-1a
+    cidrBlock: 10.0.1.0/24
+    region: us-east-1
+    vpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: foo
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: Subnet
+metadata:
+  labels:
+    testing.upbound.io/example-name: foo
+  name: foo-1b
+spec:
+  forProvider:
+    availabilityZone: us-east-1b
+    cidrBlock: 10.0.2.0/24
+    region: us-east-1
+    vpcIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: foo
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: VPC
+metadata:
+  labels:
+    testing.upbound.io/example-name: foo
+  name: foo
+spec:
+  forProvider:
+    cidrBlock: 10.0.0.0/16
+    region: us-east-1
+---
 apiVersion: elasticache.aws.upbound.io/v1beta2
 kind: ReplicationGroup
 metadata:
@@ -14,13 +68,25 @@ metadata:
 spec:
   forProvider:
     automaticFailoverEnabled: true
+    atRestEncryptionEnabled: true
+    autoGenerateAuthToken: true
+    authTokenSecretRef:
+      name: redis-auth-token
+      namespace: crossplane-system
+      key: auth-token
     description: example description
     maintenanceWindow: sun:05:00-sun:09:00
-    nodeType: cache.m4.large
+    nodeType: cache.t4g.small
     numCacheClusters: 2
+    transitEncryptionEnabled: true
     parameterGroupName: default.redis7
     port: 6379
+    subnetGroupNameRef:
+      name: subnet-group
     preferredCacheClusterAzs:
-      - us-west-1a
-      - us-west-1b
-    region: us-west-1
+      - us-east-1a
+      - us-east-1b
+    region: us-east-1
+  writeConnectionSecretToRef:
+    name: redis-conn
+    namespace: crossplane-system

--- a/examples/elasticache/v1beta2/replicationgroup.yaml
+++ b/examples/elasticache/v1beta2/replicationgroup.yaml
@@ -5,21 +5,25 @@
 apiVersion: elasticache.aws.upbound.io/v1beta1
 kind: SubnetGroup
 metadata:
+  annotations:
+    meta.upbound.io/example-id: elasticache/v1beta2/replicationgroup
   labels:
-    testing.upbound.io/example-name: bar
+    testing.upbound.io/example-name: replicationgroup
   name: subnet-group
 spec:
   forProvider:
     region: us-east-1
-    subnetIdRefs:
-      - name: foo-1a
-      - name: foo-1b
+    subnetIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: replicationgroup
 ---
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: Subnet
 metadata:
+  annotations:
+    meta.upbound.io/example-id: elasticache/v1beta2/replicationgroup
   labels:
-    testing.upbound.io/example-name: foo
+    testing.upbound.io/example-name: replicationgroup
   name: foo-1a
 spec:
   forProvider:
@@ -28,13 +32,15 @@ spec:
     region: us-east-1
     vpcIdSelector:
       matchLabels:
-        testing.upbound.io/example-name: foo
+        testing.upbound.io/example-name: replicationgroup
 ---
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: Subnet
 metadata:
+  annotations:
+    meta.upbound.io/example-id: elasticache/v1beta2/replicationgroup
   labels:
-    testing.upbound.io/example-name: foo
+    testing.upbound.io/example-name: replicationgroup
   name: foo-1b
 spec:
   forProvider:
@@ -43,13 +49,15 @@ spec:
     region: us-east-1
     vpcIdSelector:
       matchLabels:
-        testing.upbound.io/example-name: foo
+        testing.upbound.io/example-name: replicationgroup
 ---
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: VPC
 metadata:
+  annotations:
+    meta.upbound.io/example-id: elasticache/v1beta2/replicationgroup
   labels:
-    testing.upbound.io/example-name: foo
+    testing.upbound.io/example-name: replicationgroup
   name: foo
 spec:
   forProvider:
@@ -60,7 +68,7 @@ apiVersion: elasticache.aws.upbound.io/v1beta2
 kind: ReplicationGroup
 metadata:
   annotations:
-    meta.upbound.io/example-id: elasticache/v1beta1/replicationgroup
+    meta.upbound.io/example-id: elasticache/v1beta2/replicationgroup
     uptest.upbound.io/timeout: "3600"
   labels:
     testing.upbound.io/example-name: example
@@ -72,7 +80,7 @@ spec:
     autoGenerateAuthToken: true
     authTokenSecretRef:
       name: redis-auth-token
-      namespace: crossplane-system
+      namespace: upbound-system
       key: auth-token
     description: example description
     maintenanceWindow: sun:05:00-sun:09:00
@@ -81,12 +89,13 @@ spec:
     transitEncryptionEnabled: true
     parameterGroupName: default.redis7
     port: 6379
-    subnetGroupNameRef:
-      name: subnet-group
+    subnetGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: replicationgroup
     preferredCacheClusterAzs:
       - us-east-1a
       - us-east-1b
     region: us-east-1
   writeConnectionSecretToRef:
     name: redis-conn
-    namespace: crossplane-system
+    namespace: upbound-system

--- a/package/crds/elasticache.aws.upbound.io_replicationgroups.yaml
+++ b/package/crds/elasticache.aws.upbound.io_replicationgroups.yaml
@@ -1630,8 +1630,9 @@ spec:
                     description: Whether to enable encryption at rest.
                     type: boolean
                   authTokenSecretRef:
-                    description: Password used to access a password protected server.
-                      Can be specified only if transit_encryption_enabled = true.
+                    description: |-
+                      Password used to access a password protected server. Can be specified only if transit_encryption_enabled = true.
+                      If you set autoGenerateAuthToken to true, the Secret referenced here will be created or updated with generated auth token if it does not already contain one.
                     properties:
                       key:
                         description: The key to select.
@@ -1651,6 +1652,11 @@ spec:
                     description: Strategy to use when updating the auth_token. Valid
                       values are SET, ROTATE, and DELETE. Defaults to ROTATE.
                     type: string
+                  autoGenerateAuthToken:
+                    description: |-
+                      Password used to access a password protected server. Can be specified only if transit_encryption_enabled = true.
+                      If true, the auth token will be auto-generated and stored in the Secret referenced by the authTokenSecretRef field.
+                    type: boolean
                   autoMinorVersionUpgrade:
                     description: |-
                       Specifies whether minor version engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window.
@@ -2122,8 +2128,9 @@ spec:
                     description: Whether to enable encryption at rest.
                     type: boolean
                   authTokenSecretRef:
-                    description: Password used to access a password protected server.
-                      Can be specified only if transit_encryption_enabled = true.
+                    description: |-
+                      Password used to access a password protected server. Can be specified only if transit_encryption_enabled = true.
+                      If you set autoGenerateAuthToken to true, the Secret referenced here will be created or updated with generated auth token if it does not already contain one.
                     properties:
                       key:
                         description: The key to select.


### PR DESCRIPTION
- Add option autoGenerateAuthToken for ElastiCache ReplicationGroup
- Add port/endpoint connection details for ElastiCache ReplicationGroup

<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1102

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Uptest run: https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/9397299773
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
