### PR TITLE
Update tf provider to the commit ca3a4c5ba291 and add a test example

### DIFF
--- a/examples/mq/v1alpha1/user-with-groups.yaml
+++ b/examples/mq/v1alpha1/user-with-groups.yaml
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+apiVersion: mq.aws.upbound.io/v1alpha1
+kind: User
+metadata:
+  annotations:
+    meta.upbound.io/example-id: mq/v1alpha1/user
+  labels:
+    testing.upbound.io/example-name: example
+  name: mquser1
+spec:
+  providerConfigRef:
+    name: default
+  forProvider:
+    brokerIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
+    consoleAccess: false
+    passwordSecretRef:
+      key: password
+      name: mq-admin-secret
+      namespace: upbound-system
+    username: mquser1
+    groups:
+      - users
+      - dev
+    region: us-west-1
+---
+apiVersion: mq.aws.upbound.io/v1alpha1
+kind: User
+metadata:
+  annotations:
+    meta.upbound.io/example-id: mq/v1alpha1/user
+  labels:
+    testing.upbound.io/example-name: example
+  name: mquser2
+spec:
+  providerConfigRef:
+    name: default
+  forProvider:
+    brokerIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
+    consoleAccess: false
+    passwordSecretRef:
+      key: password
+      name: mq-admin-secret
+      namespace: upbound-system
+    username: mquser2
+    groups:
+      - users
+      - dev
+    region: us-west-1
+---
+apiVersion: mq.aws.upbound.io/v1alpha1
+kind: User
+metadata:
+  annotations:
+    meta.upbound.io/example-id: mq/v1alpha1/user
+  labels:
+    testing.upbound.io/example-name: example
+  name: mquser3
+spec:
+  providerConfigRef:
+    name: default
+  forProvider:
+    brokerIdSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
+    consoleAccess: false
+    passwordSecretRef:
+      key: password
+      name: mq-admin-secret
+      namespace: upbound-system
+    username: mquser3
+    groups:
+      - users
+      - dev
+    region: us-west-1
+---
+apiVersion: mq.aws.upbound.io/v1beta2
+kind: Broker
+metadata:
+  annotations:
+    meta.upbound.io/example-id: mq/v1alpha1/user
+  labels:
+    testing.upbound.io/example-name: example
+  name: example-test
+spec:
+  forProvider:
+    applyImmediately: true
+    brokerName: example-test-broker
+    engineType: ActiveMQ
+    engineVersion: 5.17.6
+    hostInstanceType: mq.t2.micro
+    region: us-west-1
+    securityGroupRefs:
+    - name: sg-test
+  providerConfigRef:
+    name: default
+  initProvider:
+    user:
+    - passwordSecretRef:
+        key: password
+        name: mq-admin-secret
+        namespace: upbound-system
+      username: admin
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    meta.upbound.io/example-id: mq/v1alpha1/user
+    uptest.upbound.io/pre-delete-hook: testhooks/delete-broker.sh
+  labels:
+    testing.upbound.io/example-name: mq-secret
+  name: mq-admin-secret
+  namespace: upbound-system
+stringData:
+  password: Upboundtest!
+type: Opaque
+---
+apiVersion: ec2.aws.upbound.io/v1beta1
+kind: SecurityGroup
+metadata:
+  annotations:
+    meta.upbound.io/example-id: mq/v1alpha1/user
+  name: sg-test
+spec:
+  forProvider:
+    description: Allow TLS inbound traffic
+    name: allow_tls
+    region: us-west-1
+    tags:
+      Name: allow_tls

--- a/go.mod
+++ b/go.mod
@@ -441,4 +441,4 @@ require (
 // copied from the Terraform provider
 replace github.com/hashicorp/terraform-plugin-log => github.com/gdavison/terraform-plugin-log v0.0.0-20230928191232-6c653d8ef8fb
 
-replace github.com/hashicorp/terraform-provider-aws => github.com/upbound/terraform-provider-aws v0.0.0-20250109090836-986571bdb591
+replace github.com/hashicorp/terraform-provider-aws => github.com/upbound/terraform-provider-aws v0.0.0-20250210124112-ca3a4c5ba291

--- a/go.sum
+++ b/go.sum
@@ -868,8 +868,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
-github.com/upbound/terraform-provider-aws v0.0.0-20250109090836-986571bdb591 h1:uvvMS8OmHsLXKOVHkDKkdbxdKEspEwejdenfe8Dwl64=
-github.com/upbound/terraform-provider-aws v0.0.0-20250109090836-986571bdb591/go.mod h1:B7SdSRSmPRFkPECx8/XlhVDovQuzdg34iQzuLUFqgs8=
+github.com/upbound/terraform-provider-aws v0.0.0-20250210124112-ca3a4c5ba291 h1:Q8atmog81+eoPwwU+0ZI6MDaXDuBpWS+wvXvUtNdthA=
+github.com/upbound/terraform-provider-aws v0.0.0-20250210124112-ca3a4c5ba291/go.mod h1:B7SdSRSmPRFkPECx8/XlhVDovQuzdg34iQzuLUFqgs8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
### Description of your changes

This PR updates tf provider to the commit `ca3a4c5ba291` and adds a test example with `groups` field for the MQ User resource.

Fixes https://github.com/crossplane-contrib/provider-upjet-aws/issues/1657

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Manually and uptest: https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/13241246044

*Note: A Broker reboot is required for any MQ User operations to take effect. After creating 3 User resources here, a reboot is required.*
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
