### PR TITLE
rds_global_cluster endpoint in connection details

### DIFF
--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -212,6 +212,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			}
 			return conn, nil
 		}
+	})
 
 	p.AddResourceConfigurator("aws_db_proxy", func(r *config.Resource) {
 		r.UseAsync = true

--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -203,6 +203,16 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		}
 	})
 
+	p.AddResourceConfigurator("aws_rds_global_cluster", func(r *config.Resource) {
+		r.UseAsync = true
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]any) (map[string][]byte, error) {
+			conn := map[string][]byte{}
+			if a, ok := attr["endpoint"].(string); ok {
+				conn["endpoint"] = []byte(a)
+			}
+			return conn, nil
+		}
+
 	p.AddResourceConfigurator("aws_db_proxy", func(r *config.Resource) {
 		r.UseAsync = true
 	})


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

This is to ensure global cluster endpoints are exported to connection secrets.

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

A local build was deployed to a cluster, an RDS GlobalDatabase was created, and the secret was inspected. The endpoint value was there as expected.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
