### PR TITLE
fix(late-init): add late-init skips for v1beta1

### DIFF
--- a/apis/ec2/v1beta1/zz_launchtemplate_terraformed.go
+++ b/apis/ec2/v1beta1/zz_launchtemplate_terraformed.go
@@ -118,6 +118,7 @@ func (tr *LaunchTemplate) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("DefaultVersion"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/eks/v1beta1/zz_nodegroup_terraformed.go
+++ b/apis/eks/v1beta1/zz_nodegroup_terraformed.go
@@ -119,6 +119,7 @@ func (tr *NodeGroup) LateInitialize(attrs []byte) (bool, error) {
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
 	opts = append(opts, resource.WithNameFilter("ReleaseVersion"))
+	opts = append(opts, resource.WithNameFilter("Version"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes
followup for https://github.com/crossplane-contrib/provider-upjet-aws/pull/1374 and https://github.com/crossplane-contrib/provider-upjet-aws/pull/1377

@ulucinar in chat: `upjet currently does not generate the older versions, it generates only the latest version. We need to manually maintain the older versions.`

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1415

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Uptest: https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/10074958060

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
