### PR TITLE
Make SSO examples uptestable

### DIFF
--- a/examples/identitystore/v1beta1/group.yaml
+++ b/examples/identitystore/v1beta1/group.yaml
@@ -7,7 +7,6 @@ kind: Group
 metadata:
   annotations:
     meta.upbound.io/example-id: identitystore/v1beta1/group
-    upjet.upbound.io/manual-intervention: "This resource requires a valid identityStoreId"
   labels:
     testing.upbound.io/example-name: example-group
   name: example-group
@@ -15,5 +14,5 @@ spec:
   forProvider:
     description: Example description
     displayName: Example group
-    identityStoreId: Identity store id from a manually created SSO instance in the same region specified below
+    identityStoreId: "${data.identity_store_id}"
     region: us-east-1

--- a/examples/identitystore/v1beta1/groupmembership.yaml
+++ b/examples/identitystore/v1beta1/groupmembership.yaml
@@ -7,7 +7,6 @@ kind: GroupMembership
 metadata:
   annotations:
     meta.upbound.io/example-id: identitystore/v1beta1/groupmembership
-    upjet.upbound.io/manual-intervention: "This resource requires a valid identityStoreId"
   labels:
     testing.upbound.io/example-name: example-membership
   name: example-membership
@@ -16,7 +15,7 @@ spec:
     groupIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example-membership
-    identityStoreId: Identity store id from a manually created SSO instance in the same region specified below
+    identityStoreId: "${data.identity_store_id}"
     memberIdSelector:
       matchLabels:
         testing.upbound.io/example-name: example-membership
@@ -29,7 +28,6 @@ kind: Group
 metadata:
   annotations:
     meta.upbound.io/example-id: identitystore/v1beta1/groupmembership
-    upjet.upbound.io/manual-intervention: "This resource requires a valid identityStoreId"
   labels:
     testing.upbound.io/example-name: example-membership
   name: example-membership
@@ -37,7 +35,7 @@ spec:
   forProvider:
     description: Some group name
     displayName: MyGroup
-    identityStoreId: Identity store id from a manually created SSO instance in the same region specified below
+    identityStoreId: "${data.identity_store_id}"
     region: us-east-1
 
 ---
@@ -47,14 +45,13 @@ kind: User
 metadata:
   annotations:
     meta.upbound.io/example-id: identitystore/v1beta1/groupmembership
-    upjet.upbound.io/manual-intervention: "This resource requires a valid identityStoreId"
   labels:
     testing.upbound.io/example-name: example-membership
   name: example-membership
 spec:
   forProvider:
     displayName: John Doe
-    identityStoreId: Identity store id from a manually created SSO instance in the same region specified below
+    identityStoreId: "${data.identity_store_id}"
     name:
     - familyName: Doe
       givenName: John

--- a/examples/identitystore/v1beta1/user.yaml
+++ b/examples/identitystore/v1beta1/user.yaml
@@ -7,7 +7,6 @@ kind: User
 metadata:
   annotations:
     meta.upbound.io/example-id: identitystore/v1beta1/user
-    upjet.upbound.io/manual-intervention: "This resource requires a valid identityStoreId"
   labels:
     testing.upbound.io/example-name: example-user
   name: example-user
@@ -16,7 +15,7 @@ spec:
     displayName: John Doe
     emails:
     - value: john@example.com
-    identityStoreId: Identity store id from a manually created SSO instance in the same region specified below
+    identityStoreId: "${data.identity_store_id}"
     name:
     - familyName: Doe
       givenName: John

--- a/examples/identitystore/v1beta2/user.yaml
+++ b/examples/identitystore/v1beta2/user.yaml
@@ -7,7 +7,6 @@ kind: User
 metadata:
   annotations:
     meta.upbound.io/example-id: identitystore/v1beta2/user
-    upjet.upbound.io/manual-intervention: This resource requires a valid identityStoreId
   labels:
     testing.upbound.io/example-name: example-user
   name: example-user
@@ -16,8 +15,7 @@ spec:
     displayName: John Doe
     emails:
       value: john@example.com
-    identityStoreId: Identity store id from a manually created SSO instance in the
-      same region specified below
+    identityStoreId: "${data.identity_store_id}"
     name:
       familyName: Doe
       givenName: John

--- a/examples/ssoadmin/v1beta1/accountassignment.yaml
+++ b/examples/ssoadmin/v1beta1/accountassignment.yaml
@@ -7,13 +7,12 @@ kind: AccountAssignment
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta1/accountassignment
-    upjet.upbound.io/manual-intervention: "This resource requires a valid instanceArn(The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed)."
   labels:
     testing.upbound.io/example-name: ssoadmin-accountassignment
   name: ssoadmin-accountassignment
 spec:
   forProvider:
