### PR TITLE
Update PR template to reference codegen

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,8 @@ Fixes #
 I have:
 
 - [ ] Read and followed Crossplane's [contribution process].
-- [ ] Run `make reviewable` to ensure this PR is ready for review.
+- [ ] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
+- [ ] Not made any manual changes to generated files, and verified this with `make check-diff`.
 
 ### How has this code been tested
 


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

I just set up a clean dev environment, and while I was able to get `make reviewable` to run successfully, it took 55 minutes! It's possible it would have failed on a machine with less RAM available. This seems like an unreasonably high bar to expect from new contributors. I confess that I generally do not run it locally on my own PRs because it takes so long, and because most (all?) of its functionality is also implemented in CI. 

I think there's probably some more adjustments we can make to the language in the template to make this more clear, and I'm also interested in finding ways to improve the new-contributor experience as far as ability to run CI checks, although I understand there are some valid security concerns there. 

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
