### PR TITLE
Add cleanupexamples tool to subpackages build process

### DIFF
--- a/cluster/images/provider-aws/Makefile
+++ b/cluster/images/provider-aws/Makefile
@@ -56,7 +56,10 @@ ifeq (-,$(findstring -,$(VERSION)))
 endif
 BUILD_ONLY ?= false
 STORE_PACKAGES ?= ""
+XPKG_CLEANUP_EXAMPLES_VERSION ?= v0.12.1
 batch-process: $(UP)
+	@rm -rf $(WORK_DIR)/xpkg-cleaned-examples
+	@GOOS=$(HOSTOS) GOARCH=$(TARGETARCH) go run github.com/upbound/uptest/cmd/cleanupexamples@$(XPKG_CLEANUP_EXAMPLES_VERSION) $(ROOT_DIR)/examples $(WORK_DIR)/xpkg-cleaned-examples || $(FAIL)
 	@$(INFO) Batch processing smaller provider packages for: "$(SUBPACKAGES)"
 	@mkdir -p "$(XPKG_OUTPUT_DIR)/$(PLATFORM)" && \
 	$(UP) xpkg batch --smaller-providers "$$(tr ' ' ',' <<< "$(SUBPACKAGES)")" \
@@ -69,7 +72,7 @@ batch-process: $(UP)
 		--output-dir $(XPKG_OUTPUT_DIR) \
 		--store-packages "$(STORE_PACKAGES)" \
 		--build-only=$(BUILD_ONLY) \
-		--examples-root $(ROOT_DIR)/examples \
+		--examples-root $(WORK_DIR)/xpkg-cleaned-examples \
 		--examples-group-override monolith=* --examples-group-override config=providerconfig \
 		--auth-ext $(XPKG_DIR)/auth.yaml \
 		--crd-root $(XPKG_DIR)/crds \
@@ -80,3 +83,4 @@ batch-process: $(UP)
 		--concurrency $(CONCURRENCY) \
 		--push-retry 10 || $(FAIL)
 	@$(OK) Done processing smaller provider packages for: "$(SUBPACKAGES)"
+	@rm -rf $(WORK_DIR)/xpkg-cleaned-examples


### PR DESCRIPTION
### Description of your changes

Adds `cleanupexamples` tool to subpackages build process

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually tested with `make build.all publish BRANCH_NAME=main` command in local provider-upjet-aws.
Created and controlled image `index.docker.io/turkenf/provider-aws:v1.14.0-rc.0.11.gda1945136`


[contribution process]: https://git.io/fj2m9
