### PR TITLE
Fix Topic.sns update loops

### DIFF
--- a/config/sns/config.go
+++ b/config/sns/config.go
@@ -6,6 +6,10 @@ package sns
 
 import (
 	"github.com/crossplane/upjet/pkg/config"
+	awspolicy "github.com/hashicorp/awspolicyequivalence"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	jsoniter "github.com/json-iterator/go"
+	"github.com/pkg/errors"
 
 	"github.com/upbound/provider-aws/config/common"
 )
@@ -26,5 +30,42 @@ func Configure(p *config.Provider) {
 		// If the topic policy is unset on the Topic resource, don't late initialize it, to avoid conflicts with the
 		// policy managed by a TopicPolicy resource.
 		r.LateInitializer.IgnoredFields = append(r.LateInitializer.IgnoredFields, "policy")
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			if diff == nil || diff.Attributes["policy"] == nil || diff.Attributes["policy"].Old == "" || diff.Attributes["policy"].New == "" {
+				return diff, nil
+			}
+
+			vOld, err := removePolicyVersion(diff.Attributes["policy"].Old)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to remove Version from the old AWS policy document")
+			}
+			vNew, err := removePolicyVersion(diff.Attributes["policy"].New)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to remove Version from the new AWS policy document")
+			}
+
+			ok, err := awspolicy.PoliciesAreEquivalent(vOld, vNew)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to compare the old and the new AWS policy documents")
+			}
+			if ok {
+				delete(diff.Attributes, "policy")
+			}
+			return diff, nil
+		}
 	})
+}
+
+func removePolicyVersion(p string) (string, error) {
+	var policy any
+	if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(p), &policy); err != nil {
+		return "", errors.Wrap(err, "failed to unmarshal the policy from JSON")
+	}
+	m, ok := policy.(map[string]any)
+	if !ok {
+		return p, nil
+	}
+	delete(m, "Version")
+	r, err := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(m)
+	return string(r), errors.Wrap(err, "failed to marshal the policy map as JSON")
 }

--- a/examples/sns/v1beta1/topic-with-policy.yaml
+++ b/examples/sns/v1beta1/topic-with-policy.yaml
@@ -5,6 +5,8 @@
 apiVersion: sns.aws.upbound.io/v1beta1
 kind: Topic
 metadata:
+  annotations:
+    meta.upbound.io/example-id: sns/v1beta1/topic
   name: example-topic-${Rand.RFC1123Subdomain}
   labels:
     testing.upbound.io/example-name: sns
@@ -19,7 +21,7 @@ spec:
           "Effect": "Allow",
           "Principal": {
             "AWS": [
-              "arn:aws:iam::123456789110:role/test/project/test/principal1"
+              "arn:aws:iam::153891904029:role/sample-role"
             ]
           },
           "Action": "sns:Publish",
@@ -30,7 +32,7 @@ spec:
           "Effect": "Allow",
           "Principal": {
             "AWS": [
-              "arn:aws:iam::123456789110:role/test/project/test/principal1"
+              "arn:aws:iam::153891904029:role/sample-role"
             ]
           },
           "Action": "sns:GetTopicAttributes",
@@ -41,11 +43,37 @@ spec:
           "Effect": "Allow",
           "Principal": {
             "AWS": [
-              "arn:aws:iam::123456789110:role/test/project/test/principal1"
+              "arn:aws:iam::153891904029:role/sample-role"
             ]
           },
           "Action": "sns:ListSubscriptionsByTopic",
           "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
         }
+        ]
+      }
+
+---
+
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Role
+metadata:
+  annotations:
+    meta.upbound.io/example-id: sns/v1beta1/topic
+  labels:
+    testing.upbound.io/example-name: role
+  name: sample-role
+spec:
+  forProvider:
+    assumeRolePolicy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "eks.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+          }
         ]
       }

--- a/examples/sns/v1beta1/topic-with-policy.yaml
+++ b/examples/sns/v1beta1/topic-with-policy.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+apiVersion: sns.aws.upbound.io/v1beta1
+kind: Topic
+metadata:
+  name: example-topic-${Rand.RFC1123Subdomain}
+  labels:
+    testing.upbound.io/example-name: sns
+spec:
+  forProvider:
+    region: us-west-1
+    policy: |-
+      {
+        "Statement": [
+        {
+          "Sid": "publish",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": [
+              "arn:aws:iam::123456789110:role/test/project/test/principal1"
+            ]
+          },
+          "Action": "sns:Publish",
+          "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
+        },
+        {
+          "Sid": "get-attributes",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": [
+              "arn:aws:iam::123456789110:role/test/project/test/principal1"
+            ]
+          },
+          "Action": "sns:GetTopicAttributes",
+          "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
+        },
+        {
+          "Sid": "list-subscriptions",
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": [
+              "arn:aws:iam::123456789110:role/test/project/test/principal1"
+            ]
+          },
+          "Action": "sns:ListSubscriptionsByTopic",
+          "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
+        }
+        ]
+      }

