### PR TITLE
Check repository permission instead of author association.

### DIFF
--- a/.github/workflows/uptest-trigger.yaml
+++ b/.github/workflows/uptest-trigger.yaml
@@ -12,19 +12,32 @@ env:
   GO_VERSION: "1.23.6"
 
 jobs:
-  debug:
+  check-permissions:
     runs-on: ubuntu-latest
+    outputs:
+      permission: ${{ steps.check-permissions.outputs.permission }}
     steps:
-      - name: Debug
+      - name: Get Commenter Permissions
+        id: check-permissions
         run: |
           echo "Trigger keyword: '/test-examples'"
           echo "Go version: ${{ env.GO_VERSION }}"
-          echo "github.event.comment.author_association: ${{ github.event.comment.author_association }}"
+
+          REPO=${{ github.repository }}
+          COMMENTER=${{ github.event.comment.user.login }}
+
+          # Fetch the commenter's repo-level permission grant
+          GRANTED=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/$REPO/collaborators/$COMMENTER/permission" | jq -r .permission)
+
+          # Make it accessible in the workflow via a job output -- cannot use env
+          echo "User $COMMENTER has $GRANTED permissions"
+          echo "permission=$GRANTED" >> "$GITHUB_OUTPUT"
 
   get-example-list:
-    if: ${{ (github.event.comment.author_association == 'OWNER' ) &&
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/test-examples' ) }}
+    needs: check-permissions
+    if: ${{ (needs.check-permissions.outputs.permission == 'admin' || needs.check-permissions.outputs.permission == 'maintain') && github.event.issue.pull_request != null && contains(github.event.comment.body, '/test-examples')}}
     runs-on: ubuntu-latest
     outputs:
       example_list: ${{ steps.get-example-list-name.outputs.example-list }}
@@ -79,12 +92,11 @@ jobs:
             -f context="Uptest-${{ steps.get-example-list-name.outputs.example-hash }}"
 
   uptest:
-    if: ${{ (github.event.comment.author_association == 'OWNER' ) &&
-      github.event.issue.pull_request &&
-      contains(github.event.comment.body, '/test-examples' ) }}
+    needs:
+      - check-permissions
+      - get-example-list
+    if: ${{ (needs.check-permissions.outputs.permission == 'admin' || needs.check-permissions.outputs.permission == 'maintain') && github.event.issue.pull_request != null && contains(github.event.comment.body, '/test-examples')}}
     runs-on: ubuntu-latest
-    needs: get-example-list
-
     steps:
       - name: Cleanup Disk
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes
Determine appropriate access for comment-based workflow triggers based on the commenter's repository-level permission, rather than author association (which is a non-intuitive derivation based on membership in the GitHub organization in addition to repository-level permissions).

This aims to ensure trusted actors are able to run their e2e workflows in repositories they maintain, without necessarily requiring membership in the crossplane-contrib organization.

xref https://github.com/crossplane-contrib/provider-upjet-azuread/pull/208

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

On a personal fork. https://github.com/jastang/provider-upjet-aws/actions/runs/13634041711

[contribution process]: https://git.io/fj2m9
