### PR TITLE
Update DynamoDB GSI rangeKey description

### DIFF
--- a/package/crds/dynamodb.aws.upbound.io_tables.yaml
+++ b/package/crds/dynamodb.aws.upbound.io_tables.yaml
@@ -145,7 +145,7 @@ spec:
                             to the attributes that thatKEYS_ONLY project.
                           type: string
                         rangeKey:
-                          description: Name of the range key; must be defined
+                          description: Name of the range key.
                           type: string
                         readCapacity:
                           description: Number of read units for this index. Must be
@@ -492,7 +492,7 @@ spec:
                             to the attributes that thatKEYS_ONLY project.
                           type: string
                         rangeKey:
-                          description: Name of the range key; must be defined
+                          description: Name of the range key.
                           type: string
                         readCapacity:
                           description: Number of read units for this index. Must be
@@ -995,7 +995,7 @@ spec:
                             to the attributes that thatKEYS_ONLY project.
                           type: string
                         rangeKey:
-                          description: Name of the range key; must be defined
+                          description: Name of the range key.
                           type: string
                         readCapacity:
                           description: Number of read units for this index. Must be
@@ -1472,7 +1472,7 @@ spec:
                             to the attributes that thatKEYS_ONLY project.
                           type: string
                         rangeKey:
-                          description: Name of the range key; must be defined
+                          description: Name of the range key.
                           type: string
                         readCapacity:
                           description: Number of read units for this index. Must be
@@ -1801,7 +1801,7 @@ spec:
                             to the attributes that thatKEYS_ONLY project.
                           type: string
                         rangeKey:
-                          description: Name of the range key; must be defined
+                          description: Name of the range key.
                           type: string
                         readCapacity:
                           description: Number of read units for this index. Must be
@@ -2286,7 +2286,7 @@ spec:
                             to the attributes that thatKEYS_ONLY project.
                           type: string
                         rangeKey:
-                          description: Name of the range key; must be defined
+                          description: Name of the range key.
                           type: string
                         readCapacity:
                           description: Number of read units for this index. Must be


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

Removed "must be defined" from the DynamoDB global secondary index range key description. This text makes it sound like range key is a required field when it is not. This update makes the description match the local secondary index.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

I have spent several hours trying to run `make reviewable`. It can't get it to work with a clean checkout of the main branch. I'm willing to run this, but I will need some instructions to help me establish a working development environment. I have tried with go 1.23.6, installing goimports, and trying many of the make targets.

### How has this code been tested

This is just a documentation change.

[contribution process]: https://git.io/fj2m9