--- a/go.mod
+++ b/go.mod
@@ -23,10 +23,12 @@ require (
 	github.com/crossplane/upjet v1.4.1
 	github.com/go-ini/ini v1.46.0
 	github.com/google/go-cmp v0.6.0
+	github.com/hashicorp/awspolicyequivalence v1.6.0
 	github.com/hashicorp/terraform-json v0.21.0
 	github.com/hashicorp/terraform-plugin-framework v1.8.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.33.0
 	github.com/hashicorp/terraform-provider-aws v0.0.0-00010101000000-000000000000
+	github.com/json-iterator/go v1.1.12
 	github.com/pkg/errors v0.9.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/yaml.v3 v3.0.1
@@ -259,7 +261,6 @@ require (
 	github.com/hashicorp/aws-cloudformation-resource-schema-sdk-go v0.22.0 // indirect
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.53 // indirect
 	github.com/hashicorp/aws-sdk-go-base/v2/awsv1shim/v2 v2.0.0-beta.54 // indirect
-	github.com/hashicorp/awspolicyequivalence v1.6.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
@@ -289,7 +290,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattbaird/jsonpatch v0.0.0-20230413205102-771768614e91 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
We've observed update loops with the `Topic.sns` resources when inline policies are given. The desired policy document in the `spec` can differ from the actual (observed) document in the following two ways:
- Missing `Version` node. An example is as follows:
```json
      {
        "Statement": [
        {
          "Sid": "publish",
          "Effect": "Allow",
          "Principal": {
            "AWS": "arn:aws:iam::123456789110:role/sample-role"
          },
          "Action": "sns:Publish",
          "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
        },
        {
          "Sid": "get-attributes",
          "Effect": "Allow",
          "Principal": {
            "AWS": "arn:aws:iam::123456789110:role/sample-role"
          },
          "Action": "sns:GetTopicAttributes",
          "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
        },
        {
          "Sid": "list-subscriptions",
          "Effect": "Allow",
          "Principal": {
            "AWS": "arn:aws:iam::123456789110:role/sample-role"
          },
          "Action": "sns:ListSubscriptionsByTopic",
          "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
        }
        ]
      }
```
What's observed constains a `Version` node:
```json
      {
        "Version": "2008-10-17",
        "Statement": [
        {
          "Sid": "publish",
          "Effect": "Allow",
          "Principal": {
            "AWS": "arn:aws:iam::123456789110:role/sample-role"
          },
          "Action": "sns:Publish",
          "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
        },
        {
          "Sid": "get-attributes",
          "Effect": "Allow",
          "Principal": {
            "AWS": "arn:aws:iam::123456789110:role/sample-role"
          },
          "Action": "sns:GetTopicAttributes",
          "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
        },
        {
          "Sid": "list-subscriptions",
          "Effect": "Allow",
          "Principal": {
            "AWS": "arn:aws:iam::123456789110:role/sample-role"
          },
          "Action": "sns:ListSubscriptionsByTopic",
          "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
        }
        ]
      }
```
Please note the `Version` node in the observed policy document.

- Topology differences:
What's declared in `spec` could be:
```json
      {
        "Statement": [
        {
          "Sid": "publish",
          "Effect": "Allow",
          "Principal": {
            "AWS": [
              "arn:aws:iam::123456789110:role/sample-role"
            ]
          },
          "Action": "sns:Publish",
          "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
        },
        {
          "Sid": "get-attributes",
          "Effect": "Allow",
          "Principal": {
            "AWS": [
              "arn:aws:iam::123456789110:role/sample-role"
            ]
          },
          "Action": "sns:GetTopicAttributes",
          "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
        },
        {
          "Sid": "list-subscriptions",
          "Effect": "Allow",
          "Principal": {
            "AWS": [
              "arn:aws:iam::123456789110:role/sample-role"
            ]
          },
          "Action": "sns:ListSubscriptionsByTopic",
          "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
        }
        ]
      }
```

And what's observed could then be:
```json
      {
        "Version": "2008-10-17",
        "Statement": [
        {
          "Sid": "publish",
          "Effect": "Allow",
          "Principal": {
            "AWS": "arn:aws:iam::123456789110:role/sample-role"
          },
          "Action": "sns:Publish",
          "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
        },
        {
          "Sid": "get-attributes",
          "Effect": "Allow",
          "Principal": {
            "AWS": "arn:aws:iam::123456789110:role/sample-role"
          },
          "Action": "sns:GetTopicAttributes",
          "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
        },
        {
          "Sid": "list-subscriptions",
          "Effect": "Allow",
          "Principal": {
            "AWS": "arn:aws:iam::123456789110:role/sample-role"
          },
          "Action": "sns:ListSubscriptionsByTopic",
          "Resource": "arn:aws:sns:us-west-1:123456789110:resource1"
        }
        ]
      }
```
Please note that the declared AWS IAM principals are JSON arrays whereas the observed ones are strings.

This PR proposes to introduce a custom Terraform diff to filter out such differences that result in an update loop. This is already implemented as a diff suppress function in the underlying Terraform provider. We should consider making sure that these suppress functions are properly invoked in a future iteration but it will result in a larger change that will require more rigorous testing.

This PR also adds a `Topic.sns` example manifest with an inline policy document to test the fix.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

- Successful uptest run with the diff customization: https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/9406883608/
- Also validated that we can force an update loop **without** the diff customization: https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/9408319232

[contribution process]: https://git.io/fj2m9
