### PR TITLE
Integrate reusable workflows for provider package publishing

### DIFF
--- a/.github/workflows/publish-provider-packages.yaml
+++ b/.github/workflows/publish-provider-packages.yaml
@@ -1,0 +1,40 @@
+name: Publish Provider Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      subpackages:
+        description: 'Subpackages to be built individually (e.g. config ec2)'
+        default: 'config'
+        required: false
+      size:
+        description: "Number of smaller provider packages to build and push with each build job"
+        default: '30'
+        required: true
+      concurrency:
+        description: "Number of parallel package builds within each build job"
+        default: '1'
+        required: false
+      version:
+        description: "Version string to use while publishing the packages (e.g. v1.0.0-alpha.1)"
+        default: ''
+        required: false
+      go-version:
+        description: 'Go version to use if building needs to be done'
+        default: '1.23'
+        required: false
+
+jobs:
+  publish-provider-packages:
+    uses: crossplane-contrib/provider-workflows/.github/workflows/publish-provider-family.yml@main
+    with:
+      subpackages: ${{ github.event.inputs.subpackages }}
+      size: ${{ github.event.inputs.size }}
+      concurrency: ${{ github.event.inputs.concurrency }}
+      repository: provider-aws
+      version: ${{ github.event.inputs.version }}
+      go-version: ${{ github.event.inputs.go-version }}
+      cleanup-disk: true
+    secrets:
+      GHCR_PAT: ${{ secrets.GITHUB_TOKEN }}
+      XPKG_UPBOUND_TOKEN: ${{ secrets.XPKG_UPBOUND_TOKEN }}


### PR DESCRIPTION
### Description of your changes

This PR integrates reusable workflows for provider package publishing. Here is the workflow that wanted to integrate: https://github.com/crossplane-contrib/provider-workflows/blob/main/.github/workflows/publish-provider-family.yml

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
