### PR TITLE
Reduce linter concurrency to 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,4 +103,5 @@ jobs:
           GOLANGCI_LINT_CACHE: ${{ steps.go_cache.outputs.analysis_cache }}
           SKIP_LINTER_ANALYSIS: false
           RUN_BUILDTAGGER: true
+          GOGC: "50"
         run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: CC0-1.0
 
 run:
-  timeout: 60m
+  timeout: 90m
   show-stats: true
-  concurrency: 3
+  concurrency: 1
 
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
While [bumping the underlying Terraform provider version](https://github.com/crossplane-contrib/provider-upjet-aws/pull/1315), we've observed failing linter runs. This is probably caused by the changing dependencies and the invalidation of the linter cache. We had previously observed a similar situation when working with the linter in the `release-0.47` branch, and we had applied more aggressive parameters in #1217. This PR copies some of those parameters to the `main` branch.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Via `make lint` runs and in #1217.


[contribution process]: https://git.io/fj2m9
