### PR TITLE
lateinit version due to nodegroup conflict

### DIFF
--- a/apis/eks/v1beta2/zz_nodegroup_terraformed.go
+++ b/apis/eks/v1beta2/zz_nodegroup_terraformed.go
@@ -119,6 +119,7 @@ func (tr *NodeGroup) LateInitialize(attrs []byte) (bool, error) {
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
 	opts = append(opts, resource.WithNameFilter("ReleaseVersion"))
+	opts = append(opts, resource.WithNameFilter("Version"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/eks/config.go
+++ b/config/eks/config.go
@@ -53,6 +53,7 @@ func Configure(p *config.Provider) {
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{
 				"release_version",
+				"version",
 			},
 		}
 		r.UseAsync = true

--- a/examples/eks/v1beta2/cluster.yaml
+++ b/examples/eks/v1beta2/cluster.yaml
@@ -86,7 +86,7 @@ metadata:
   name: sample-subnet2
 spec:
   forProvider:
-    availabilityZone: us-west-1a
+    availabilityZone: us-west-1c
     cidrBlock: 172.16.11.0/24
     mapPublicIpOnLaunch: true
     region: us-west-1


### PR DESCRIPTION
### Description of your changes

This is a followup to PR https://github.com/crossplane-contrib/provider-upjet-aws/pull/977, and adds the version field. 

I've also changed one of the test subnets to AZ us-west-1c, as some accounts don't get access to 1a

```shell
aws ec2 describe-availability-zones --region us-west-1 
{
    "AvailabilityZones": [
        {
            "State": "available",
            "OptInStatus": "opt-in-not-required",
            "Messages": [],
            "RegionName": "us-west-1",
            "ZoneName": "us-west-1b",
            "ZoneId": "usw1-az3",
            "GroupName": "us-west-1",
            "NetworkBorderGroup": "us-west-1",
            "ZoneType": "availability-zone"
        },
        {
            "State": "available",
            "OptInStatus": "opt-in-not-required",
            "Messages": [],
            "RegionName": "us-west-1",
            "ZoneName": "us-west-1c",
            "ZoneId": "usw1-az1",
            "GroupName": "us-west-1",
            "NetworkBorderGroup": "us-west-1",
            "ZoneType": "availability-zone"
        }
    ]
}
```



- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Uptest run <https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/9642201880/job/26589493440> on v1beta2 Cluster & NodeGroup