### PR TITLE
Fix documentation of `rule.filter.prefix` field for `BucketLifecycleConfiguration.s3`

### DIFF
--- a/apis/s3/v1beta1/zz_bucketlifecycleconfiguration_types.go
+++ b/apis/s3/v1beta1/zz_bucketlifecycleconfiguration_types.go
@@ -40,7 +40,7 @@ type AndInitParameters struct {
 	// Maximum object size (in bytes) to which the rule applies.
 	ObjectSizeLessThan *float64 `json:"objectSizeLessThan,omitempty" tf:"object_size_less_than,omitempty"`
 
-	// DEPRECATED Use filter instead. This has been deprecated by Amazon S3. Prefix identifying one or more objects to which the rule applies. Defaults to an empty string ("") if filter is not specified.
+	// Prefix identifying one or more objects to which the rule applies.
 	Prefix *string `json:"prefix,omitempty" tf:"prefix,omitempty"`
 
 	// Key-value map of resource tags. All of these tags must exist in the object's tag set in order for the rule to apply.
@@ -56,7 +56,7 @@ type AndObservation struct {
 	// Maximum object size (in bytes) to which the rule applies.
 	ObjectSizeLessThan *float64 `json:"objectSizeLessThan,omitempty" tf:"object_size_less_than,omitempty"`
 
-	// DEPRECATED Use filter instead. This has been deprecated by Amazon S3. Prefix identifying one or more objects to which the rule applies. Defaults to an empty string ("") if filter is not specified.
+	// Prefix identifying one or more objects to which the rule applies.
 	Prefix *string `json:"prefix,omitempty" tf:"prefix,omitempty"`
 
 	// Key-value map of resource tags. All of these tags must exist in the object's tag set in order for the rule to apply.
@@ -74,7 +74,7 @@ type AndParameters struct {
 	// +kubebuilder:validation:Optional
 	ObjectSizeLessThan *float64 `json:"objectSizeLessThan,omitempty" tf:"object_size_less_than,omitempty"`
 
-	// DEPRECATED Use filter instead. This has been deprecated by Amazon S3. Prefix identifying one or more objects to which the rule applies. Defaults to an empty string ("") if filter is not specified.
+	// Prefix identifying one or more objects to which the rule applies.
 	// +kubebuilder:validation:Optional
 	Prefix *string `json:"prefix,omitempty" tf:"prefix,omitempty"`
 
@@ -300,7 +300,7 @@ type RuleFilterInitParameters struct {
 	// Maximum object size (in bytes) to which the rule applies.
 	ObjectSizeLessThan *string `json:"objectSizeLessThan,omitempty" tf:"object_size_less_than,omitempty"`
 
-	// DEPRECATED Use filter instead. This has been deprecated by Amazon S3. Prefix identifying one or more objects to which the rule applies. Defaults to an empty string ("") if filter is not specified.
+	// Prefix identifying one or more objects to which the rule applies. Defaults to an empty string ("") if not specified.
 	Prefix *string `json:"prefix,omitempty" tf:"prefix,omitempty"`
 
 	// Configuration block for specifying a tag key and value. See below.
@@ -318,7 +318,7 @@ type RuleFilterObservation struct {
 	// Maximum object size (in bytes) to which the rule applies.
 	ObjectSizeLessThan *string `json:"objectSizeLessThan,omitempty" tf:"object_size_less_than,omitempty"`
 
-	// DEPRECATED Use filter instead. This has been deprecated by Amazon S3. Prefix identifying one or more objects to which the rule applies. Defaults to an empty string ("") if filter is not specified.
+	// Prefix identifying one or more objects to which the rule applies. Defaults to an empty string ("") if not specified.
 	Prefix *string `json:"prefix,omitempty" tf:"prefix,omitempty"`
 
 	// Configuration block for specifying a tag key and value. See below.
@@ -339,7 +339,7 @@ type RuleFilterParameters struct {
 	// +kubebuilder:validation:Optional
 	ObjectSizeLessThan *string `json:"objectSizeLessThan,omitempty" tf:"object_size_less_than,omitempty"`
 
-	// DEPRECATED Use filter instead. This has been deprecated by Amazon S3. Prefix identifying one or more objects to which the rule applies. Defaults to an empty string ("") if filter is not specified.
+	// Prefix identifying one or more objects to which the rule applies. Defaults to an empty string ("") if not specified.
 	// +kubebuilder:validation:Optional
 	Prefix *string `json:"prefix,omitempty" tf:"prefix,omitempty"`
 

--- a/config/s3/config.go
+++ b/config/s3/config.go
@@ -117,4 +117,9 @@ func Configure(p *config.Provider) {
 			Extractor:     `github.com/crossplane/upjet/pkg/resource.ExtractParamPath("arn",true)`,
 		}
 	})
+
+	p.AddResourceConfigurator("aws_s3_bucket_lifecycle_configuration", func(r *config.Resource) {
+		r.MetaResource.ArgumentDocs["rule.filter.prefix"] = `- (Optional) Prefix identifying one or more objects to which the rule applies. Defaults to an empty string ("") if not specified.`
+		r.MetaResource.ArgumentDocs["rule.filter.and.prefix"] = `- (Optional) Prefix identifying one or more objects to which the rule applies.`
+	})
 }

--- a/package/crds/s3.aws.upbound.io_bucketlifecycleconfigurations.yaml
+++ b/package/crds/s3.aws.upbound.io_bucketlifecycleconfigurations.yaml
@@ -228,11 +228,8 @@ spec:
                                         to which the rule applies.
                                       type: number
                                     prefix:
-                                      description: DEPRECATED Use filter instead.
-                                        This has been deprecated by Amazon S3. Prefix
-                                        identifying one or more objects to which the
-                                        rule applies. Defaults to an empty string
-                                        ("") if filter is not specified.
+                                      description: Prefix identifying one or more
+                                        objects to which the rule applies.
                                       type: string
                                     tags:
                                       additionalProperties:
@@ -253,10 +250,9 @@ spec:
                                   the rule applies.
                                 type: string
                               prefix:
-                                description: DEPRECATED Use filter instead. This has
-                                  been deprecated by Amazon S3. Prefix identifying
-                                  one or more objects to which the rule applies. Defaults
-                                  to an empty string ("") if filter is not specified.
+                                description: Prefix identifying one or more objects
+                                  to which the rule applies. Defaults to an empty
+                                  string ("") if not specified.
                                 type: string
                               tag:
                                 description: Configuration block for specifying a
@@ -518,11 +514,8 @@ spec:
                                         to which the rule applies.
                                       type: number
                                     prefix:
-                                      description: DEPRECATED Use filter instead.
-                                        This has been deprecated by Amazon S3. Prefix
-                                        identifying one or more objects to which the
-                                        rule applies. Defaults to an empty string
-                                        ("") if filter is not specified.
+                                      description: Prefix identifying one or more
+                                        objects to which the rule applies.
                                       type: string
                                     tags:
                                       additionalProperties:
@@ -543,10 +536,9 @@ spec:
                                   the rule applies.
                                 type: string
                               prefix:
-                                description: DEPRECATED Use filter instead. This has
-                                  been deprecated by Amazon S3. Prefix identifying
-                                  one or more objects to which the rule applies. Defaults
-                                  to an empty string ("") if filter is not specified.
+                                description: Prefix identifying one or more objects
+                                  to which the rule applies. Defaults to an empty
+                                  string ("") if not specified.
                                 type: string
                               tag:
                                 description: Configuration block for specifying a
@@ -900,11 +892,8 @@ spec:
                                         to which the rule applies.
                                       type: number
                                     prefix:
-                                      description: DEPRECATED Use filter instead.
-                                        This has been deprecated by Amazon S3. Prefix
-                                        identifying one or more objects to which the
-                                        rule applies. Defaults to an empty string
-                                        ("") if filter is not specified.
+                                      description: Prefix identifying one or more
+                                        objects to which the rule applies.
                                       type: string
                                     tags:
                                       additionalProperties:
@@ -925,10 +914,9 @@ spec:
                                   the rule applies.
                                 type: string
                               prefix:
-                                description: DEPRECATED Use filter instead. This has
-                                  been deprecated by Amazon S3. Prefix identifying
-                                  one or more objects to which the rule applies. Defaults
-                                  to an empty string ("") if filter is not specified.
+                                description: Prefix identifying one or more objects
+                                  to which the rule applies. Defaults to an empty
+                                  string ("") if not specified.
                                 type: string
                               tag:
                                 description: Configuration block for specifying a


### PR DESCRIPTION
### Description of your changes

This PR fixes the documentation of [`rule.filter.prefix`](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v1.5.0/resources/s3.aws.upbound.io/BucketLifecycleConfiguration/v1beta1#doc:spec-forProvider-rule-filter-prefix) and [`rule.filter.and.prefix`](https://marketplace.upbound.io/providers/upbound/provider-aws-s3/v1.5.0/resources/s3.aws.upbound.io/BucketLifecycleConfiguration/v1beta1#doc:spec-forProvider-rule-filter-and-prefix) fields for `BucketLifecycleConfiguration.s3`.

The field that will be deprecated is the [`rule.prefix`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration#prefix) argument, somehow the document was generated incorrectly for `rule.filter.prefix` and `rule.filter.and.prefix` arguments.

Fixes: https://github.com/crossplane-contrib/provider-upjet-aws/issues/885



I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~


[contribution process]: https://git.io/fj2m9
