### PR TITLE
Improve external-name config of iot thing type

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -1512,7 +1512,8 @@ var TerraformPluginSDKExternalNameConfigs = map[string]config.ExternalName{
 	// TODO: For now API is not normalized. While testing resource we can check the actual ID and normalize the API.
 	"aws_iot_thing_principal_attachment": config.IdentifierFromProvider,
 	// IOT Thing Types can be imported using the name
-	"aws_iot_thing_type": config.IdentifierFromProvider,
+	// NameAsIdentifier would be better, but that would be a breaking api change to remove spec.forProvider.name
+	"aws_iot_thing_type": FormattedIdentifierFromProvider("", "name"),
 	// IoT Topic Rules can be imported using the name
 	"aws_iot_topic_rule": config.NameAsIdentifier,
 	// IoT topic rule destinations can be imported using the arn

--- a/examples/iot/v1beta1/thingtype.yaml
+++ b/examples/iot/v1beta1/thingtype.yaml
@@ -7,10 +7,11 @@ kind: ThingType
 metadata:
   annotations:
     meta.upbound.io/example-id: iot/v1beta1/thingtype
+    uptest.upbound.io/update-parameter: '{"deprecated":true}'
   labels:
-    testing.upbound.io/example-name: example
+    testing.upbound.io/example-name: lightbulb
   name: lightbulb
 spec:
   forProvider:
     name: "my_iot_thing"
-    region: us-west-1
+    region: us-east-2

--- a/examples/iot/v1beta2/thingtype.yaml
+++ b/examples/iot/v1beta2/thingtype.yaml
@@ -7,10 +7,11 @@ kind: ThingType
 metadata:
   annotations:
     meta.upbound.io/example-id: iot/v1beta2/thingtype
+    uptest.upbound.io/update-parameter: '{"deprecated":true}'
   labels:
-    testing.upbound.io/example-name: example
-  name: lightbulb
+    testing.upbound.io/example-name: toaster
+  name: toaster
 spec:
   forProvider:
-    name: my_iot_thing
-    region: us-west-1
+    name: bread_heater
+    region: us-east-2


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

The aws iot ThingType resource uses a parameter called "name" as its terraform id. Unfortunately, when it was first implemented, it was done using IdentifierFromProvider, which means that creating a new managed resource always attempts to create a new external resource, even if there already is one with the same name. For this particular resource, this results in errors from the AWS api. 

The best external name config would be `config.NameAsIdentifier`, which would remove the redundant `name` property from both `spec.forProvider` and `spec.initProvider`, and initialize the name from `metadata.name`. But that's a breaking api change.

The next best external name config would be `config.TemplatedStringAsIdentifier("", "{{ .parameters.name }}")`, but that will (correctly) set `name` as an identifier field, which will remove it from `spec.initProvider`, which is also a breaking change. 

So this is the best I can do at the moment without changing the schema. The content of the external name remains the same, but now crossplane knows how to construct it from the `spec`, so it can check for resource existence before trying to create it. 

Because `name` is part of the id, but not set as an identifier field, various edge cases where the user omits it may continue to fail in less-than-ideal ways, but that's not a change from current behavior.


<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Running uptest on the pr.

Manually confirming that the external name is the in the same format both before and after this change.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