-    instanceArn: ARN of a manually created SSO instance in the same region specified below
+    instanceArn: "${data.sso_instance_arn}"
     permissionSetArnSelector:
       matchLabels:
         testing.upbound.io/example-name: ssoadmin-accountassignment
@@ -22,7 +21,7 @@ spec:
         testing.upbound.io/example-name: ssoadmin-accountassignment
     principalType: GROUP
     region: us-east-1
-    targetId: "012347678910"
+    targetId: "${data.aws_account_id}"
     targetType: AWS_ACCOUNT
 
 ---
@@ -31,14 +30,13 @@ kind: PermissionSet
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta1/accountassignment
-    upjet.upbound.io/manual-intervention: "This resource requires a valid instanceArn(The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed)."
   labels:
     testing.upbound.io/example-name: ssoadmin-accountassignment
   name: ssoadmin-accountassignment
 spec:
   forProvider:
     description: An example
-    instanceArn: ARN of a manually created SSO instance in the same region specified below
+    instanceArn: "${data.sso_instance_arn}"
     name: example-acct-assignment
     region: us-east-1
     sessionDuration: PT2H
@@ -49,12 +47,11 @@ kind: Group
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta1/accountassignment
-    upjet.upbound.io/manual-intervention: "This resource requires a valid identityStoreId"
   labels:
     testing.upbound.io/example-name: ssoadmin-accountassignment
   name: ssoadmin-accountassignment
 spec:
   forProvider:
-    identityStoreId: identity store id from a manually created SSO instance in the same region specified below
+    identityStoreId: "${data.identity_store_id}"
     region: us-east-1
     displayName: example-acct-assignment

--- a/examples/ssoadmin/v1beta1/customermanagedpolicyattachment.yaml
+++ b/examples/ssoadmin/v1beta1/customermanagedpolicyattachment.yaml
@@ -7,7 +7,6 @@ kind: CustomerManagedPolicyAttachment
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta1/customermanagedpolicyattachment
-    upjet.upbound.io/manual-intervention: "This resource requires a valid instanceArn(The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed)."
   labels:
     testing.upbound.io/example-name: ssoadmin-customer-managed-policy-attachment
   name: ssoadmin-customer-managed-policy-attachment
@@ -19,7 +18,7 @@ spec:
         matchLabels:
           testing.upbound.io/example-name: ssoadmin-customer-managed-policy-attachment
       path: "/"
-    instanceArn: ARN of a manually created SSO instance in the same region specified below
+    instanceArn: "${data.sso_instance_arn}"
     permissionSetArnSelector:
       matchLabels:
         testing.upbound.io/example-name: ssoadmin-customer-managed-policy-attachment
@@ -57,12 +56,11 @@ kind: PermissionSet
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta1/customermanagedpolicyattachment
-    upjet.upbound.io/manual-intervention: "This resource requires a valid instanceArn(The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed)."
   labels:
     testing.upbound.io/example-name: ssoadmin-customer-managed-policy-attachment
   name: ssoadmin-customer-managed-policy-attachment
 spec:
   forProvider:
-    instanceArn: ARN of a manually created SSO instance in the same region specified below
+    instanceArn: "${data.sso_instance_arn}"
     name: example-cmpa
     region: us-east-1

--- a/examples/ssoadmin/v1beta1/instanceaccesscontrolattributes.yaml
+++ b/examples/ssoadmin/v1beta1/instanceaccesscontrolattributes.yaml
@@ -7,13 +7,12 @@ kind: InstanceAccessControlAttributes
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta1/instanceaccesscontrolattributes
-    upjet.upbound.io/manual-intervention: "This resource requires a valid instanceArn(The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed)."
   labels:
     testing.upbound.io/example-name: ssoadmin-instance-access-control-attributes
   name: ssoadmin-instance-access-control-attributes
 spec:
   forProvider:
-    instanceArn: ARN of a manually created SSO instance in the same region specified below
+    instanceArn: "${data.sso_instance_arn}"
     attribute:
     - key: name
       value:

--- a/examples/ssoadmin/v1beta1/managedpolicyattachment.yaml
+++ b/examples/ssoadmin/v1beta1/managedpolicyattachment.yaml
@@ -7,13 +7,12 @@ kind: ManagedPolicyAttachment
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta1/managedpolicyattachment
-    upjet.upbound.io/manual-intervention: "This resource requires a valid instanceArn(The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed)."
   labels:
     testing.upbound.io/example-name: ssoadmin-managed-policy-attachment
   name: ssoadmin-managed-policy-attachment
 spec:
   forProvider:
