### PR TITLE
fix(sqs): update loop queues.sqs

### DIFF
--- a/config/sns/config.go
+++ b/config/sns/config.go
@@ -8,7 +8,6 @@ import (
 	"github.com/crossplane/upjet/pkg/config"
 	awspolicy "github.com/hashicorp/awspolicyequivalence"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	jsoniter "github.com/json-iterator/go"
 	"github.com/pkg/errors"
 
 	"github.com/upbound/provider-aws/config/common"
@@ -35,11 +34,11 @@ func Configure(p *config.Provider) {
 				return diff, nil
 			}
 
-			vOld, err := removePolicyVersion(diff.Attributes["policy"].Old)
+			vOld, err := common.RemovePolicyVersion(diff.Attributes["policy"].Old)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to remove Version from the old AWS policy document")
 			}
-			vNew, err := removePolicyVersion(diff.Attributes["policy"].New)
+			vNew, err := common.RemovePolicyVersion(diff.Attributes["policy"].New)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to remove Version from the new AWS policy document")
 			}
@@ -54,18 +53,4 @@ func Configure(p *config.Provider) {
 			return diff, nil
 		}
 	})
-}
-
-func removePolicyVersion(p string) (string, error) {
-	var policy any
-	if err := jsoniter.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(p), &policy); err != nil {
-		return "", errors.Wrap(err, "failed to unmarshal the policy from JSON")
-	}
-	m, ok := policy.(map[string]any)
-	if !ok {
-		return p, nil
-	}
-	delete(m, "Version")
-	r, err := jsoniter.ConfigCompatibleWithStandardLibrary.Marshal(m)
-	return string(r), errors.Wrap(err, "failed to marshal the policy map as JSON")
 }

--- a/config/sqs/config.go
+++ b/config/sqs/config.go
@@ -6,6 +6,9 @@ package sqs
 
 import (
 	"github.com/crossplane/upjet/pkg/config"
+	awspolicy "github.com/hashicorp/awspolicyequivalence"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/pkg/errors"
 
 	"github.com/upbound/provider-aws/config/common"
 )
@@ -30,6 +33,30 @@ func Configure(p *config.Provider) {
 		// If the key policy is unset on the Queue resource, don't late initialize it, to avoid conflicts with the policy
 		// managed by a QueuePolicy resource.
 		r.LateInitializer.IgnoredFields = append(r.LateInitializer.IgnoredFields, "name_prefix", "policy")
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			if diff == nil || diff.Attributes["policy"] == nil || diff.Attributes["policy"].Old == "" || diff.Attributes["policy"].New == "" {
+				return diff, nil
+			}
+
+			vOld, err := common.RemovePolicyVersion(diff.Attributes["policy"].Old)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to remove Version from the old AWS policy document")
+			}
+			vNew, err := common.RemovePolicyVersion(diff.Attributes["policy"].New)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to remove Version from the new AWS policy document")
+			}
+
+			ok, err := awspolicy.PoliciesAreEquivalent(vOld, vNew)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to compare the old and the new AWS policy documents")
+			}
+			if ok {
+				delete(diff.Attributes, "policy")
+			}
+			return diff, nil
+		}
+
 	})
 
 	p.AddResourceConfigurator("aws_sqs_queue_redrive_policy", func(r *config.Resource) {

--- a/examples/sqs/v1beta1/queue-with-policy.yaml
+++ b/examples/sqs/v1beta1/queue-with-policy.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+apiVersion: sqs.aws.upbound.io/v1beta1
+kind: Queue
+metadata:
+  name: example-with-policy
+  labels:
+    testing.upbound.io/example-name: example
+spec:
+  forProvider:
+    name: upbound-sqs-with-policy
+    policy: |
+      {
+        "Statement": [
+          {
+            "Sid": "example",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "s3.amazonaws.com"
+            },
+            "Action": "sqs:SendMessage",
+            "Resource": "arn:aws:sqs:us-west-1:*:queue-policy"
+          }
+        ]
+      }
+    delaySeconds: 90
+    maxMessageSize: 2048
+    messageRetentionSeconds: 86400
+    receiveWaitTimeSeconds: 10
+    region: us-west-1
+    tags:
+      Environment: production
+  writeConnectionSecretToRef:
+    name: "upbound-sqs-with-policy"
+    namespace: "upbound-system"


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes
We've observed update loops with the Queue.sqs resources when inline policies are given. 
The desired policy document in the `spec` can differ from the actual (observed) document

like:

```
{
	"Statement":[
		{
			"Sid":"example",
			"Effect":"Allow",
			"Principal":{
				"Service":"s3.amazonaws.com"
			},
			"Action":"sqs:SendMessage",
			"Resource":"arn:aws:sqs:us-west-1:*:queue-policy"
		}
	]
}
```

```
{
	"Statement":[
		{
			"Action":"sqs:SendMessage",
			"Effect":"Allow",
			"Principal":{
				"Service":"s3.amazonaws.com"
			},
			"Resource":"arn:aws:sqs:us-west-1:*:queue-policy",
			"Sid":"example"
		}
	],
	"Version":"2008-10-17"
}
```

so i used the custom diff which we implemented here also: https://github.com/crossplane-contrib/provider-upjet-aws/pull/1347

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
