### PR TITLE
Fix ec2 instance recreation issue after manual termination

### DIFF
--- a/apis/ec2/v1beta1/zz_instance_terraformed.go
+++ b/apis/ec2/v1beta1/zz_instance_terraformed.go
@@ -120,11 +120,13 @@ func (tr *Instance) LateInitialize(attrs []byte) (bool, error) {
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
 	opts = append(opts, resource.WithNameFilter("AssociatePublicIPAddress"))
 	opts = append(opts, resource.WithNameFilter("CPUCoreCount"))
+	opts = append(opts, resource.WithNameFilter("CPUOptions"))
 	opts = append(opts, resource.WithNameFilter("CPUThreadsPerCore"))
 	opts = append(opts, resource.WithNameFilter("IPv6AddressCount"))
 	opts = append(opts, resource.WithNameFilter("IPv6Addresses"))
 	opts = append(opts, resource.WithNameFilter("NetworkInterface"))
 	opts = append(opts, resource.WithNameFilter("PrivateIP"))
+	opts = append(opts, resource.WithNameFilter("RootBlockDevice"))
 	opts = append(opts, resource.WithNameFilter("SourceDestCheck"))
 	opts = append(opts, resource.WithNameFilter("SubnetID"))
 	opts = append(opts, resource.WithNameFilter("VPCSecurityGroupIds"))

--- a/apis/ec2/v1beta2/zz_instance_terraformed.go
+++ b/apis/ec2/v1beta2/zz_instance_terraformed.go
@@ -120,11 +120,13 @@ func (tr *Instance) LateInitialize(attrs []byte) (bool, error) {
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
 	opts = append(opts, resource.WithNameFilter("AssociatePublicIPAddress"))
 	opts = append(opts, resource.WithNameFilter("CPUCoreCount"))
+	opts = append(opts, resource.WithNameFilter("CPUOptions"))
 	opts = append(opts, resource.WithNameFilter("CPUThreadsPerCore"))
 	opts = append(opts, resource.WithNameFilter("IPv6AddressCount"))
 	opts = append(opts, resource.WithNameFilter("IPv6Addresses"))
 	opts = append(opts, resource.WithNameFilter("NetworkInterface"))
 	opts = append(opts, resource.WithNameFilter("PrivateIP"))
+	opts = append(opts, resource.WithNameFilter("RootBlockDevice"))
 	opts = append(opts, resource.WithNameFilter("SourceDestCheck"))
 	opts = append(opts, resource.WithNameFilter("SubnetID"))
 	opts = append(opts, resource.WithNameFilter("VPCSecurityGroupIds"))

--- a/config/ec2/config.go
+++ b/config/ec2/config.go
@@ -51,6 +51,8 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 				"ipv6_address_count",
 				"cpu_core_count",
 				"cpu_threads_per_core",
+				"cpu_options",
+				"root_block_device",
 			},
 		}
 		r.TerraformCustomDiff = common.RemoveDiffIfEmpty([]string{


### PR DESCRIPTION
### Description of your changes

This PR fixes ec2 instance recreation issue after manual termination by ignoring the `cpu_options` and `root_block_device` fields from LateInitializer.

Fixes: https://github.com/crossplane-contrib/provider-upjet-aws/issues/1306

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested

Tested recreation case manually with `index.docker.io/turkenf/provider-aws:v1.21.0-rc.0.56.gddd4ddd05` and uptest: https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/13684144410

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
