### PR TITLE
Bump upjet version

### DIFF
--- a/examples/batch/v1beta1/jobqueue.yaml
+++ b/examples/batch/v1beta1/jobqueue.yaml
@@ -14,7 +14,7 @@ spec:
             testing.upbound.io/example-name: sample
         order: 1
     priority: 1
-    region: eu-west-1
+    region: us-east-2
     state: ENABLED
 ---
 apiVersion: batch.aws.upbound.io/v1beta1
@@ -43,7 +43,7 @@ spec:
       subnetsRefs:
       - name: sample
       type: EC2
-    region: eu-west-1
+    region: us-east-2
     serviceRoleSelector:
       matchLabels:
         testing.upbound.io/example-name: aws_batch_service_role
@@ -156,7 +156,7 @@ metadata:
   name: sample
 spec:
   forProvider:
-    region: eu-west-1
+    region: us-east-2
     strategy: cluster  
 ---
 apiVersion: iam.aws.upbound.io/v1beta1
@@ -290,7 +290,7 @@ metadata:
   name: sample
 spec:
   forProvider:
-    region: eu-west-1
+    region: us-east-2
     vpcIdSelector:
       matchLabels:
         testing.upbound.io/example-name: sample  
@@ -306,7 +306,7 @@ metadata:
 spec:
   forProvider:
     cidrBlock: 10.1.1.0/24
-    region: eu-west-1
+    region: us-east-2
     vpcIdSelector:
       matchLabels:
         testing.upbound.io/example-name: sample  
@@ -322,4 +322,4 @@ metadata:
 spec:
   forProvider:
     cidrBlock: 10.1.0.0/16
-    region: eu-west-1 
+    region: us-east-2 

