### PR TITLE
`nolint:gocyclo` resource configurations

### DIFF
--- a/config/acm/config.go
+++ b/config/acm/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the acm group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_acm_certificate_validation", func(r *config.Resource) {
 		r.References = map[string]config.Reference{
 			"certificate_arn": {

--- a/config/acmpca/config.go
+++ b/config/acmpca/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the acmpca group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_acmpca_certificate_authority", func(r *config.Resource) {
 		// NOTE(muvaf): It causes circular dependency. See https://github.com/crossplane/crossplane-runtime/issues/313
 		delete(r.References, "revocation_configuration.crl_configuration.s3_bucket_name")

--- a/config/apigateway/config.go
+++ b/config/apigateway/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the apigateway group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_api_gateway_rest_api", func(r *config.Resource) {
 		config.MoveToStatus(r.TerraformResource, "policy")
 	})

--- a/config/apigatewayv2/config.go
+++ b/config/apigatewayv2/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the apigatewayv2 group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_apigatewayv2_api_mapping", func(r *config.Resource) {
 		r.References["api_id"] = config.Reference{
 			TerraformName: "aws_apigatewayv2_api",

--- a/config/apprunner/config.go
+++ b/config/apprunner/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the apprunner group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_apprunner_vpc_connector", func(r *config.Resource) {
 		r.References["subnets"] = config.Reference{
 			TerraformName:     "aws_subnet",

--- a/config/appstream/config.go
+++ b/config/appstream/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the appstream group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_appstream_fleet", func(r *config.Resource) {
 		r.References["vpc_config.subnet_ids"] = config.Reference{
 			TerraformName:     "aws_subnet",

--- a/config/athena/config.go
+++ b/config/athena/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the athena group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_athena_workgroup", func(r *config.Resource) {
 		r.References["configuration.result_configuration.encryption_configuration.kms_key_arn"] = config.Reference{
 			TerraformName: "aws_kms_key",

--- a/config/autoscaling/config.go
+++ b/config/autoscaling/config.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Configure adds configurations for the autoscaling group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_autoscaling_group", func(r *config.Resource) {
 		// These are mutually exclusive with aws_autoscaling_attachment.
 		config.MoveToStatus(r.TerraformResource, "load_balancers", "target_group_arns")

--- a/config/backup/config.go
+++ b/config/backup/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the backup group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_backup_vault", func(r *config.Resource) {
 		r.References["kms_key_arn"] = config.Reference{
 			TerraformName: "aws_kms_key",

--- a/config/bedrockagent/config.go
+++ b/config/bedrockagent/config.go
@@ -10,7 +10,7 @@ import (
 	"github.com/upbound/provider-aws/config/common"
 )
 
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_bedrockagent_agent", func(r *config.Resource) {
 		r.References["customer_encryption_key_arn"] = config.Reference{
 			TerraformName: "aws_kms_key",

--- a/config/budgets/config.go
+++ b/config/budgets/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the budgets group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_budgets_budget_action", func(r *config.Resource) {
 		r.References["definition.iam_action_definition.aws_iam_role.example.name"] = config.Reference{
 			TerraformName: "aws_iam_role",

--- a/config/cloudformation/config.go
+++ b/config/cloudformation/config.go
@@ -7,7 +7,7 @@ package cloudformation
 import "github.com/crossplane/upjet/pkg/config"
 
 // Configure adds configurations for the cloudformation group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_cloudformation_stack_set_instance", func(r *config.Resource) {
 		r.TerraformConfigurationInjector = func(jsonMap map[string]any, params map[string]any) error {
 			params["region"] = jsonMap["region"]

--- a/config/cloudfront/config.go
+++ b/config/cloudfront/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the cloudfront group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_cloudfront_distribution", func(r *config.Resource) {
 		r.UseAsync = true
 		delete(r.References, "origin.domain_name")

--- a/config/cloudsearch/config.go
+++ b/config/cloudsearch/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the cloudsearch group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_cloudsearch_domain", func(r *config.Resource) {
 		r.UseAsync = true
 	})

--- a/config/cloudwatch/config.go
+++ b/config/cloudwatch/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the cloudwatch group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_cloudwatch_metric_stream", func(r *config.Resource) {
 		config.MarkAsRequired(r.TerraformResource, "name")
 		r.LateInitializer = config.LateInitializer{

--- a/config/cloudwatchevents/config.go
+++ b/config/cloudwatchevents/config.go
@@ -23,7 +23,7 @@ import (
 )
 
 // Configure adds configurations for the cloudwatchevents group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_cloudwatch_event_permission", func(r *config.Resource) {
 		r.References["event_bus_name"] = config.Reference{
 			TerraformName: "aws_cloudwatch_event_bus",

--- a/config/cloudwatchlogs/config.go
+++ b/config/cloudwatchlogs/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the cloudwatchlogs group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_cloudwatch_log_destination", func(r *config.Resource) {
 		// the target_arn field is generated together with the associated
 		// referencer fields but the auto-generated extractor refers to

--- a/config/codeartifact/config.go
+++ b/config/codeartifact/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the codeartifact group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_codeartifact_domain", func(r *config.Resource) {
 		r.References["encryption_key"] = config.Reference{
 			TerraformName: "aws_kms_key",

--- a/config/cognitoidentity/config.go
+++ b/config/cognitoidentity/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the cognitoidentity group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_cognito_identity_pool", func(r *config.Resource) {
 		r.References["saml_provider_arns"] = config.Reference{
 			TerraformName: "aws_iam_saml_provider",

--- a/config/cognitoidp/config.go
+++ b/config/cognitoidp/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the cognitoidp group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_cognito_user_pool_client", func(r *config.Resource) {
 		r.References["user_pool_id"] = config.Reference{
 			TerraformName: "aws_cognito_user_pool",

--- a/config/cur/config.go
+++ b/config/cur/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the cur group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_cur_report_definition", func(r *config.Resource) {
 		r.References["s3_bucket"] = config.Reference{
 			TerraformName: "aws_s3_bucket",

--- a/config/datasync/config.go
+++ b/config/datasync/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the datasync group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_datasync_task", func(r *config.Resource) {
 		r.References["destination_location_arn"] = config.Reference{
 			TerraformName: "aws_datasync_location_s3",

--- a/config/dax/config.go
+++ b/config/dax/config.go
@@ -7,7 +7,7 @@ package dax
 import "github.com/crossplane/upjet/pkg/config"
 
 // Configure adds configurations for the dax group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_dax_cluster", func(r *config.Resource) {
 		r.UseAsync = true
 	})

--- a/config/devicefarm/config.go
+++ b/config/devicefarm/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the devicefarm group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_devicefarm_test_grid_project", func(r *config.Resource) {
 		r.References["vpc_config.subnet_ids"] = config.Reference{
 			TerraformName:     "aws_subnet",

--- a/config/directconnect/config.go
+++ b/config/directconnect/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the directconnect group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_dx_public_virtual_interface", func(r *config.Resource) {
 		r.References["connection_id"] = config.Reference{
 			TerraformName: "aws_dx_connection",

--- a/config/dms/config.go
+++ b/config/dms/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Configure adds configurations for the dms group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_dms_endpoint", func(r *config.Resource) {
 		r.References = config.References{
 			"secrets_manager_access_role_arn": {

--- a/config/docdb/config.go
+++ b/config/docdb/config.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Configure adds configurations for the docdb group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_docdb_cluster", func(r *config.Resource) {
 		config.MoveToStatus(r.TerraformResource, "cluster_members")
 		r.UseAsync = true

--- a/config/ds/config.go
+++ b/config/ds/config.go
@@ -7,7 +7,7 @@ package ds
 import "github.com/crossplane/upjet/pkg/config"
 
 // Configure adds configurations for the ds group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_directory_service_directory", func(r *config.Resource) {
 		r.References["vpc_settings.subnet_ids"] = config.Reference{
 			TerraformName: "aws_subnet",

--- a/config/dynamodb/config.go
+++ b/config/dynamodb/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the dynamodb group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	// currently needs an ARN reference for external name
 	p.AddResourceConfigurator("aws_dynamodb_contributor_insights", func(r *config.Resource) {
 		r.References["table_name"] = config.Reference{

--- a/config/ebs/config.go
+++ b/config/ebs/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the ebs group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_ebs_volume", func(r *config.Resource) {
 		r.References = map[string]config.Reference{
 			"kms_key_id": {

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Configure adds configurations for the ec2 group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_instance", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["subnet_id"] = config.Reference{

--- a/config/ecr/config.go
+++ b/config/ecr/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the ecr group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_ecr_repository", func(r *config.Resource) {
 		r.References = map[string]config.Reference{
 			"encryption_configuration.kms_key": {

--- a/config/ecrpublic/config.go
+++ b/config/ecrpublic/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the ecrpublic group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_ecrpublic_repository", func(r *config.Resource) {
 		// Deletion takes a while.
 		r.UseAsync = true

--- a/config/ecs/config.go
+++ b/config/ecs/config.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Configure adds configurations for the ecs group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_ecs_cluster", func(r *config.Resource) {
 		r.ExternalName.GetExternalNameFn = func(tfstate map[string]interface{}) (string, error) {
 			// expected id format: arn:aws:ecs:us-west-2:123456789123:cluster/example-cluster

--- a/config/efs/config.go
+++ b/config/efs/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the efs group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_efs_mount_target", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["file_system_id"] = config.Reference{

--- a/config/eks/config.go
+++ b/config/eks/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the eks group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_eks_cluster", func(r *config.Resource) {
 		r.References = config.References{
 			"role_arn": {

--- a/config/elb/config.go
+++ b/config/elb/config.go
@@ -7,7 +7,7 @@ package elb
 import "github.com/crossplane/upjet/pkg/config"
 
 // Configure adds configurations for the elb group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_elb", func(r *config.Resource) {
 		r.References["instances"] = config.Reference{
 			TerraformName: "aws_instance",

--- a/config/elbv2/config.go
+++ b/config/elbv2/config.go
@@ -7,7 +7,7 @@ package elbv2
 import "github.com/crossplane/upjet/pkg/config"
 
 // Configure adds configurations for the elbv2 group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_lb", func(r *config.Resource) {
 		r.ExternalName.OmittedFields = append(r.ExternalName.OmittedFields, "name_prefix")
 		r.References = config.References{

--- a/config/firehose/config.go
+++ b/config/firehose/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Configure adds configurations for the firehose group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_kinesis_firehose_delivery_stream", func(r *config.Resource) {
 		r.TerraformResource.Schema["splunk_configuration"].Elem.(*schema.Resource).Schema["hec_token"].Sensitive = true
 

--- a/config/fsx/config.go
+++ b/config/fsx/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the fsx group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_fsx_windows_file_system", func(r *config.Resource) {
 		r.References["kms_key_id"] = config.Reference{
 			TerraformName: "aws_kms_key",

--- a/config/gamelift/config.go
+++ b/config/gamelift/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the gamelift group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_gamelift_build", func(r *config.Resource) {
 		r.References["storage_location.role_arn"] = config.Reference{
 			TerraformName: "aws_iam_role",

--- a/config/globalaccelerator/config.go
+++ b/config/globalaccelerator/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the globalaccelerator group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_globalaccelerator_endpoint_group", func(r *config.Resource) {
 		r.References = config.References{
 			"listener_arn": {

--- a/config/glue/config.go
+++ b/config/glue/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Configure adds configurations for the glue group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_glue_catalog_database", func(r *config.Resource) {
 		// Required in ID but optional in schema since TF defaults to Account ID.
 		// This causes refresh to fail in the first reconcile.

--- a/config/grafana/config.go
+++ b/config/grafana/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the grafana group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_grafana_workspace", func(r *config.Resource) {
 		r.References["role_arn"] = config.Reference{
 			TerraformName: "aws_iam_role",

--- a/config/iam/config.go
+++ b/config/iam/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the iam group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_iam_access_key", func(r *config.Resource) {
 		r.References["user"] = config.Reference{
 			TerraformName: "aws_iam_user",

--- a/config/identitystore/config.go
+++ b/config/identitystore/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the identitystore group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_identitystore_group", func(r *config.Resource) {
 		// Display name is required by terraform, and while it's not part of the external name or terraform id, it is
 		// how the group is displayed, and it's immutable.

--- a/config/iot/config.go
+++ b/config/iot/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the iot group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_iot_topic_rule_destination", func(r *config.Resource) {
 		r.References["vpc_configuration.security_groups"] = config.Reference{
 			TerraformName:     "aws_security_group",

--- a/config/kafkaconnect/config.go
+++ b/config/kafkaconnect/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the kafkaconnect group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_mskconnect_connector", func(r *config.Resource) {
 		// This will always refer to a Cluster in the kafka api group, if it refers to any managed resource at all,
 		// but which property from the status of that cluster to use depends on the authentication mechanism chosen.

--- a/config/kendra/config.go
+++ b/config/kendra/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the kendra group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_kendra_thesaurus", func(r *config.Resource) {
 		r.Path = "thesaurus"
 	})

--- a/config/kinesis/config.go
+++ b/config/kinesis/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the kinesis group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_kinesis_stream_consumer", func(r *config.Resource) {
 		r.References["stream_arn"] = config.Reference{
 			TerraformName: "aws_kinesis_stream",

--- a/config/kinesisanalytics/config.go
+++ b/config/kinesisanalytics/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the kinesisanalytics group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_kinesis_analytics_application", func(r *config.Resource) {
 		r.References["inputs.kinesis_stream.resource_arn"] = config.Reference{
 			TerraformName: "aws_kinesis_stream",

--- a/config/kinesisanalyticsv2/config.go
+++ b/config/kinesisanalyticsv2/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the kinesisanalytics2 group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_kinesisanalyticsv2_application", func(r *config.Resource) {
 		r.References["application_configuration.application_code_configuration.code_content.s3_content_location.bucket_arn"] = config.Reference{
 			TerraformName: "aws_s3_bucket",

--- a/config/kms/config.go
+++ b/config/kms/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the kms group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_kms_alias", func(r *config.Resource) {
 		r.References["target_key_id"] = config.Reference{
 			TerraformName: "aws_kms_key",

--- a/config/lakeformation/config.go
+++ b/config/lakeformation/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the lakeformation group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_lakeformation_data_lake_settings", func(r *config.Resource) {
 		delete(r.References, "create_database_default_permissions.principal")
 		delete(r.References, "create_table_default_permissions.principal")

--- a/config/lambda/config.go
+++ b/config/lambda/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the lambda group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_lambda_alias", func(r *config.Resource) {
 		r.References["function_name"] = config.Reference{
 			TerraformName: "aws_lambda_function",

--- a/config/licensemanager/config.go
+++ b/config/licensemanager/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the licensemanager group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_licensemanager_association", func(r *config.Resource) {
 		r.References["license_configuration_arn"] = config.Reference{
 			TerraformName: "aws_licensemanager_license_configuration",

--- a/config/medialive/config.go
+++ b/config/medialive/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the medialive group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_medialive_multiplex", func(r *config.Resource) {
 		r.Path = "multiplices"
 	})

--- a/config/memorydb/config.go
+++ b/config/memorydb/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the memorydb group.
-func Configure(p *config.Provider) { // nolint:gocyclo
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_memorydb_cluster", func(r *config.Resource) {
 		r.UseAsync = true
 

--- a/config/mq/config.go
+++ b/config/mq/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Configure adds configurations for the mq group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_mq_broker", func(r *config.Resource) {
 		r.References["security_groups"] = config.Reference{
 			TerraformName:     "aws_security_group",

--- a/config/mwaa/config.go
+++ b/config/mwaa/config.go
@@ -8,7 +8,7 @@ import (
 	"github.com/crossplane/upjet/pkg/config"
 )
 
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_mwaa_environment", func(r *config.Resource) {
 		r.References["network_configuration.subnet_ids"] = config.Reference{
 			TerraformName: "aws_subnet",

--- a/config/neptune/config.go
+++ b/config/neptune/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the neptune group
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_neptune_cluster", func(r *config.Resource) {
 		r.UseAsync = true
 		r.References["snapshot_identifier"] = config.Reference{

--- a/config/networkfirewall/config.go
+++ b/config/networkfirewall/config.go
@@ -17,7 +17,7 @@ import (
 )
 
 // Configure adds configurations for the networkfirewall group.
-func Configure(p *config.Provider) { // nolint:gocyclo
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_networkfirewall_firewall_policy", func(r *config.Resource) {
 		r.References = config.References{
 			"firewall_policy.stateless_rule_group_reference.resource_arn": {

--- a/config/networkmanager/config.go
+++ b/config/networkmanager/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the networkmanager group
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_networkmanager_link", func(r *config.Resource) {
 		r.References["site_id"] = config.Reference{
 			TerraformName: "aws_networkmanager_site",

--- a/config/opensearch/config.go
+++ b/config/opensearch/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Configure adds configurations for the opensearch group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_opensearch_domain", func(r *config.Resource) {
 		config.MoveToStatus(r.TerraformResource, "access_policies")
 		r.References["encrypt_at_rest.kms_key_id"] = config.Reference{

--- a/config/opensearchserverless/config.go
+++ b/config/opensearchserverless/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the opensearchserverless group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_opensearchserverless_security_config", func(r *config.Resource) {
 		r.RemoveSingletonListConversion("saml_options")
 		// set the path saml_options as an embedded object to honor

--- a/config/opsworks/config.go
+++ b/config/opsworks/config.go
@@ -7,7 +7,7 @@ package opsworks
 import "github.com/crossplane/upjet/pkg/config"
 
 // Configure adds configurations for the opsworks group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_opsworks_stack", func(r *config.Resource) {
 		r.References["default_subnet_id"] = config.Reference{
 			TerraformName: "aws_subnet",

--- a/config/organization/config.go
+++ b/config/organization/config.go
@@ -7,7 +7,7 @@ package organization
 import "github.com/crossplane/upjet/pkg/config"
 
 // Configure adds configurations for the organization group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	// please see: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/organizations_account
 	// If `role_name` is used, it's stated that Terraform will always
 	// show a difference. Thus, that argument is removed here.

--- a/config/osis/config.go
+++ b/config/osis/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the osis group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_osis_pipeline", func(r *config.Resource) {
 		r.References["vpc_options.security_group_ids"] = config.Reference{
 			TerraformName:     "aws_security_group",

--- a/config/qldb/config.go
+++ b/config/qldb/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the qldb group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_qldb_stream", func(r *config.Resource) {
 		r.References["kinesis_configuration.stream_arn"] = config.Reference{
 			TerraformName: "aws_kinesis_stream",

--- a/config/ram/config.go
+++ b/config/ram/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the ram group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_ram_resource_association", func(r *config.Resource) {
 		delete(r.References, "resource_arn")
 	})

--- a/config/redshift/config.go
+++ b/config/redshift/config.go
@@ -7,7 +7,7 @@ package redshift
 import "github.com/crossplane/upjet/pkg/config"
 
 // Configure adds configurations for the redshift group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_redshift_cluster", func(r *config.Resource) {
 		r.UseAsync = true
 	})

--- a/config/redshiftserverless/config.go
+++ b/config/redshiftserverless/config.go
@@ -7,7 +7,7 @@ package redshiftserverless
 import "github.com/crossplane/upjet/pkg/config"
 
 // Configure adds configurations for redshiftserverless group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_redshiftserverless_namespace", func(r *config.Resource) {
 		r.Kind = "RedshiftServerlessNamespace"
 		r.LateInitializer = config.LateInitializer{

--- a/config/rolesanywhere/config.go
+++ b/config/rolesanywhere/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the rolesanywhere group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_rolesanywhere_profile", func(r *config.Resource) {
 		r.References["role_arns"] = config.Reference{
 			TerraformName: "aws_iam_role",

--- a/config/route53/config.go
+++ b/config/route53/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the route53 group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_route53_traffic_policy_instance", func(r *config.Resource) {
 		r.References["hosted_zone_id"] = config.Reference{
 			TerraformName: "aws_route53_zone",

--- a/config/route53recoverycontrolconfig/config.go
+++ b/config/route53recoverycontrolconfig/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the route53recoverycontrolconfig group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_route53recoverycontrolconfig_control_panel", func(r *config.Resource) {
 		r.References["cluster_arn"] = config.Reference{
 			TerraformName: "aws_route53recoverycontrolconfig_cluster",

--- a/config/route53resolver/config.go
+++ b/config/route53resolver/config.go
@@ -16,7 +16,7 @@ import (
 )
 
 // Configure adds configurations for the route53resolver group.
-func Configure(p *config.Provider) { // nolint:gocyclo
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_route53_resolver_query_log_config", func(r *config.Resource) {
 		delete(r.References, "destination_arn")
 	})

--- a/config/s3/config.go
+++ b/config/s3/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Configure adds configurations for the s3 group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_s3_bucket", func(r *config.Resource) {
 		// Mutually exclusive with:
 		// aws_s3_bucket_accelerate_configuration

--- a/config/sagemaker/config.go
+++ b/config/sagemaker/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Configure adds configurations for the sagemaker group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_sagemaker_workforce", func(r *config.Resource) {
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"source_ip_config"},

--- a/config/servicecatalog/config.go
+++ b/config/servicecatalog/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the servicecatalog group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	// done for proper normalization as the defaulting is done by Terraform
 	// please refer to this resource's external-name configuration for details.
 	p.AddResourceConfigurator("aws_servicecatalog_principal_portfolio_association", func(r *config.Resource) {

--- a/config/servicediscovery/config.go
+++ b/config/servicediscovery/config.go
@@ -7,7 +7,7 @@ package servicediscovery
 import "github.com/crossplane/upjet/pkg/config"
 
 // Configure adds configurations for the servicediscovery group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_service_discovery_private_dns_namespace", func(r *config.Resource) {
 		r.References["vpc"] = config.Reference{
 			TerraformName: "aws_vpc",

--- a/config/sfn/config.go
+++ b/config/sfn/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the sfn group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_sfn_state_machine", func(r *config.Resource) {
 		r.References["role_arn"] = config.Reference{
 			TerraformName: "aws_iam_role",

--- a/config/sns/config.go
+++ b/config/sns/config.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Configure adds configurations for the sns group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_sns_topic_subscription", func(r *config.Resource) {
 		r.References["endpoint"] = config.Reference{
 			TerraformName: "aws_sqs_queue",

--- a/config/sqs/config.go
+++ b/config/sqs/config.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Configure adds configurations for the sqs group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_sqs_queue_policy", func(r *config.Resource) {
 		r.References["queue_url"] = config.Reference{
 			TerraformName: "aws_sqs_queue",

--- a/config/ssoadmin/config.go
+++ b/config/ssoadmin/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the ssoadmin group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_ssoadmin_account_assignment", func(r *config.Resource) {
 		r.References["principal_id"] = config.Reference{
 			TerraformName:     "aws_identitystore_group",

--- a/config/transfer/config.go
+++ b/config/transfer/config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Configure adds configurations for the transfer group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_transfer_user", func(r *config.Resource) {
 		r.References["server_id"] = config.Reference{
 			TerraformName: "aws_transfer_server",


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

* Add `//nolint:gocyclo` to resource configuration files, `config/*/config.go`, that didn't have it.
* In the ones that have it, but in the form `// nolint:gocyclo`, replace it with `//nolint:gocyclo`, which [seems to be the standard form](https://github.com/golangci/golangci-lint/issues/3201#issuecomment-1241945872) going forward.

`//nolint:gocyclo` has been our de facto solution to cyclomatic complexity errors in resource configuration files. Cyclomatic complexity doesn't really apply to resource configurations. Configurations contain limited business logic, if any, which is independent between resources, even if they are defined inside the same function.

Our linter takes a long time to complete. Discovering the cyclomatic complexity error after a standard resource configuration introduces unnecessary latency to our release process. Here is the latest example: https://github.com/crossplane-contrib/provider-upjet-aws/pull/1528

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~


### How has this code been tested

See the [result of the linter job](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/11406451902/job/31740248305?pr=1530).

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