-    instanceArn: ARN of a manually created SSO instance in the same region specified below
+    instanceArn: "${data.sso_instance_arn}"
     managedPolicyArn: arn:aws:iam::aws:policy/AlexaForBusinessDeviceSetup
     permissionSetArnSelector:
       matchLabels:
@@ -27,12 +26,11 @@ kind: PermissionSet
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta1/managedpolicyattachment
-    upjet.upbound.io/manual-intervention: "This resource requires a valid instanceArn(The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed)."
   labels:
     testing.upbound.io/example-name: ssoadmin-managed-policy-attachment
   name: ssoadmin-managed-policy-attachment
 spec:
   forProvider:
-    instanceArn: ARN of a manually created SSO instance in the same region specified below
+    instanceArn: "${data.sso_instance_arn}"
     name: example-mpa
     region: us-east-1

--- a/examples/ssoadmin/v1beta1/permissionsboundaryattachment.yaml
+++ b/examples/ssoadmin/v1beta1/permissionsboundaryattachment.yaml
@@ -7,13 +7,12 @@ kind: PermissionsBoundaryAttachment
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta1/permissionsboundaryattachment
-    upjet.upbound.io/manual-intervention: "This resource requires a valid instanceArn(The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed)."
   labels:
     testing.upbound.io/example-name: ssoadmin-permissions-boundary-attachment
   name: ssoadmin-permissions-boundary-attachment
 spec:
   forProvider:
-    instanceArn: ARN of a manually created SSO instance in the same region specified below
+    instanceArn: "${data.sso_instance_arn}"
     permissionSetArnSelector:
       matchLabels:
         testing.upbound.io/example-name: ssoadmin-permissions-boundary-attachment
@@ -57,12 +56,11 @@ kind: PermissionSet
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta1/permissionsboundaryattachment
-    upjet.upbound.io/manual-intervention: "This resource requires a valid instanceArn(The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed)."
   labels:
     testing.upbound.io/example-name: ssoadmin-permissions-boundary-attachment
   name: ssoadmin-permissions-boundary-attachment
 spec:
   forProvider:
-    instanceArn: ARN of a manually created SSO instance in the same region specified below
+    instanceArn: "${data.sso_instance_arn}"
     name: example-pba
     region: us-east-1

--- a/examples/ssoadmin/v1beta1/permissionset.yaml
+++ b/examples/ssoadmin/v1beta1/permissionset.yaml
@@ -7,14 +7,13 @@ kind: PermissionSet
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta1/permissionset
-    upjet.upbound.io/manual-intervention: "This resource requires a valid instanceArn(The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed)."
   labels:
     testing.upbound.io/example-name: ssoadmin-permission-set
   name: ssoadmin-permission-set
 spec:
   forProvider:
     description: An example
-    instanceArn: ARN of a manually created SSO instance in the same region specified below
+    instanceArn: "${data.sso_instance_arn}"
     name: example-ps
     region: us-east-1
     relayState: https://s3.console.aws.amazon.com/s3/home?region=us-east-1#

--- a/examples/ssoadmin/v1beta1/permissionsetinlinepolicy.yaml
+++ b/examples/ssoadmin/v1beta1/permissionsetinlinepolicy.yaml
@@ -7,13 +7,12 @@ kind: PermissionSetInlinePolicy
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta1/permissionsetinlinepolicy
-    upjet.upbound.io/manual-intervention: "This resource requires a valid instanceArn(The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed)."
   labels:
     testing.upbound.io/example-name: ssoadmin-permission-set-inline-policy
   name: ssoadmin-permission-set-inline-policy
 spec:
   forProvider:
-    instanceArn: ARN of a manually created SSO instance in the same region specified below
+    instanceArn: "${data.sso_instance_arn}"
     permissionSetArnSelector:
       matchLabels:
         testing.upbound.io/example-name: ssoadmin-permission-set-inline-policy
@@ -40,12 +39,11 @@ kind: PermissionSet
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta1/permissionsetinlinepolicy
-    upjet.upbound.io/manual-intervention: "This resource requires a valid instanceArn(The Amazon Resource Name (ARN) of the SSO Instance under which the operation will be executed)."
   labels:
     testing.upbound.io/example-name: ssoadmin-permission-set-inline-policy
   name: ssoadmin-permission-set-inline-policy
 spec:
   forProvider:
-    instanceArn: ARN of a manually created SSO instance in the same region specified below
+    instanceArn: "${data.sso_instance_arn}"
     name: example-inline
     region: us-east-1

--- a/examples/ssoadmin/v1beta2/customermanagedpolicyattachment.yaml
+++ b/examples/ssoadmin/v1beta2/customermanagedpolicyattachment.yaml
@@ -7,7 +7,6 @@ kind: CustomerManagedPolicyAttachment
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta2/customermanagedpolicyattachment
-    upjet.upbound.io/manual-intervention: This resource requires a valid instanceArn(The
       Amazon Resource Name (ARN) of the SSO Instance under which the operation will
       be executed).
   labels:
