### PR TITLE
Add Observe only CloudFormation Stack

### DIFF
--- a/examples/cloudformation/v1beta1/stack.yaml
+++ b/examples/cloudformation/v1beta1/stack.yaml
@@ -38,3 +38,18 @@ spec:
           }
         }
       }
+
+---
+# Observe only CloudFormation Stack
+apiVersion: cloudformation.aws.upbound.io/v1beta1
+kind: Stack
+metadata:
+  name: my-k8s-stack-resource-name
+  annotations:
+    crossplane.io/external-name: "97f1dc70-f461-11ef-b8bd-06f58344f049" # /!\ Needs to be cloudformation stack ID
+spec:
+  managementPolicies:
+    - Observe
+  forProvider:
+    region: eu-west-1
+    name: DevPlatform0EksStack # /!\ Needs to be cloudformation stack name


### PR DESCRIPTION
### Description of your changes

Add an example of Cloudformation Stack Observe which behave in a specific way

I have:

- [X] Read and followed Crossplane's [contribution process].
- [ ] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [ ] Not made any manual changes to generated files, and verified this with `make check-diff`.
--> I only updated documentation

### How has this code been tested

This is documentation

[contribution process]: https://git.io/fj2m9
