### PR TITLE
Ignore late initialize for scaling_config in NodeGroup resource

### DIFF
--- a/apis/eks/v1beta1/zz_nodegroup_terraformed.go
+++ b/apis/eks/v1beta1/zz_nodegroup_terraformed.go
@@ -119,8 +119,12 @@ func (tr *NodeGroup) LateInitialize(attrs []byte) (bool, error) {
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
 	opts = append(opts, resource.WithNameFilter("ReleaseVersion"))
-	opts = append(opts, resource.WithNameFilter("ScalingConfig"))
 	opts = append(opts, resource.WithNameFilter("Version"))
+	initParams, err := tr.GetInitParameters()
+	if err != nil {
+		return false, errors.Wrapf(err, "cannot get init parameters for resource '%q'", tr.GetName())
+	}
+	opts = append(opts, resource.WithConditionalFilter("ScalingConfig", initParams))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/eks/v1beta1/zz_nodegroup_terraformed.go
+++ b/apis/eks/v1beta1/zz_nodegroup_terraformed.go
@@ -119,6 +119,7 @@ func (tr *NodeGroup) LateInitialize(attrs []byte) (bool, error) {
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
 	opts = append(opts, resource.WithNameFilter("ReleaseVersion"))
+	opts = append(opts, resource.WithNameFilter("ScalingConfig"))
 	opts = append(opts, resource.WithNameFilter("Version"))
 
 	li := resource.NewGenericLateInitializer(opts...)

--- a/apis/eks/v1beta2/zz_nodegroup_terraformed.go
+++ b/apis/eks/v1beta2/zz_nodegroup_terraformed.go
@@ -119,8 +119,12 @@ func (tr *NodeGroup) LateInitialize(attrs []byte) (bool, error) {
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
 	opts = append(opts, resource.WithNameFilter("ReleaseVersion"))
-	opts = append(opts, resource.WithNameFilter("ScalingConfig"))
 	opts = append(opts, resource.WithNameFilter("Version"))
+	initParams, err := tr.GetInitParameters()
+	if err != nil {
+		return false, errors.Wrapf(err, "cannot get init parameters for resource '%q'", tr.GetName())
+	}
+	opts = append(opts, resource.WithConditionalFilter("ScalingConfig", initParams))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/eks/v1beta2/zz_nodegroup_terraformed.go
+++ b/apis/eks/v1beta2/zz_nodegroup_terraformed.go
@@ -119,6 +119,7 @@ func (tr *NodeGroup) LateInitialize(attrs []byte) (bool, error) {
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
 	opts = append(opts, resource.WithNameFilter("ReleaseVersion"))
+	opts = append(opts, resource.WithNameFilter("ScalingConfig"))
 	opts = append(opts, resource.WithNameFilter("Version"))
 
 	li := resource.NewGenericLateInitializer(opts...)

--- a/config/eks/config.go
+++ b/config/eks/config.go
@@ -54,6 +54,8 @@ func Configure(p *config.Provider) {
 			IgnoredFields: []string{
 				"release_version",
 				"version",
+			},
+			ConditionalIgnoredFields: []string{
 				"scaling_config",
 			},
 		}

--- a/config/eks/config.go
+++ b/config/eks/config.go
@@ -54,6 +54,7 @@ func Configure(p *config.Provider) {
 			IgnoredFields: []string{
 				"release_version",
 				"version",
+				"scaling_config",
 			},
 		}
 		r.UseAsync = true


### PR DESCRIPTION
### Description of your changes

Ignores late initialize for `scaling_config` field in `NodeGroup.eks` resource.

Fixes https://github.com/crossplane-contrib/provider-upjet-aws/issues/1469

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

Manually tested with `index.docker.io/turkenf/provider-aws:v1.13.0-rc.0.1.gf7fd1d8ba`

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
