### PR TITLE
feat(pod-identity): add option for pod-identity

### DIFF
--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -226,7 +226,7 @@ type Tag struct {
 // ProviderCredentials required to authenticate.
 type ProviderCredentials struct {
 	// Source of the provider credentials.
-	// +kubebuilder:validation:Enum=None;Secret;IRSA;WebIdentity;Upbound
+	// +kubebuilder:validation:Enum=None;Secret;IRSA;WebIdentity;PodIdentity;Upbound
 	Source xpv1.CredentialsSource `json:"source"`
 
 	// WebIdentity defines the options for assuming an IAM role with a Web Identity.

--- a/examples/providerconfig/v1beta1/pod-identity-providerconfig.yaml
+++ b/examples/providerconfig/v1beta1/pod-identity-providerconfig.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: pod-identity
+spec:
+  credentials:
+    source: PodIdentity

--- a/internal/clients/provider_config.go
+++ b/internal/clients/provider_config.go
@@ -40,6 +40,7 @@ const (
 	// authentication types
 	authKeyIRSA        = "IRSA"
 	authKeyWebIdentity = "WebIdentity"
+	authKeyPodIdentity = "PodIdentity"
 	authKeyUpbound     = "Upbound"
 	// authKeySAML        = "SAML"
 
@@ -49,6 +50,7 @@ const (
 	errAWSConfig            = "failed to get AWS config"
 	errAWSConfigIRSA        = "failed to get AWS config using IAM Roles for Service Accounts"
 	errAWSConfigWebIdentity = "failed to get AWS config using web identity token"
+	errAWSConfigPodIdentity = "failed to get AWS config using pod identity"
 	errAWSConfigUpbound     = "failed to get AWS config using Upbound identity"
 
 	upboundProviderIdentityTokenFile = "/var/run/secrets/upbound.io/provider/token"
@@ -100,6 +102,11 @@ func GetAWSConfigWithoutTracking(ctx context.Context, c client.Client, obj runti
 		cfg, err = UseDefault(ctx, region)
 		if err != nil {
 			return nil, errors.Wrap(err, errAWSConfigIRSA)
+		}
+	case authKeyPodIdentity:
+		cfg, err = UseDefault(ctx, region)
+		if err != nil {
+			return nil, errors.Wrap(err, errAWSConfigPodIdentity)
 		}
 	case authKeyWebIdentity:
 		cfg, err = UseWebIdentityToken(ctx, region, &pc.Spec, c)

--- a/package/crds/aws.upbound.io_providerconfigs.yaml
+++ b/package/crds/aws.upbound.io_providerconfigs.yaml
@@ -153,6 +153,7 @@ spec:
                     - Secret
                     - IRSA
                     - WebIdentity
+                    - PodIdentity
                     - Upbound
                     type: string
                   upbound:


### PR DESCRIPTION
<!--
Thank you for helping to improve Official AWS Provider!

Please read through https://git.io/fj2m9 if this is your first time opening a
Official AWS Provider pull request. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes
- add new `spec.credentials.source` PodIdentity
- implemented a test environment based on: https://github.com/upbound/configuration-aws-eks here: https://github.com/haarchri/configuration-aws-eks-uxp-podidentity which added a UXP Release, Provider IAM Role, Pod Identity and a DeploymentRuntimeConfig https://github.com/haarchri/configuration-aws-eks-uxp-podidentity/blob/main/apis/pat/composition.yaml#L430-L526

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open Official AWS Provider issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #1249 #1254 #1308 #1252

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested
spin up a Network + EKS Cluster:
```
kubectl apply -f examples/pat/network-xr.yaml
kubectl apply -f examples/pat/eks-xr.yaml
```

connect to your EKS Cluster:
```
aws sso login --profile login
aws eks update-kubeconfig --region us-west-2 --name  configuration-aws-eks-v2lbr --profile AdministratorAccess-12345678910
```

apply the following resources:
```
kubectl apply -f examples/provider.yaml
kubectl apply -f examples/providerconfig.yaml
kubectl apply -f examples/vpc.yaml
```

```
kubectl get providerconfig.aws -o yaml
apiVersion: v1
items:
- apiVersion: aws.upbound.io/v1beta1
  kind: ProviderConfig
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"aws.upbound.io/v1beta1","kind":"ProviderConfig","metadata":{"annotations":{},"name":"default"},"spec":{"credentials":{"source":"PodIdentity"}}}
    creationTimestamp: "2024-08-13T15:07:56Z"
    finalizers:
    - in-use.crossplane.io
    generation: 1
    name: default
    resourceVersion: "11161"
    uid: e6eb0224-8300-4568-b617-68aa6ee35b82
  spec:
    credentials:
      source: PodIdentity
  status:
    users: 1
kind: List
metadata:
  resourceVersion: ""
```

```
kubectl get vpc -o yaml
apiVersion: v1
items:
- apiVersion: ec2.aws.upbound.io/v1beta1
  kind: VPC
  metadata:
    annotations:
      crossplane.io/external-create-pending: "2024-08-13T15:07:58Z"
      crossplane.io/external-create-succeeded: "2024-08-13T15:07:58Z"
      crossplane.io/external-name: vpc-0e424d8d4ab0015db
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"ec2.aws.upbound.io/v1beta1","kind":"VPC","metadata":{"annotations":{},"name":"vpc"},"spec":{"forProvider":{"cidrBlock":"10.1.0.0/16","region":"eu-west-1"}}}
    creationTimestamp: "2024-08-13T15:07:56Z"
    finalizers:
    - finalizer.managedresource.crossplane.io
    generation: 3
    name: vpc
    resourceVersion: "11202"
    uid: 08785497-5747-481a-b81d-9af709abf679
  spec:
    deletionPolicy: Delete
    forProvider:
      cidrBlock: 10.1.0.0/16
      enableDnsSupport: true
      instanceTenancy: default
      region: eu-west-1
      tags:
        crossplane-kind: vpc.ec2.aws.upbound.io
        crossplane-name: vpc
        crossplane-providerconfig: default
    initProvider: {}
    managementPolicies:
    - '*'
    providerConfigRef:
      name: default
  status:
    atProvider:
      arn: arn:aws:ec2:eu-west-1:123456789101:vpc/vpc-0e424d8d4ab0015db
      assignGeneratedIpv6CidrBlock: false
      cidrBlock: 10.1.0.0/16
      defaultNetworkAclId: acl-0b90aeb9eae7d1855
      defaultRouteTableId: rtb-0166e1e7e0903e59a
      defaultSecurityGroupId: sg-0408394cac0e658b6
      dhcpOptionsId: dopt-77034211
      enableDnsHostnames: false
      enableDnsSupport: true
      enableNetworkAddressUsageMetrics: false
      id: vpc-0e424d8d4ab0015db
      instanceTenancy: default
      ipv6AssociationId: ""
      ipv6CidrBlock: ""
      ipv6CidrBlockNetworkBorderGroup: ""
      ipv6IpamPoolId: ""
      ipv6NetmaskLength: 0
      mainRouteTableId: rtb-0166e1e7e0903e59a
      ownerId: "123456789101"
      tags:
        crossplane-kind: vpc.ec2.aws.upbound.io
        crossplane-name: vpc
        crossplane-providerconfig: default
      tagsAll:
        crossplane-kind: vpc.ec2.aws.upbound.io
        crossplane-name: vpc
        crossplane-providerconfig: default
    conditions:
    - lastTransitionTime: "2024-08-13T15:07:58Z"
      reason: ReconcileSuccess
      status: "True"
      type: Synced
    - lastTransitionTime: "2024-08-13T15:08:04Z"
      reason: Available
      status: "True"
      type: Ready
    - lastTransitionTime: "2024-08-13T15:08:00Z"
      reason: Success
      status: "True"
      type: LastAsyncOperation
kind: List
metadata:
  resourceVersion: ""
```

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