--- a/go.mod
+++ b/go.mod
@@ -442,3 +442,5 @@ require (
 replace github.com/hashicorp/terraform-plugin-log => github.com/gdavison/terraform-plugin-log v0.0.0-20230928191232-6c653d8ef8fb
 
 replace github.com/hashicorp/terraform-provider-aws => github.com/upbound/terraform-provider-aws v0.0.0-20250506092832-b90a2e906d79
+
+replace github.com/crossplane/upjet => github.com/turkenf/upjet v0.0.0-20250612105126-656b1c9d10b0

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/aws/smithy-go v1.22.1
 	github.com/crossplane/crossplane-runtime v1.17.0
 	github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79
-	github.com/crossplane/upjet v1.5.1
+	github.com/crossplane/upjet v1.5.2-0.20250612145416-771188e36da2
 	github.com/go-ini/ini v1.46.0
 	github.com/google/go-cmp v0.6.0
 	github.com/hashicorp/aws-sdk-go-base/v2 v2.0.0-beta.59
@@ -442,5 +442,3 @@ require (
 replace github.com/hashicorp/terraform-plugin-log => github.com/gdavison/terraform-plugin-log v0.0.0-20230928191232-6c653d8ef8fb
 
 replace github.com/hashicorp/terraform-provider-aws => github.com/upbound/terraform-provider-aws v0.0.0-20250506092832-b90a2e906d79
-
-replace github.com/crossplane/upjet => github.com/turkenf/upjet v0.0.0-20250612105126-656b1c9d10b0

--- a/go.sum
+++ b/go.sum
@@ -580,8 +580,6 @@ github.com/crossplane/crossplane-runtime v1.17.0 h1:y+GvxPT1M9s8BKt2AeZJdd2d6pg2
 github.com/crossplane/crossplane-runtime v1.17.0/go.mod h1:vtglCrnnbq2HurAk9yLHa4qS0bbnCxaKL7C21cQcB/0=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79 h1:HigXs5tEQxWz0fcj8hzbU2UAZgEM7wPe0XRFOsrtF8Y=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79/go.mod h1:+e4OaFlOcmr0JvINHl/yvEYBrZawzTgj6pQumOH1SS0=
-github.com/crossplane/upjet v1.5.1 h1:CuVYThNa6mxenXZ1O/bHEiTYnMWrY2KiAurCJiqELvA=
-github.com/crossplane/upjet v1.5.1/go.mod h1:F2u9XwKNzxM+myfS1Opjnc6a5E1N2PC7Mytbkavawvs=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/dave/jennifer v1.4.1 h1:XyqG6cn5RQsTj3qlWQTKlRGAyrTcsk1kUmWdZBzRjDw=
@@ -868,6 +866,8 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
+github.com/turkenf/upjet v0.0.0-20250612105126-656b1c9d10b0 h1:Tc3oe4i2WeXkExz93HJNNUxM0FUJvyZp3sdNjUhjmL4=
+github.com/turkenf/upjet v0.0.0-20250612105126-656b1c9d10b0/go.mod h1:F2u9XwKNzxM+myfS1Opjnc6a5E1N2PC7Mytbkavawvs=
 github.com/upbound/terraform-provider-aws v0.0.0-20250506092832-b90a2e906d79 h1:hgkIgehWzuWaZ5jIT/zQqN2zdPZEGjEO7jVQdArb/b0=
 github.com/upbound/terraform-provider-aws v0.0.0-20250506092832-b90a2e906d79/go.mod h1:B7SdSRSmPRFkPECx8/XlhVDovQuzdg34iQzuLUFqgs8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/go.sum
+++ b/go.sum
@@ -580,6 +580,8 @@ github.com/crossplane/crossplane-runtime v1.17.0 h1:y+GvxPT1M9s8BKt2AeZJdd2d6pg2
 github.com/crossplane/crossplane-runtime v1.17.0/go.mod h1:vtglCrnnbq2HurAk9yLHa4qS0bbnCxaKL7C21cQcB/0=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79 h1:HigXs5tEQxWz0fcj8hzbU2UAZgEM7wPe0XRFOsrtF8Y=
 github.com/crossplane/crossplane-tools v0.0.0-20230925130601-628280f8bf79/go.mod h1:+e4OaFlOcmr0JvINHl/yvEYBrZawzTgj6pQumOH1SS0=
+github.com/crossplane/upjet v1.5.2-0.20250612145416-771188e36da2 h1:IgIHdwz+dEc4YAsPKwZZcPVT5bESMTJyjI/zQ/Jeb9s=
+github.com/crossplane/upjet v1.5.2-0.20250612145416-771188e36da2/go.mod h1:F2u9XwKNzxM+myfS1Opjnc6a5E1N2PC7Mytbkavawvs=
 github.com/cyphar/filepath-securejoin v0.2.4 h1:Ugdm7cg7i6ZK6x3xDF1oEu1nfkyfH53EtKeQYTC3kyg=
 github.com/cyphar/filepath-securejoin v0.2.4/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
 github.com/dave/jennifer v1.4.1 h1:XyqG6cn5RQsTj3qlWQTKlRGAyrTcsk1kUmWdZBzRjDw=
@@ -866,8 +868,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=
 github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
-github.com/turkenf/upjet v0.0.0-20250612105126-656b1c9d10b0 h1:Tc3oe4i2WeXkExz93HJNNUxM0FUJvyZp3sdNjUhjmL4=
-github.com/turkenf/upjet v0.0.0-20250612105126-656b1c9d10b0/go.mod h1:F2u9XwKNzxM+myfS1Opjnc6a5E1N2PC7Mytbkavawvs=
 github.com/upbound/terraform-provider-aws v0.0.0-20250506092832-b90a2e906d79 h1:hgkIgehWzuWaZ5jIT/zQqN2zdPZEGjEO7jVQdArb/b0=
 github.com/upbound/terraform-provider-aws v0.0.0-20250506092832-b90a2e906d79/go.mod h1:B7SdSRSmPRFkPECx8/XlhVDovQuzdg34iQzuLUFqgs8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

This PR bumps the upjet to the commit `771188e` in the r[elease-1.5](https://github.com/crossplane/upjet/commits/release-1.5/) branch to consume the fix introduced in this PR: https://github.com/crossplane/upjet/pull/503

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

- [Uptest-examples/apigateway/v1beta1/account.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15609316294)
- [Uptest-examples/appconfig/v1beta1/environment.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15609798811)
- [Uptest-examples/codeguruprofiler/v1beta1/profilinggroup.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15609882703)
- [Uptest-examples/cognitoidp/v1beta1/userpoolclient.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15609950056)
- [Uptest-examples/dynamodb/v1beta1/resourcepolicy.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15609929091)
- [Uptest-examples/ec2/v1beta1/securitygroupegressrule.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15609979236)
- [Uptest-examples/ec2/v1beta1/securitygroupingressrule.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15609981018)
- [Uptest-examples/eks/v1beta1/podidentityassociation.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15610025478)
- [Uptest-examples/elasticache/v1beta1/serverlesscache.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15610012224)
- [Uptest-examples/s3/v1beta1/directorybucket.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15610041113)
- [Uptest-examples/batch/v1beta1/jobqueue.yaml](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/15610966227)

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
