### PR TITLE
Use ARN extractor for Cloudwatch log group `kms_key_id` reference

### DIFF
--- a/apis/cloudwatchlogs/v1beta1/zz_generated.resolvers.go
+++ b/apis/cloudwatchlogs/v1beta1/zz_generated.resolvers.go
@@ -121,7 +121,7 @@ func (mg *Group) ResolveReferences(ctx context.Context, c client.Reader) error {
 
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.KMSKeyID),
-			Extract:      reference.ExternalName(),
+			Extract:      common.ARNExtractor(),
 			Reference:    mg.Spec.ForProvider.KMSKeyIDRef,
 			Selector:     mg.Spec.ForProvider.KMSKeyIDSelector,
 			To:           reference.To{List: l, Managed: m},
@@ -140,7 +140,7 @@ func (mg *Group) ResolveReferences(ctx context.Context, c client.Reader) error {
 
 		rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 			CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.KMSKeyID),
-			Extract:      reference.ExternalName(),
+			Extract:      common.ARNExtractor(),
 			Reference:    mg.Spec.InitProvider.KMSKeyIDRef,
 			Selector:     mg.Spec.InitProvider.KMSKeyIDSelector,
 			To:           reference.To{List: l, Managed: m},

--- a/apis/cloudwatchlogs/v1beta1/zz_group_types.go
+++ b/apis/cloudwatchlogs/v1beta1/zz_group_types.go
@@ -19,6 +19,7 @@ type GroupInitParameters struct {
 	// AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires
 	// permissions for the CMK whenever the encrypted data is requested.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	KMSKeyID *string `json:"kmsKeyId,omitempty" tf:"kms_key_id,omitempty"`
 
 	// Reference to a Key in kms to populate kmsKeyId.
@@ -81,6 +82,7 @@ type GroupParameters struct {
 	// AWS CloudWatch Logs stops encrypting newly ingested data for the log group. All previously ingested data remains encrypted, and AWS CloudWatch Logs requires
 	// permissions for the CMK whenever the encrypted data is requested.
 	// +crossplane:generate:reference:type=github.com/upbound/provider-aws/apis/kms/v1beta1.Key
+	// +crossplane:generate:reference:extractor=github.com/upbound/provider-aws/config/common.ARNExtractor()
 	// +kubebuilder:validation:Optional
 	KMSKeyID *string `json:"kmsKeyId,omitempty" tf:"kms_key_id,omitempty"`
 

--- a/config/cloudwatchlogs/config.go
+++ b/config/cloudwatchlogs/config.go
@@ -43,6 +43,11 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"name_prefix"},
 		}
+		// The kms_key_id field actually references the KMS ARN
+		r.References["kms_key_id"] = config.Reference{
+			TerraformName: "aws_kms_key",
+			Extractor:     common.PathARNExtractor,
+		}
 	})
 
 }

--- a/examples/cloudwatchlogs/v1beta1/group-with-kms.yaml
+++ b/examples/cloudwatchlogs/v1beta1/group-with-kms.yaml
@@ -9,6 +9,37 @@ spec:
     region: us-east-1
     description: Created with Crossplane
     deletionWindowInDays: 7
+    policy: |
+      {
+        "Version": "2012-10-17",
+        "Id": "key-default-1",
+        "Statement": [
+          {
+            "Sid": "EnableIAMUserPermissions",
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::${data.aws_account_id}:root"
+            },
+            "Action": "kms:*",
+            "Resource": "*"
+          },
+          {
+            "Sid": "AllowCloudWatchLogs",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "logs.us-east-1.amazonaws.com"
+            },
+            "Action": [
+              "kms:Encrypt",
+              "kms:Decrypt",
+              "kms:ReEncrypt*",
+              "kms:GenerateDataKey*",
+              "kms:Describe*"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
 ---
 apiVersion: cloudwatchlogs.aws.upbound.io/v1beta1
 kind: Group

--- a/examples/cloudwatchlogs/v1beta1/group-with-kms.yaml
+++ b/examples/cloudwatchlogs/v1beta1/group-with-kms.yaml
@@ -1,0 +1,24 @@
+apiVersion: kms.aws.upbound.io/v1beta1
+kind: Key
+metadata:
+  labels:
+    testing.upbound.io/example-name: sample-logs-key
+  name: sample-logs-key
+spec:
+  forProvider:
+    region: us-east-1
+    description: Created with Crossplane
+    deletionWindowInDays: 7
+---
+apiVersion: cloudwatchlogs.aws.upbound.io/v1beta1
+kind: Group
+metadata:
+  labels:
+    testing.upbound.io/example-name: example-with-kms
+  name: example-with-kms
+spec:
+  forProvider:
+    kmsKeyIdRef:
+      name: sample-logs-key
+    region: us-east-1
+    retentionInDays: 5

--- a/internal/clients/zz_partitions_gen.go
+++ b/internal/clients/zz_partitions_gen.go
@@ -82,10 +82,16 @@ var (
 			serviceToDefaultRegions: map[string]string{},
 		},
 		"aws-iso-f": {
-			id:                      "aws-iso-f",
-			name:                    "AWS ISOF",
-			dnsSuffix:               "csp.hci.ic.gov",
-			serviceToDefaultRegions: map[string]string{},
+			id:        "aws-iso-f",
+			name:      "AWS ISOF",
+			dnsSuffix: "csp.hci.ic.gov",
+			serviceToDefaultRegions: map[string]string{
+				"budgets":       "us-isof-south-1",
+				"iam":           "us-isof-south-1",
+				"organizations": "us-isof-south-1",
+				"route53":       "us-isof-south-1",
+				"savingsplans":  "us-isof-south-1",
+			},
 		},
 		"aws-us-gov": {
 			id:        "aws-us-gov",


### PR DESCRIPTION
### Description of your changes

Currently, when specifying a reference to an AWS KMS Key in a Cloudwatch logs `Group`, it tries to use the KMS Key ID which does not work. It should use the ARN of the resource.

Despite the confusing parameter name, the TF provider docs do state this [here](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group):

>[kms_key_id](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group#kms_key_id-1) - (Optional) The ARN of the KMS Key to use when encrypting log data.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I have added an additional E2E test to cover this behaviour, let me know if this is suitable.

https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/13188245301

[contribution process]: https://git.io/fj2m9
