### PR TITLE
add subnet_configuration to VPCEndpoint LateInit

### DIFF
--- a/apis/ec2/v1beta1/zz_vpcendpoint_terraformed.go
+++ b/apis/ec2/v1beta1/zz_vpcendpoint_terraformed.go
@@ -118,6 +118,7 @@ func (tr *VPCEndpoint) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("SubnetConfiguration"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/ec2/v1beta2/zz_vpcendpoint_terraformed.go
+++ b/apis/ec2/v1beta2/zz_vpcendpoint_terraformed.go
@@ -118,6 +118,7 @@ func (tr *VPCEndpoint) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("SubnetConfiguration"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -153,7 +153,14 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		// aws_vpc_endpoint_subnet_association
 		// aws_vpc_endpoint_route_table_association
 		// aws_vpc_endpoint_security_group_association
-		config.MoveToStatus(r.TerraformResource, "subnet_configuration", "subnet_ids", "security_group_ids", "route_table_ids")
+		r.LateInitializer = config.LateInitializer{
+			// NOTE(muvaf): Conflicts with AvailabilityZone. See the following
+			// for more details: https://github.com/crossplane/upjet/issues/107
+			IgnoredFields: []string{
+				"subnet_configuration",
+			},
+		}
+		config.MoveToStatus(r.TerraformResource, "subnet_ids", "security_group_ids", "route_table_ids")
 		delete(r.References, "vpc_endpoint_type")
 	})
 

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -153,7 +153,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		// aws_vpc_endpoint_subnet_association
 		// aws_vpc_endpoint_route_table_association
 		// aws_vpc_endpoint_security_group_association
