### PR TITLE
Use ARN as external name for aws_iam_role

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -555,7 +555,7 @@ var TerraformPluginSDKExternalNameConfigs = map[string]config.ExternalName{
 	"aws_iam_policy":      iamPolicy(),
 	"aws_iam_user":        config.NameAsIdentifier,
 	"aws_iam_group":       config.NameAsIdentifier,
-	"aws_iam_role":        config.NameAsIdentifier,
+	"aws_iam_role":        config.TemplatedStringAsIdentifier("", "{{ .parameters.path }}/{{ .external_name }}"),
 	"aws_iam_role_policy": config.TemplatedStringAsIdentifier("name", "{{ .parameters.role }}:{{ .external_name }}"),
 	// Imported using the role name and policy arn separated by /
 	// test-role/arn:aws:iam::xxxxxxxxxxxx:policy/test-policy


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

In this PR I'm changing the external name for `aws_iam_role` to use the role path and name instead of just the role name. Role names are not unique IDs and it is possible to have in the same AWS account multiple role with the same name but with different paths.

I see the [Terraform provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role#import) is also using the role name as ID please let me know if you have a better suggestion.

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1376 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Executed tests in the CI, it's not very clear to me how to test this locally, I'd appreciate an hint on that

[contribution process]: https://git.io/fj2m9
