### PR TITLE
fix(ec2): launchtemplate late init remove for defaultVersion 

### DIFF
--- a/apis/ec2/v1beta2/zz_launchtemplate_terraformed.go
+++ b/apis/ec2/v1beta2/zz_launchtemplate_terraformed.go
@@ -118,6 +118,7 @@ func (tr *LaunchTemplate) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("DefaultVersion"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -142,6 +142,10 @@ func Configure(p *config.Provider) {
 		r.References["network_interfaces.subnet_id"] = config.Reference{
 			TerraformName: "aws_subnet",
 		}
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"default_version"},
+		}
+
 	})
 
 	p.AddResourceConfigurator("aws_vpc_endpoint", func(r *config.Resource) {

--- a/examples/ec2/v1beta1/launchtemplate.yaml
+++ b/examples/ec2/v1beta1/launchtemplate.yaml
@@ -22,10 +22,6 @@ spec:
     - cpuCredits: standard
     disableApiTermination: true
     ebsOptimized: "true"
-    elasticGpuSpecifications:
-    - type: test
-    elasticInferenceAccelerator:
-    - type: eia1.medium
     instanceInitiatedShutdownBehavior: terminate
     instanceMarketOptions:
     - marketType: spot
@@ -43,6 +39,7 @@ spec:
     - associatePublicIpAddress: "true"
     placement:
     - availabilityZone: us-west-2a
+    updateDefaultVersion: true
     tagSpecifications:
     - resourceType: instance
       tags:


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes
fix update loop issue in ec2 launchtemplate when using `spec.forProvider.updateDefaultVersion: true` we need to skip late init for defaultVersion otherwise the manifest looks like:

```
apiVersion: ec2.aws.upbound.io/v1beta1
kind: LaunchTemplate
[...]
spec:
  deletionPolicy: Delete
  forProvider:
[...]
    defaultVersion: 1
[...]
    updateDefaultVersion: true
[...]
status:
  atProvider:
[...]
    defaultVersion: 7
[...]
    latestVersion: 7
[...]
  conditions:
    - lastTransitionTime: "2024-06-05T14:17:20Z"
      reason: Available
      status: "True"
      type: Ready
    - lastTransitionTime: "2024-06-05T17:59:25Z"
      reason: ReconcilePaused
      status: "False"
      type: Synced
    - lastTransitionTime: "2024-06-05T14:17:18Z"
      reason: Success
      status: "True"
      type: LastAsyncOperation
```

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Uptest run: https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/9667399561

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
