### PR TITLE
fix(rds): fix late init for rds clusterinstance

### DIFF
--- a/apis/rds/v1beta1/zz_clusterinstance_terraformed.go
+++ b/apis/rds/v1beta1/zz_clusterinstance_terraformed.go
@@ -118,6 +118,9 @@ func (tr *ClusterInstance) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("DBParameterGroupName"))
+	opts = append(opts, resource.WithNameFilter("EngineVersion"))
+	opts = append(opts, resource.WithNameFilter("PreferredBackupWindow"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -112,6 +112,9 @@ func Configure(p *config.Provider) {
 		delete(r.References, "engine")
 		delete(r.References, "engine_version")
 		r.UseAsync = true
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"engine_version", "db_parameter_group_name", "preferred_backup_window"},
+		}
 	})
 	p.AddResourceConfigurator("aws_db_instance", func(r *config.Resource) {
 		r.References["db_subnet_group_name"] = config.Reference{

--- a/examples/rds/v1beta1/clusterinstance.yaml
+++ b/examples/rds/v1beta1/clusterinstance.yaml
@@ -18,9 +18,6 @@ spec:
         testing.upbound.io/example-name: example-ci
     engine: aurora-postgresql
     instanceClass: db.r5.large
-    dbParameterGroupNameSelector:
-      matchLabels:
-        testing.upbound.io/example-name: example-ci
 
 ---
 
@@ -36,6 +33,11 @@ spec:
   forProvider:
     region: us-west-1
     engine: aurora-postgresql
+    engineVersion: "15.6"
+    dbClusterParameterGroupNameSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example-ci
+    preferredBackupWindow: "04:00-05:00"
     masterUsername: cpadmin
     masterPasswordSecretRef:
       name: sample-cluster-password
@@ -60,19 +62,18 @@ stringData:
 ---
 
 apiVersion: rds.aws.upbound.io/v1beta1
-kind: ParameterGroup
+kind: ClusterParameterGroup
 metadata:
   annotations:
     meta.upbound.io/example-id: rds/v1beta1/clusterinstance
   labels:
     testing.upbound.io/example-name: example-ci
-  name: example-parametergroup-ci
+  name: example-clusterparametergroup-ci
 spec:
   forProvider:
     region: us-west-1
+    description: RDS default cluster parameter group
     family: aurora-postgresql15
-    description: example
     parameter:
-      - name: application_name
-        value: "example"
-        applyMethod: immediate
+      - name: apg_plan_mgmt.capture_plan_baselines
+        value: "manual"


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes
- fix a few late init problems with rds clusterinstance

After upgrading the Version in the Cluster the ClusterInstance gets stuck in an update-loop because of the `engineVersion`
`spec.forProvider.engineVersion`

```
2024-05-15T14:49:54Z    DEBUG    provider-aws    Diff detected    {"uid": "31f30f84-59ed-4720-ad3a-93aae50eb27d", "name": "xxx", "gvk": "rds.aws.upbound.io/v1beta1, Kind=ClusterInstance", "instanceDiff": "*terraform.InstanceDiff{mu:sync.Mutex{state:0, sema:0x0}, Attributes:map[string]*terraform.ResourceAttrDiff{\"engine_version\":*terraform.ResourceAttrDiff{Old:\"15.5\", New:\"15.4\", NewComputed:false, NewRemoved:false, NewExtra:interface {}(nil), RequiresNew:false, Sensitive:false, Type:0x0}}, Destroy:false, DestroyDeposed:false, DestroyTainted:false, RawConfig:cty.NilVal, RawState:cty.NilVal, RawPlan:cty.NilVal, Meta:map[string]interface {}(nil)}"}
2024-05-15T14:49:54Z    DEBUG    provider-aws    Successfully requested update of external resource    {"controller": "managed/rds.aws.upbound.io/v1beta1, kind=clusterinstance", "request": {"name":"xxx"}, "uid": "31f30f84-59ed-4720-ad3a-93aae50eb27d", "version": "15401705", "external-name": "xxx", "requeue-after": "2024-05-15T15:00:05Z"}
```

`spec.forProvider.dbParameterGroupName`
```
The parameter group default.aurora-postgresql15 with DBParameterGroupFamily aurora-postgresql15 can't be used for this instance. Use a parameter group with DBParameterGroupFamily aurora-postgresql16.
```

`spec.forProvider.preferredBackupWindow`

```
The requested DB Instance will be a member of a DB Cluster. Set backup window for the DB Cluster.",
```

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

```
--- PASS: kuttl (1339.64s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/case (1338.83s)
PASS
13:31:56 [ OK ] running automated tests
```
Uptest run: https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/9223450840
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