-		config.MoveToStatus(r.TerraformResource, "subnet_ids", "security_group_ids", "route_table_ids")
+		config.MoveToStatus(r.TerraformResource, "subnet_configuration", "subnet_ids", "security_group_ids", "route_table_ids")
 		delete(r.References, "vpc_endpoint_type")
 	})
 

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -154,8 +154,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		// aws_vpc_endpoint_route_table_association
 		// aws_vpc_endpoint_security_group_association
 		r.LateInitializer = config.LateInitializer{
-			// NOTE(muvaf): Conflicts with AvailabilityZone. See the following
-			// for more details: https://github.com/crossplane/upjet/issues/107
+			// Conflicts with VPCEndpointSubnetAssociation
 			IgnoredFields: []string{
 				"subnet_configuration",
 			},

--- a/examples/ec2/v1beta1/vpcendpointsubnetassociation.yaml
+++ b/examples/ec2/v1beta1/vpcendpointsubnetassociation.yaml
@@ -5,6 +5,8 @@
 apiVersion: ec2.aws.upbound.io/v1beta1
 kind: VPCEndpointSubnetAssociation
 metadata:
+  annotations:
+    uptest.upbound.io/disable-import: "true"
   labels:
     testing.upbound.io/example-name: sn_ec2
   name: sn-ec2


### PR DESCRIPTION
### Description of your changes

Add `subnet_configuration` to status for a VPC Endpoint.

Fixes #1596 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

We can see for the `VPCEndpoint` uptest run that `status.subnetConfiguration` is set but not lateInitialized to the `spec`.

```shell
2024-12-13T10:31:18.5260960Z     logger.go:42: 10:31:18 | case/3-delete |   kind: VPCEndpoint
2024-12-13T10:31:18.5261951Z     logger.go:42: 10:31:18 | case/3-delete |   metadata:
2024-12-13T10:31:18.5262979Z     logger.go:42: 10:31:18 | case/3-delete |     annotations:
2024-12-13T10:31:18.5264471Z     logger.go:42: 10:31:18 | case/3-delete |       crossplane.io/external-create-pending: "2024-12-13T10:28:15Z"
2024-12-13T10:31:18.5265839Z     logger.go:42: 10:31:18 | case/3-delete |       crossplane.io/external-create-succeeded: "2024-12-13T10:28:15Z"
2024-12-13T10:31:18.5267070Z     logger.go:42: 10:31:18 | case/3-delete |       crossplane.io/external-name: vpce-0169fd37e0ed505d1
2024-12-13T10:31:18.5268132Z     logger.go:42: 10:31:18 | case/3-delete |       crossplane.io/paused: "false"
2024-12-13T10:31:18.5269094Z     logger.go:42: 10:31:18 | case/3-delete |       upjet.upbound.io/test: "true"
2024-12-13T10:31:18.5271027Z     logger.go:42: 10:31:18 | case/3-delete |       uptest-old-id: vpce-0169fd37e0ed505d1
2024-12-13T10:31:18.5272073Z     logger.go:42: 10:31:18 | case/3-delete |     creationTimestamp: "2024-12-13T10:28:06Z"
2024-12-13T10:31:18.5273556Z     logger.go:42: 10:31:18 | case/3-delete |     deletionGracePeriodSeconds: 0
2024-12-13T10:31:18.5274532Z     logger.go:42: 10:31:18 | case/3-delete |     deletionTimestamp: "2024-12-13T10:31:17Z"
2024-12-13T10:31:18.5275399Z     logger.go:42: 10:31:18 | case/3-delete |     finalizers:
2024-12-13T10:31:18.5276350Z     logger.go:42: 10:31:18 | case/3-delete |     - finalizer.managedresource.crossplane.io
2024-12-13T10:31:18.5277275Z     logger.go:42: 10:31:18 | case/3-delete |     generation: 5
2024-12-13T10:31:18.5282197Z     logger.go:42: 10:31:18 | case/3-delete |     labels:
2024-12-13T10:31:18.5283444Z     logger.go:42: 10:31:18 | case/3-delete |       testing.upbound.io/example-name: ec2
2024-12-13T10:31:18.5284514Z     logger.go:42: 10:31:18 | case/3-delete |     name: ec2
2024-12-13T10:31:18.5285391Z     logger.go:42: 10:31:18 | case/3-delete |     resourceVersion: "2008"
2024-12-13T10:31:18.5286370Z     logger.go:42: 10:31:18 | case/3-delete |     uid: b870bc4e-6b85-47ee-a001-928a761aa4d1
2024-12-13T10:31:18.5287240Z     logger.go:42: 10:31:18 | case/3-delete |   spec:
2024-12-13T10:31:18.5288086Z     logger.go:42: 10:31:18 | case/3-delete |     deletionPolicy: Delete
2024-12-13T10:31:18.5288947Z     logger.go:42: 10:31:18 | case/3-delete |     forProvider:
2024-12-13T10:31:18.5289806Z     logger.go:42: 10:31:18 | case/3-delete |       dnsOptions:
2024-12-13T10:31:18.5290849Z     logger.go:42: 10:31:18 | case/3-delete |         dnsRecordIpType: ipv4
2024-12-13T10:31:18.5291775Z     logger.go:42: 10:31:18 | case/3-delete |       ipAddressType: ipv4
2024-12-13T10:31:18.5293343Z     logger.go:42: 10:31:18 | case/3-delete |       policy: '{"Statement":[{"Action":"*","Effect":"Allow","Principal":"*","Resource":"*"}]}'
2024-12-13T10:31:18.5294521Z     logger.go:42: 10:31:18 | case/3-delete |       region: us-west-1
2024-12-13T10:31:18.5295567Z     logger.go:42: 10:31:18 | case/3-delete |       serviceName: com.amazonaws.us-west-1.ec2
2024-12-13T10:31:18.5296551Z     logger.go:42: 10:31:18 | case/3-delete |       tags:
2024-12-13T10:31:18.5297698Z     logger.go:42: 10:31:18 | case/3-delete |         crossplane-kind: vpcendpoint.ec2.aws.upbound.io
2024-12-13T10:31:18.5299453Z     logger.go:42: 10:31:18 | case/3-delete |         crossplane-name: ec2
2024-12-13T10:31:18.5300836Z     logger.go:42: 10:31:18 | case/3-delete |         crossplane-providerconfig: default
2024-12-13T10:31:18.5302096Z     logger.go:42: 10:31:18 | case/3-delete |       vpcEndpointType: Interface
2024-12-13T10:31:18.5303678Z     logger.go:42: 10:31:18 | case/3-delete |       vpcId: vpc-05e607e8e3fb8f1a0
2024-12-13T10:31:18.5304927Z     logger.go:42: 10:31:18 | case/3-delete |       vpcIdRef:
2024-12-13T10:31:18.5305977Z     logger.go:42: 10:31:18 | case/3-delete |         name: vpc1
2024-12-13T10:31:18.5307053Z     logger.go:42: 10:31:18 | case/3-delete |       vpcIdSelector:
2024-12-13T10:31:18.5308418Z     logger.go:42: 10:31:18 | case/3-delete |         matchLabels:
2024-12-13T10:31:18.5309975Z     logger.go:42: 10:31:18 | case/3-delete |           testing.upbound.io/example-name: vpc1
2024-12-13T10:31:18.5311023Z     logger.go:42: 10:31:18 | case/3-delete |     initProvider: {}
2024-12-13T10:31:18.5311947Z     logger.go:42: 10:31:18 | case/3-delete |     managementPolicies:
2024-12-13T10:31:18.5312801Z     logger.go:42: 10:31:18 | case/3-delete |     - '*'
2024-12-13T10:31:18.5313699Z     logger.go:42: 10:31:18 | case/3-delete |     providerConfigRef:
2024-12-13T10:31:18.5314600Z     logger.go:42: 10:31:18 | case/3-delete |       name: default
2024-12-13T10:31:18.5315630Z     logger.go:42: 10:31:18 | case/3-delete |   status:
2024-12-13T10:31:18.5316672Z     logger.go:42: 10:31:18 | case/3-delete |     atProvider:
2024-12-13T10:31:18.5317936Z     logger.go:42: 10:31:18 | case/3-delete |       arn: arn:aws:ec2:us-west-1:153891904029:vpc-endpoint/vpce-0169fd37e0ed505d1
2024-12-13T10:31:18.5319229Z     logger.go:42: 10:31:18 | case/3-delete |       dnsEntry:
2024-12-13T10:31:18.5320611Z     logger.go:42: 10:31:18 | case/3-delete |       - dnsName: vpce-0169fd37e0ed505d1-tdvemjsx.ec2.us-west-1.vpce.amazonaws.com
2024-12-13T10:31:18.5321645Z     logger.go:42: 10:31:18 | case/3-delete |         hostedZoneId: Z12I86A8N7VCZO
2024-12-13T10:31:18.5322767Z     logger.go:42: 10:31:18 | case/3-delete |       - dnsName: vpce-0169fd37e0ed505d1-tdvemjsx-us-west-1b.ec2.us-west-1.vpce.amazonaws.com
2024-12-13T10:31:18.5323544Z     logger.go:42: 10:31:18 | case/3-delete |         hostedZoneId: Z12I86A8N7VCZO
2024-12-13T10:31:18.5324089Z     logger.go:42: 10:31:18 | case/3-delete |       dnsOptions:
2024-12-13T10:31:18.5324666Z     logger.go:42: 10:31:18 | case/3-delete |         dnsRecordIpType: ipv4
2024-12-13T10:31:18.5325348Z     logger.go:42: 10:31:18 | case/3-delete |         privateDnsOnlyForInboundResolverEndpoint: false
2024-12-13T10:31:18.5326128Z     logger.go:42: 10:31:18 | case/3-delete |       id: vpce-0169fd37e0ed505d1
2024-12-13T10:31:18.5326795Z     logger.go:42: 10:31:18 | case/3-delete |       ipAddressType: ipv4
2024-12-13T10:31:18.5327351Z     logger.go:42: 10:31:18 | case/3-delete |       networkInterfaceIds:
2024-12-13T10:31:18.5328003Z     logger.go:42: 10:31:18 | case/3-delete |       - eni-0bed3803d0d1aff85
2024-12-13T10:31:18.5328627Z     logger.go:42: 10:31:18 | case/3-delete |       ownerId: "153891904029"
2024-12-13T10:31:18.5329479Z     logger.go:42: 10:31:18 | case/3-delete |       policy: '{"Statement":[{"Action":"*","Effect":"Allow","Principal":"*","Resource":"*"}]}'
2024-12-13T10:31:18.5330543Z     logger.go:42: 10:31:18 | case/3-delete |       privateDnsEnabled: false
2024-12-13T10:31:18.5331493Z     logger.go:42: 10:31:18 | case/3-delete |       requesterManaged: false
2024-12-13T10:31:18.5332170Z     logger.go:42: 10:31:18 | case/3-delete |       securityGroupIds:
2024-12-13T10:31:18.5332794Z     logger.go:42: 10:31:18 | case/3-delete |       - sg-0919882b88af1508e
2024-12-13T10:31:18.5333499Z     logger.go:42: 10:31:18 | case/3-delete |       serviceName: com.amazonaws.us-west-1.ec2
2024-12-13T10:31:18.5334155Z     logger.go:42: 10:31:18 | case/3-delete |       state: available
2024-12-13T10:31:18.5334690Z     logger.go:42: 10:31:18 | case/3-delete |       subnetConfiguration:
2024-12-13T10:31:18.5335436Z     logger.go:42: 10:31:18 | case/3-delete |       - ipv4: 10.0.1.218
2024-12-13T10:31:18.5336200Z     logger.go:42: 10:31:18 | case/3-delete |         ipv6: ""
2024-12-13T10:31:18.5337074Z     logger.go:42: 10:31:18 | case/3-delete |         subnetId: subnet-0ce896076f7ce5eb0
2024-12-13T10:31:18.5337732Z     logger.go:42: 10:31:18 | case/3-delete |       subnetIds:
2024-12-13T10:31:18.5338418Z     logger.go:42: 10:31:18 | case/3-delete |       - subnet-0ce896076f7ce5eb0
2024-12-13T10:31:18.5338963Z     logger.go:42: 10:31:18 | case/3-delete |       tags:
2024-12-13T10:31:18.5339755Z     logger.go:42: 10:31:18 | case/3-delete |         crossplane-kind: vpcendpoint.ec2.aws.upbound.io
2024-12-13T10:31:18.5340533Z     logger.go:42: 10:31:18 | case/3-delete |         crossplane-name: ec2
2024-12-13T10:31:18.5341499Z     logger.go:42: 10:31:18 | case/3-delete |         crossplane-providerconfig: default
2024-12-13T10:31:18.5342286Z     logger.go:42: 10:31:18 | case/3-delete |       tagsAll:
2024-12-13T10:31:18.5342998Z     logger.go:42: 10:31:18 | case/3-delete |         crossplane-kind: vpcendpoint.ec2.aws.upbound.io
2024-12-13T10:31:18.5343620Z     logger.go:42: 10:31:18 | case/3-delete |         crossplane-name: ec2
2024-12-13T10:31:18.5344311Z     logger.go:42: 10:31:18 | case/3-delete |         crossplane-providerconfig: default
2024-12-13T10:31:18.5344906Z     logger.go:42: 10:31:18 | case/3-delete |       vpcEndpointType: Interface
2024-12-13T10:31:18.5345569Z     logger.go:42: 10:31:18 | case/3-delete |       vpcId: vpc-05e607e8e3fb8f1a0
2024-12-13T10:31:18.5346100Z     logger.go:42: 10:31:18 | case/3-delete |     conditions:
2024-12-13T10:31:18.5346761Z     logger.go:42: 10:31:18 | case/3-delete |     - lastTransitionTime: "2024-12-13T10:31:14Z"
2024-12-13T10:31:18.5347613Z     logger.go:42: 10:31:18 | case/3-delete |       reason: ReconcileSuccess
2024-12-13T10:31:18.5348241Z     logger.go:42: 10:31:18 | case/3-delete |       status: "True"
2024-12-13T10:31:18.5348829Z     logger.go:42: 10:31:18 | case/3-delete |       type: Synced
2024-12-13T10:31:18.5350149Z     logger.go:42: 10:31:18 | case/3-delete |     - lastTransitionTime: "2024-12-13T10:31:17Z"
2024-12-13T10:31:18.5350984Z     logger.go:42: 10:31:18 | case/3-delete |       reason: Deleting
2024-12-13T10:31:18.5351813Z     logger.go:42: 10:31:18 | case/3-delete |       status: "False"
2024-12-13T10:31:18.5352540Z     logger.go:42: 10:31:18 | case/3-delete |       type: Ready
2024-12-13T10:31:18.5353200Z     logger.go:42: 10:31:18 | case/3-delete |     - lastTransitionTime: "2024-12-13T10:31:14Z"
2024-12-13T10:31:18.5354109Z     logger.go:42: 10:31:18 | case/3-delete |       reason: UpToDate
2024-12-13T10:31:18.5354748Z     logger.go:42: 10:31:18 | case/3-delete |       status: "True"
2024-12-13T10:31:18.5355371Z     logger.go:42: 10:31:18 | case/3-delete |       type: Test
2024-12-13T10:31:18.5356245Z     logger.go:42: 10:31:18 | case/3-delete |     - lastTransitionTime: "2024-12-13T10:31:14Z"
2024-12-13T10:31:18.5356925Z     logger.go:42: 10:31:18 | case/3-delete |       reason: Success
2024-12-13T10:31:18.5357456Z     logger.go:42: 10:31:18 | case/3-delete |       status: "True"
2024-12-13T10:31:18.5358097Z     logger.go:42: 10:31:18 | case/3-delete |       type: LastAsyncOperation
```

[contribution process]: https://git.io/fj2m9
