### PR TITLE
chore(deps): bump upjet dependency to crossplane-v2 branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ module github.com/upbound/provider-aws
 
 go 1.23.6
 
-replace github.com/crossplane/upjet => github.com/negz/upjet v0.0.0-20250320063135-520f63c242c6
-
 require (
 	dario.cat/mergo v1.0.1
 	github.com/aws/aws-sdk-go v1.55.5
@@ -20,7 +18,7 @@ require (
 	github.com/aws/smithy-go v1.22.1
 	github.com/crossplane/crossplane-runtime v1.17.0
 	github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79
-	github.com/crossplane/upjet v1.5.0
+	github.com/crossplane/upjet v1.5.1-0.20250326011105-978f519ee970
 	github.com/go-ini/ini v1.46.0
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.59

--- a/go.sum
+++ b/go.sum
@@ -580,6 +580,8 @@ github.com/crossplane/crossplane-runtime v1.17.0 h1:y+GvxPT1M9s8BKt2AeZJdd2d6pg2
 github.com/crossplane/crossplane-runtime v1.17.0/go.mod h1:vtglCrnnbq2HurAk9yLHa4qS0bbnCxaKL7C21cQcB/0=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79 h1:HigXs5tEQxWz0fcj8hzbU2UAZgEM7wPe0XRFOsrtF8Y=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79/go.mod h1:+e4OaFlOcmr0JvINHl/yvEYBrZawzTgj6pQumOH1SS0=
+github.com/crossplane/upjet v1.5.1-0.20250326011105-978f519ee970 h1:ocjl9z2YluIdKb919R+JibzPRFpDFenW3yy3riPh3uE=
+github.com/crossplane/upjet v1.5.1-0.20250326011105-978f519ee970/go.mod h1:F2u9XwKNzxM+myfS1Opjnc6a5E1N2PC7Mytbkavawvs=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/dave/jennifer v1.4.1 h1:XyqG6cn5RQsTj3qlWQTKlRGAyrTcsk1kUmWdZBzRjDw=
@@ -804,8 +806,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/muvaf/typewriter v0.0.0-20210910160850-80e49fe1eb32 h1:yBQlHXLeUJL3TWVmzup5uT3wG5FLxhiTAiTsmNVocys=
 github.com/muvaf/typewriter v0.0.0-20210910160850-80e49fe1eb32/go.mod h1:SAAdeMEiFXR8LcHffvIdiLI1w243DCH2DuHq7UrA5YQ=
-github.com/negz/upjet v0.0.0-20250320063135-520f63c242c6 h1:UvITk13uQc754KSHQKcLvjXdwrOtho9Dxeu4pMJSNlM=
-github.com/negz/upjet v0.0.0-20250320063135-520f63c242c6/go.mod h1:F2u9XwKNzxM+myfS1Opjnc6a5E1N2PC7Mytbkavawvs=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=


### PR DESCRIPTION
### Description of your changes

This is a small follow-up PR to #1753 to bump the upjet dependency to the latest in its [crossplane-v2](https://github.com/crossplane/upjet/tree/crossplane-v2) branch, now that upjet PR https://github.com/crossplane/upjet/pull/480 has been merged.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

I've manually run `make generate` and saw no difference in functionality, which isn't surprising because this is effectively the same upjet code we'd been testing all along in #1753 😁 

[contribution process]: https://git.io/fj2m9
