### PR TITLE
fix custom diff for Domain.opensearch ignoring valid diff

### DIFF
--- a/config/opensearch/config.go
+++ b/config/opensearch/config.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Configure adds configurations for the opensearch group.
-func Configure(p *config.Provider) {
+func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_opensearch_domain", func(r *config.Resource) {
 		config.MoveToStatus(r.TerraformResource, "access_policies")
 		r.References["encrypt_at_rest.kms_key_id"] = config.Reference{
@@ -36,7 +36,11 @@ func Configure(p *config.Provider) {
 		r.UseAsync = true
 
 		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
-			if diff != nil && diff.Attributes != nil {
+			if diff == nil || diff.Empty() || diff.Destroy || diff.Attributes == nil {
+				return diff, nil
+			}
+			asoDiff, ok := diff.Attributes["advanced_security_options.#"]
+			if ok && asoDiff.Old == "" && asoDiff.New == "" && asoDiff.NewComputed {
 				delete(diff.Attributes, "advanced_security_options.#")
 			}
 			return diff, nil

--- a/examples/opensearch/v1beta1/domain-with-advanced-security-options.yaml
+++ b/examples/opensearch/v1beta1/domain-with-advanced-security-options.yaml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+apiVersion: opensearch.aws.upbound.io/v1beta1
+kind: Domain
+metadata:
+  annotations:
+    meta.upbound.io/example-id: opensearch/v1beta1/domain
+  labels:
+    testing.upbound.io/example-name: example-advanced-security-options
+  name: example-advanced-security-options
+spec:
+  writeConnectionSecretToRef:
+    name: example-aso-domain
+    namespace: default
+  forProvider:
+    domainName: ${Rand.RFC1123Subdomain}
+    engineVersion: OpenSearch_1.0
+    region: us-west-1
+    advancedSecurityOptions:
+      - enabled: true
+        internalUserDatabaseEnabled: false
+        masterUserOptions:
+          - masterUserArn: arn:aws:iam::${data.aws_account_id}:user/example
+    nodeToNodeEncryption:
+      - enabled: true
+    encryptAtRest:
+      - enabled: true
+    domainEndpointOptions:
+      - enforceHttps: true
+    clusterConfig:
+      - instanceType: m4.large.search
+    ebsOptions:
+      - ebsEnabled: true
+        volumeType: gp2
+        volumeSize: 10


### PR DESCRIPTION
### Description of your changes

Fixes the custom diff function for `Domain.opensearch` resource, which ignored valid diffs for `advanced_security_options.#`, therefore configuring these options were not propagated to the external resource.

Fixes #1531 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually and [uptest](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/11456404274)

[contribution process]: https://git.io/fj2m9