@@ -21,8 +20,7 @@ spec:
       policyNameSelector:
         matchLabels:
           testing.upbound.io/example-name: ssoadmin-customer-managed-policy-attachment
-    instanceArn: ARN of a manually created SSO instance in the same region specified
-      below
+    instanceArn: "${data.sso_instance_arn}"
     permissionSetArnSelector:
       matchLabels:
         testing.upbound.io/example-name: ssoadmin-customer-managed-policy-attachment
@@ -60,15 +58,11 @@ kind: PermissionSet
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta2/customermanagedpolicyattachment
-    upjet.upbound.io/manual-intervention: This resource requires a valid instanceArn(The
-      Amazon Resource Name (ARN) of the SSO Instance under which the operation will
-      be executed).
   labels:
     testing.upbound.io/example-name: ssoadmin-customer-managed-policy-attachment
   name: ssoadmin-customer-managed-policy-attachment
 spec:
   forProvider:
-    instanceArn: ARN of a manually created SSO instance in the same region specified
-      below
+    instanceArn: "${data.sso_instance_arn}"
     name: example-cmpa
     region: us-east-1

--- a/examples/ssoadmin/v1beta2/permissionsboundaryattachment.yaml
+++ b/examples/ssoadmin/v1beta2/permissionsboundaryattachment.yaml
@@ -7,16 +7,12 @@ kind: PermissionsBoundaryAttachment
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta2/permissionsboundaryattachment
-    upjet.upbound.io/manual-intervention: This resource requires a valid instanceArn(The
-      Amazon Resource Name (ARN) of the SSO Instance under which the operation will
-      be executed).
   labels:
     testing.upbound.io/example-name: ssoadmin-permissions-boundary-attachment
   name: ssoadmin-permissions-boundary-attachment
 spec:
   forProvider:
-    instanceArn: ARN of a manually created SSO instance in the same region specified
-      below
+    instanceArn: "${data.sso_instance_arn}"
     permissionSetArnSelector:
       matchLabels:
         testing.upbound.io/example-name: ssoadmin-permissions-boundary-attachment
@@ -60,15 +56,11 @@ kind: PermissionSet
 metadata:
   annotations:
     meta.upbound.io/example-id: ssoadmin/v1beta2/permissionsboundaryattachment
-    upjet.upbound.io/manual-intervention: This resource requires a valid instanceArn(The
-      Amazon Resource Name (ARN) of the SSO Instance under which the operation will
-      be executed).
   labels:
     testing.upbound.io/example-name: ssoadmin-permissions-boundary-attachment
   name: ssoadmin-permissions-boundary-attachment
 spec:
   forProvider:
-    instanceArn: ARN of a manually created SSO instance in the same region specified
-      below
+    instanceArn: "${data.sso_instance_arn}"
     name: example-pba
     region: us-east-1


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

I noticed when doing https://github.com/crossplane-contrib/provider-upjet-aws/pull/1349 that some of the ssoadmin resources have an external name configuration that uses `index` to extract a value that appears in a singleton object. These seemed like good candidates to test with these changes. 

I'm pleased to report that :heavy_check_mark: the tests pass with no issues for all the v1beta1 and v1beta2 manifests in both identitystore and ssoadmin. Logs are attached. Note that because I deliberately used unique names for each resource when I first wrote these example manifests, I was able to uptest them all at once (per api version), which was quite fast.

I also made the ssoadmin and identitystore resources uptestable by using an uptest datasource.

In order for these to pass with the config used in github actions, someone from upbound will need to:
* Create an instance of aws iam identity center in us-east-1 in the aws organization the uptest account belongs to. If it's not in an organization, then it can just be made into an org (I did this with my personal account)
* If the uptest account is not the primary account for its aws organization, then it needs to be made a delegated admin account in the IAM identity Center console.
* Put the appropriate values in the github secret used for the uptest datasource.

Note on aws terminology: IAM Identiy Center is the current name for what aws originally launched as "sso" and "identity store". We still have the old names in the SDK, but the console uses the new marketing names. 

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
[ssoadmin-v1beta1.logs.txt](https://github.com/user-attachments/files/15755383/ssoadmin-v1beta1.logs.txt)
[ssoadmin-v1beta2.logs.txt](https://github.com/user-attachments/files/15755384/ssoadmin-v1beta2.logs.txt)
[identitystore.logs.txt](https://github.com/user-attachments/files/15755385/identitystore.logs.txt)

[contribution process]: https://git.io/fj2m9
