### PR TITLE
feat(acm): add reference and selector for certificate_authority_arn

### DIFF
--- a/apis/acm/v1beta1/zz_certificate_types.go
+++ b/apis/acm/v1beta1/zz_certificate_types.go
@@ -16,7 +16,16 @@ import (
 type CertificateInitParameters struct {
 
 	// ARN of an ACM PCA
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/acmpca/v1beta1.CertificateAuthority
 	CertificateAuthorityArn *string `json:"certificateAuthorityArn,omitempty" tf:"certificate_authority_arn,omitempty"`
+
+	// Reference to a CertificateAuthority in acmpca to populate certificateAuthorityArn.
+	// +kubebuilder:validation:Optional
+	CertificateAuthorityArnRef *v1.Reference `json:"certificateAuthorityArnRef,omitempty" tf:"-"`
+
+	// Selector for a CertificateAuthority in acmpca to populate certificateAuthorityArn.
+	// +kubebuilder:validation:Optional
+	CertificateAuthorityArnSelector *v1.Selector `json:"certificateAuthorityArnSelector,omitempty" tf:"-"`
 
 	// Certificate's PEM-formatted public key
 	CertificateBody *string `json:"certificateBody,omitempty" tf:"certificate_body,omitempty"`
@@ -142,8 +151,17 @@ type CertificateObservation struct {
 type CertificateParameters struct {
 
 	// ARN of an ACM PCA
+	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/acmpca/v1beta1.CertificateAuthority
 	// +kubebuilder:validation:Optional
 	CertificateAuthorityArn *string `json:"certificateAuthorityArn,omitempty" tf:"certificate_authority_arn,omitempty"`
+
+	// Reference to a CertificateAuthority in acmpca to populate certificateAuthorityArn.
+	// +kubebuilder:validation:Optional
+	CertificateAuthorityArnRef *v1.Reference `json:"certificateAuthorityArnRef,omitempty" tf:"-"`
+
+	// Selector for a CertificateAuthority in acmpca to populate certificateAuthorityArn.
+	// +kubebuilder:validation:Optional
+	CertificateAuthorityArnSelector *v1.Selector `json:"certificateAuthorityArnSelector,omitempty" tf:"-"`
 
 	// Certificate's PEM-formatted public key
 	// +kubebuilder:validation:Optional

--- a/apis/acm/v1beta1/zz_generated.deepcopy.go
+++ b/apis/acm/v1beta1/zz_generated.deepcopy.go
@@ -48,6 +48,16 @@ func (in *CertificateInitParameters) DeepCopyInto(out *CertificateInitParameters
 		*out = new(string)
 		**out = **in
 	}
+	if in.CertificateAuthorityArnRef != nil {
+		in, out := &in.CertificateAuthorityArnRef, &out.CertificateAuthorityArnRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.CertificateAuthorityArnSelector != nil {
+		in, out := &in.CertificateAuthorityArnSelector, &out.CertificateAuthorityArnSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.CertificateBody != nil {
 		in, out := &in.CertificateBody, &out.CertificateBody
 		*out = new(string)
@@ -347,6 +357,16 @@ func (in *CertificateParameters) DeepCopyInto(out *CertificateParameters) {
 		in, out := &in.CertificateAuthorityArn, &out.CertificateAuthorityArn
 		*out = new(string)
 		**out = **in
+	}
+	if in.CertificateAuthorityArnRef != nil {
+		in, out := &in.CertificateAuthorityArnRef, &out.CertificateAuthorityArnRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.CertificateAuthorityArnSelector != nil {
+		in, out := &in.CertificateAuthorityArnSelector, &out.CertificateAuthorityArnSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.CertificateBody != nil {
 		in, out := &in.CertificateBody, &out.CertificateBody

--- a/apis/acm/v1beta1/zz_generated.resolvers.go
+++ b/apis/acm/v1beta1/zz_generated.resolvers.go
@@ -9,14 +9,65 @@ package v1beta1
 import (
 	"context"
 	reference "github.com/crossplane/crossplane-runtime/pkg/reference"
-	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	errors "github.com/pkg/errors"
+
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	apisresolver "github.com/upbound/provider-aws/internal/apis"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (mg *CertificateValidation) ResolveReferences( // ResolveReferences of this CertificateValidation.
+func (mg *Certificate) ResolveReferences( // ResolveReferences of this Certificate.
 	ctx context.Context, c client.Reader) error {
+	var m xpresource.Managed
+	var l xpresource.ManagedList
+	r := reference.NewAPIResolver(c, mg)
+
+	var rsp reference.ResolutionResponse
+	var err error
+	{
+		m, l, err = apisresolver.GetManagedResource("acmpca.aws.upbound.io", "v1beta1", "CertificateAuthority", "CertificateAuthorityList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.CertificateAuthorityArn),
+			Extract:      reference.ExternalName(),
+			Reference:    mg.Spec.ForProvider.CertificateAuthorityArnRef,
+			Selector:     mg.Spec.ForProvider.CertificateAuthorityArnSelector,
+			To:           reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.CertificateAuthorityArn")
+	}
+	mg.Spec.ForProvider.CertificateAuthorityArn = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.CertificateAuthorityArnRef = rsp.ResolvedReference
+	{
+		m, l, err = apisresolver.GetManagedResource("acmpca.aws.upbound.io", "v1beta1", "CertificateAuthority", "CertificateAuthorityList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.CertificateAuthorityArn),
+			Extract:      reference.ExternalName(),
+			Reference:    mg.Spec.InitProvider.CertificateAuthorityArnRef,
+			Selector:     mg.Spec.InitProvider.CertificateAuthorityArnSelector,
+			To:           reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.CertificateAuthorityArn")
+	}
+	mg.Spec.InitProvider.CertificateAuthorityArn = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.InitProvider.CertificateAuthorityArnRef = rsp.ResolvedReference
+
+	return nil
+}
+
+// ResolveReferences of this CertificateValidation.
+func (mg *CertificateValidation) ResolveReferences(ctx context.Context, c client.Reader) error {
 	var m xpresource.Managed
 	var l xpresource.ManagedList
 	r := reference.NewAPIResolver(c, mg)

--- a/config/acm/config.go
+++ b/config/acm/config.go
@@ -20,6 +20,11 @@ func Configure(p *config.Provider) {
 		r.UseAsync = true
 	})
 	p.AddResourceConfigurator("aws_acm_certificate", func(r *config.Resource) {
+		r.References = map[string]config.Reference{
+			"certificate_authority_arn": {
+				TerraformName: "aws_acmpca_certificate_authority",
+			},
+		}
 		r.LateInitializer = config.LateInitializer{
 			// These are ignored because they conflict with each other.
 			// See the following for more details: https://github.com/upbound/provider-aws/issues/464

--- a/package/crds/acm.aws.upbound.io_certificates.yaml
+++ b/package/crds/acm.aws.upbound.io_certificates.yaml
@@ -76,6 +76,82 @@ spec:
                   certificateAuthorityArn:
                     description: ARN of an ACM PCA
                     type: string
+                  certificateAuthorityArnRef:
+                    description: Reference to a CertificateAuthority in acmpca to
+                      populate certificateAuthorityArn.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  certificateAuthorityArnSelector:
+                    description: Selector for a CertificateAuthority in acmpca to
+                      populate certificateAuthorityArn.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   certificateBody:
                     description: Certificate's PEM-formatted public key
                     type: string
@@ -187,6 +263,82 @@ spec:
                   certificateAuthorityArn:
                     description: ARN of an ACM PCA
                     type: string
+                  certificateAuthorityArnRef:
+                    description: Reference to a CertificateAuthority in acmpca to
+                      populate certificateAuthorityArn.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  certificateAuthorityArnSelector:
+                    description: Selector for a CertificateAuthority in acmpca to
+                      populate certificateAuthorityArn.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   certificateBody:
                     description: Certificate's PEM-formatted public key
                     type: string


### PR DESCRIPTION


<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes
add reference and selector for certificate_authority_arn to acmpca certificate authority
we want to migrate from community provider to provider-upjet-aws but reference and selector is missing like:

https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws/v0.48.1/resources/acm.aws.crossplane.io/Certificate/v1beta1#doc:spec-forProvider-certificateAuthorityARNRef

https://marketplace.upbound.io/providers/crossplane-contrib/provider-aws/v0.48.1/resources/acm.aws.crossplane.io/Certificate/v1beta1#doc:spec-forProvider-certificateAuthorityARNSelector

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
