### PR TITLE
Remove monolithic provider from updoc workflow

### DIFF
--- a/.github/workflows/updoc.yml
+++ b/.github/workflows/updoc.yml
@@ -11,7 +11,7 @@ jobs:
   publish-docs:
     uses: upbound/official-providers-ci/.github/workflows/provider-updoc.yml@standard-runners
     with:
-      providers: "monolith config"
+      providers: "config"
       go-version: 1.22
     secrets:
       UPBOUND_CI_PROD_BUCKET_SA: ${{ secrets.UPBOUND_CI_PROD_BUCKET_SA }}


### PR DESCRIPTION
### Description of your changes

This PR removes monolithic provider from updoc workflow.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- ~[ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.~



[contribution process]: https://git.io/fj2m9
