### PR TITLE
Add PathARNExtractor for kms_key_id to rds cluster

### DIFF
--- a/apis/rds/v1beta1/zz_cluster_types.go
+++ b/apis/rds/v1beta1/zz_cluster_types.go
@@ -145,6 +145,7 @@ type ClusterInitParameters struct {
 
 	// ARN for the KMS encryption key. When specifying kms_key_id, storage_encrypted needs to be set to true.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	KMSKeyID *string `json:"kmsKeyId,omitempty" tf:"kms_key_id,omitempty"`
 
 	// Reference to a Key in kms to populate kmsKeyId.
@@ -646,6 +647,7 @@ type ClusterParameters struct {
 
 	// ARN for the KMS encryption key. When specifying kms_key_id, storage_encrypted needs to be set to true.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	// +kubebuilder:validation:Optional
 	KMSKeyID *string `json:"kmsKeyId,omitempty" tf:"kms_key_id,omitempty"`
 

--- a/apis/rds/v1beta1/zz_generated.resolvers.go
+++ b/apis/rds/v1beta1/zz_generated.resolvers.go
@@ -93,7 +93,7 @@ func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error
 
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.KMSKeyID),
-			Extract:      reference.ExternalName(),
+			Extract:      common.ARNExtractor(),
 			Reference:    mg.Spec.ForProvider.KMSKeyIDRef,
 			Selector:     mg.Spec.ForProvider.KMSKeyIDSelector,
 			To:           reference.To{List: l, Managed: m},
@@ -249,7 +249,7 @@ func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error
 
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.KMSKeyID),
-			Extract:      reference.ExternalName(),
+			Extract:      common.ARNExtractor(),
 			Reference:    mg.Spec.InitProvider.KMSKeyIDRef,
 			Selector:     mg.Spec.InitProvider.KMSKeyIDSelector,
 			To:           reference.To{List: l, Managed: m},

--- a/apis/rds/v1beta2/zz_cluster_types.go
+++ b/apis/rds/v1beta2/zz_cluster_types.go
@@ -145,6 +145,7 @@ type ClusterInitParameters struct {
 
 	// ARN for the KMS encryption key. When specifying kms_key_id, storage_encrypted needs to be set to true.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	KMSKeyID *string `json:"kmsKeyId,omitempty" tf:"kms_key_id,omitempty"`
 
 	// Reference to a Key in kms to populate kmsKeyId.
@@ -646,6 +647,7 @@ type ClusterParameters struct {
 
 	// ARN for the KMS encryption key. When specifying kms_key_id, storage_encrypted needs to be set to true.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	// +kubebuilder:validation:Optional
 	KMSKeyID *string `json:"kmsKeyId,omitempty" tf:"kms_key_id,omitempty"`
 

--- a/apis/rds/v1beta2/zz_generated.resolvers.go
+++ b/apis/rds/v1beta2/zz_generated.resolvers.go
@@ -93,7 +93,7 @@ func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error
 
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.KMSKeyID),
-			Extract:      reference.ExternalName(),
+			Extract:      common.ARNExtractor(),
 			Reference:    mg.Spec.ForProvider.KMSKeyIDRef,
 			Selector:     mg.Spec.ForProvider.KMSKeyIDSelector,
 			To:           reference.To{List: l, Managed: m},
@@ -249,7 +249,7 @@ func (mg *Cluster) ResolveReferences(ctx context.Context, c client.Reader) error
 
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.KMSKeyID),
-			Extract:      reference.ExternalName(),
+			Extract:      common.ARNExtractor(),
 			Reference:    mg.Spec.InitProvider.KMSKeyIDRef,
 			Selector:     mg.Spec.InitProvider.KMSKeyIDSelector,
 			To:           reference.To{List: l, Managed: m},

--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -37,6 +37,10 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		r.References["db_instance_parameter_group_name"] = config.Reference{
 			TerraformName: "aws_db_parameter_group",
 		}
+		r.References["kms_key_id"] = config.Reference{
+			TerraformName: "aws_kms_key",
+			Extractor:     common.PathARNExtractor,
+		}
 		r.UseAsync = true
 		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
 			conn := map[string][]byte{}

--- a/examples/rds/v1beta1/cluster-with-kmskey.yaml
+++ b/examples/rds/v1beta1/cluster-with-kmskey.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: Cluster
+metadata:
+  annotations:
+    meta.upbound.io/example-id: rds/v1beta1/clusterendpoint
+  labels:
+    testing.upbound.io/example-name: default-ce
+  name: kms-test
+spec:
+  forProvider:
+    engine: aurora-postgresql
+    autoGeneratePassword: true
+    masterPasswordSecretRef:
+      key: password
+      name: sample-cluster-password
+      namespace: upbound-system
+    masterUsername: cpadmin
+    region: us-west-1
+    skipFinalSnapshot: true
+    storageEncrypted: true
+    kmsKeyIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: sample-key
+  writeConnectionSecretToRef:
+    name: sample-rds-cluster-secret
+    namespace: upbound-system
+---
+apiVersion: kms.aws.upbound.io/v1beta1
+kind: Key
+metadata:
+  labels:
+    testing.upbound.io/example-name: sample-key
+  name: sample-key
+spec:
+  forProvider:
+    deletionWindowInDays: 7
+    description: Created with Crossplane
+    region: us-west-1


### PR DESCRIPTION
### Description of your changes

Adds the `PathARNExtractor` for `kms_key_id` to the rds cluster resource

Fixes: https://github.com/crossplane-contrib/provider-upjet-aws/issues/1523

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

Tested with uptest (https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/11456655642) and manually:
```
  conditions:
  - lastTransitionTime: "2024-10-22T08:42:00Z"
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  - lastTransitionTime: "2024-10-22T08:42:55Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2024-10-22T08:42:53Z"
    reason: Success
    status: "True"
    type: LastAsyncOperation
  - lastTransitionTime: "2024-10-22T08:44:24Z"
    reason: UpToDate
    status: "True"
    type: Test
```

[contribution process]: https://git.io/fj2m9
