### PR TITLE
Consume EC2 Instance panic fix and address perpetual diff

### DIFF
--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -53,6 +53,9 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 				"cpu_threads_per_core",
 			},
 		}
+		r.TerraformCustomDiff = common.RemoveDiffIfEmpty([]string{
+			"volume_tags.%",
+		})
 		config.MoveToStatus(r.TerraformResource, "security_groups")
 	})
 	p.AddResourceConfigurator("aws_eip", func(r *config.Resource) {

--- a/go.mod
+++ b/go.mod
@@ -439,4 +439,4 @@ require (
 // copied from the Terraform provider
 replace github.com/hashicorp/terraform-plugin-log => github.com/gdavison/terraform-plugin-log v0.0.0-20230928191232-6c653d8ef8fb
 
-replace github.com/hashicorp/terraform-provider-aws => github.com/upbound/terraform-provider-aws v0.0.0-20241203141151-997a60ec5360
+replace github.com/hashicorp/terraform-provider-aws => github.com/upbound/terraform-provider-aws v0.0.0-20250102143213-c0eb96154778

--- a/go.sum
+++ b/go.sum
@@ -865,8 +865,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
-github.com/upbound/terraform-provider-aws v0.0.0-20241203141151-997a60ec5360 h1:HLrTYw0kB74C7JMNM5dUe0h7V2nzvdSMzciWmsJCUvQ=
-github.com/upbound/terraform-provider-aws v0.0.0-20241203141151-997a60ec5360/go.mod h1:7l6VnUvAF/LY5jcEABkfHuK8gAkOODwTT1TcGpy+tl0=
+github.com/upbound/terraform-provider-aws v0.0.0-20250102143213-c0eb96154778 h1:RxW17Zn9BdCvSSeB7LGOZCoJJYO1d4VDvrdPmSRP5G8=
+github.com/upbound/terraform-provider-aws v0.0.0-20250102143213-c0eb96154778/go.mod h1:7l6VnUvAF/LY5jcEABkfHuK8gAkOODwTT1TcGpy+tl0=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #1579. See https://github.com/upbound/terraform-provider-aws/pull/279 for a detailed explanation of the problem and the fix.

I modularized the custom diff code in https://github.com/crossplane-contrib/provider-upjet-azure/pull/816, so that we can simply call this function to ignore empty diffs, as in [the example](https://github.com/crossplane-contrib/provider-upjet-aws/pull/1625/files#diff-1dd08ae78b69dddf38b311b827ebd655e113ca72c2a63f98c21d459c021a3d0eR56-R58).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Uptest runs:

1. [examples/ec2/v1beta1/instance.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/12584328521)
2. [examples/ec2/v1beta2/instance.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/12584874277)
3. [examples/s3/v1beta1/bucket.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/12589381490)
4. [examples/ec2/v1beta2/vpcendpoint.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/12589404355)

[contribution process]: https://git.io/fj2m9
