### PR TITLE
Disable lateinit for enabledCloudwatchLogsExports in rds Cluster

### DIFF
--- a/apis/rds/v1beta1/zz_cluster_terraformed.go
+++ b/apis/rds/v1beta1/zz_cluster_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Cluster) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("EnabledCloudwatchLogsExports"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/rds/v1beta2/zz_cluster_terraformed.go
+++ b/apis/rds/v1beta2/zz_cluster_terraformed.go
@@ -118,6 +118,7 @@ func (tr *Cluster) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("EnabledCloudwatchLogsExports"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/rds/config.go
+++ b/config/rds/config.go
@@ -100,6 +100,9 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			}
 			return diff, nil
 		}
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"enabled_cloudwatch_logs_exports"},
+		}
 	})
 
 	p.AddResourceConfigurator("aws_rds_cluster_instance", func(r *config.Resource) {

--- a/examples/rds/v1beta2/cluster.yaml
+++ b/examples/rds/v1beta2/cluster.yaml
@@ -42,7 +42,7 @@ metadata:
 spec:
   forProvider:
     description: RDS custom cluster parameter group
-    family: aurora-postgresql15
+    family: aurora-postgresql16
     parameter:
     - applyMethod: immediate
       name: application_name
@@ -62,7 +62,7 @@ metadata:
 spec:
   forProvider:
     description: example
-    family: aurora-postgresql15
+    family: aurora-postgresql16
     parameter:
     - applyMethod: immediate
       name: application_name


### PR DESCRIPTION
### Description of your changes

Disable late init for enabledCloudwatchLogsExports in rds Cluster

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- `examples/rds/v1beta1/cluster.yaml` => https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/12932627523
- `examples/rds/v1beta2/cluster.yaml` => https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/12954227675

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
