### PR TITLE
add basic plumbing for provider startup checks

### DIFF
--- a/cmd/provider/accessanalyzer/zz_main.go
+++ b/cmd/provider/accessanalyzer/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/account/zz_main.go
+++ b/cmd/provider/account/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/acm/zz_main.go
+++ b/cmd/provider/acm/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/acmpca/zz_main.go
+++ b/cmd/provider/acmpca/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/amp/zz_main.go
+++ b/cmd/provider/amp/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/amplify/zz_main.go
+++ b/cmd/provider/amplify/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/apigateway/zz_main.go
+++ b/cmd/provider/apigateway/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/apigatewayv2/zz_main.go
+++ b/cmd/provider/apigatewayv2/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/appautoscaling/zz_main.go
+++ b/cmd/provider/appautoscaling/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/appconfig/zz_main.go
+++ b/cmd/provider/appconfig/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/appflow/zz_main.go
+++ b/cmd/provider/appflow/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/appintegrations/zz_main.go
+++ b/cmd/provider/appintegrations/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/applicationinsights/zz_main.go
+++ b/cmd/provider/applicationinsights/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/appmesh/zz_main.go
+++ b/cmd/provider/appmesh/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/apprunner/zz_main.go
+++ b/cmd/provider/apprunner/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/appstream/zz_main.go
+++ b/cmd/provider/appstream/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/appsync/zz_main.go
+++ b/cmd/provider/appsync/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/athena/zz_main.go
+++ b/cmd/provider/athena/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/autoscaling/zz_main.go
+++ b/cmd/provider/autoscaling/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/autoscalingplans/zz_main.go
+++ b/cmd/provider/autoscalingplans/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/backup/zz_main.go
+++ b/cmd/provider/backup/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/batch/zz_main.go
+++ b/cmd/provider/batch/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/bedrock/zz_main.go
+++ b/cmd/provider/bedrock/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/bedrockagent/zz_main.go
+++ b/cmd/provider/bedrockagent/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/budgets/zz_main.go
+++ b/cmd/provider/budgets/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/ce/zz_main.go
+++ b/cmd/provider/ce/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/chime/zz_main.go
+++ b/cmd/provider/chime/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/cloud9/zz_main.go
+++ b/cmd/provider/cloud9/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/cloudcontrol/zz_main.go
+++ b/cmd/provider/cloudcontrol/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/cloudformation/zz_main.go
+++ b/cmd/provider/cloudformation/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/cloudfront/zz_main.go
+++ b/cmd/provider/cloudfront/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/cloudsearch/zz_main.go
+++ b/cmd/provider/cloudsearch/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/cloudtrail/zz_main.go
+++ b/cmd/provider/cloudtrail/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/cloudwatch/zz_main.go
+++ b/cmd/provider/cloudwatch/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/cloudwatchevents/zz_main.go
+++ b/cmd/provider/cloudwatchevents/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/cloudwatchlogs/zz_main.go
+++ b/cmd/provider/cloudwatchlogs/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/codeartifact/zz_main.go
+++ b/cmd/provider/codeartifact/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/codecommit/zz_main.go
+++ b/cmd/provider/codecommit/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/codeguruprofiler/zz_main.go
+++ b/cmd/provider/codeguruprofiler/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/codepipeline/zz_main.go
+++ b/cmd/provider/codepipeline/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/codestarconnections/zz_main.go
+++ b/cmd/provider/codestarconnections/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/codestarnotifications/zz_main.go
+++ b/cmd/provider/codestarnotifications/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/cognitoidentity/zz_main.go
+++ b/cmd/provider/cognitoidentity/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/cognitoidp/zz_main.go
+++ b/cmd/provider/cognitoidp/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/config/zz_main.go
+++ b/cmd/provider/config/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/configservice/zz_main.go
+++ b/cmd/provider/configservice/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/connect/zz_main.go
+++ b/cmd/provider/connect/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/cur/zz_main.go
+++ b/cmd/provider/cur/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/dataexchange/zz_main.go
+++ b/cmd/provider/dataexchange/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/datapipeline/zz_main.go
+++ b/cmd/provider/datapipeline/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/datasync/zz_main.go
+++ b/cmd/provider/datasync/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/dax/zz_main.go
+++ b/cmd/provider/dax/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/deploy/zz_main.go
+++ b/cmd/provider/deploy/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/detective/zz_main.go
+++ b/cmd/provider/detective/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/devicefarm/zz_main.go
+++ b/cmd/provider/devicefarm/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/directconnect/zz_main.go
+++ b/cmd/provider/directconnect/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/dlm/zz_main.go
+++ b/cmd/provider/dlm/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/dms/zz_main.go
+++ b/cmd/provider/dms/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/docdb/zz_main.go
+++ b/cmd/provider/docdb/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/ds/zz_main.go
+++ b/cmd/provider/ds/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/dynamodb/zz_main.go
+++ b/cmd/provider/dynamodb/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/ec2/zz_main.go
+++ b/cmd/provider/ec2/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/ecr/zz_main.go
+++ b/cmd/provider/ecr/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/ecrpublic/zz_main.go
+++ b/cmd/provider/ecrpublic/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/ecs/zz_main.go
+++ b/cmd/provider/ecs/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/efs/zz_main.go
+++ b/cmd/provider/efs/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/eks/zz_main.go
+++ b/cmd/provider/eks/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/elasticache/zz_main.go
+++ b/cmd/provider/elasticache/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/elasticbeanstalk/zz_main.go
+++ b/cmd/provider/elasticbeanstalk/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/elasticsearch/zz_main.go
+++ b/cmd/provider/elasticsearch/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/elastictranscoder/zz_main.go
+++ b/cmd/provider/elastictranscoder/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/elb/zz_main.go
+++ b/cmd/provider/elb/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/elbv2/zz_main.go
+++ b/cmd/provider/elbv2/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/emr/zz_main.go
+++ b/cmd/provider/emr/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/emrserverless/zz_main.go
+++ b/cmd/provider/emrserverless/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/evidently/zz_main.go
+++ b/cmd/provider/evidently/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/firehose/zz_main.go
+++ b/cmd/provider/firehose/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/fis/zz_main.go
+++ b/cmd/provider/fis/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/fsx/zz_main.go
+++ b/cmd/provider/fsx/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/gamelift/zz_main.go
+++ b/cmd/provider/gamelift/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/glacier/zz_main.go
+++ b/cmd/provider/glacier/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/globalaccelerator/zz_main.go
+++ b/cmd/provider/globalaccelerator/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/glue/zz_main.go
+++ b/cmd/provider/glue/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/grafana/zz_main.go
+++ b/cmd/provider/grafana/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/guardduty/zz_main.go
+++ b/cmd/provider/guardduty/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/iam/zz_main.go
+++ b/cmd/provider/iam/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/identitystore/zz_main.go
+++ b/cmd/provider/identitystore/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/imagebuilder/zz_main.go
+++ b/cmd/provider/imagebuilder/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/inspector/zz_main.go
+++ b/cmd/provider/inspector/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/inspector2/zz_main.go
+++ b/cmd/provider/inspector2/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/iot/zz_main.go
+++ b/cmd/provider/iot/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/ivs/zz_main.go
+++ b/cmd/provider/ivs/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/kafka/zz_main.go
+++ b/cmd/provider/kafka/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/kafkaconnect/zz_main.go
+++ b/cmd/provider/kafkaconnect/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/kendra/zz_main.go
+++ b/cmd/provider/kendra/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/keyspaces/zz_main.go
+++ b/cmd/provider/keyspaces/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/kinesis/zz_main.go
+++ b/cmd/provider/kinesis/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/kinesisanalytics/zz_main.go
+++ b/cmd/provider/kinesisanalytics/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/kinesisanalyticsv2/zz_main.go
+++ b/cmd/provider/kinesisanalyticsv2/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/kinesisvideo/zz_main.go
+++ b/cmd/provider/kinesisvideo/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/kms/zz_main.go
+++ b/cmd/provider/kms/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/lakeformation/zz_main.go
+++ b/cmd/provider/lakeformation/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/lambda/zz_main.go
+++ b/cmd/provider/lambda/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/lexmodels/zz_main.go
+++ b/cmd/provider/lexmodels/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/licensemanager/zz_main.go
+++ b/cmd/provider/licensemanager/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/lightsail/zz_main.go
+++ b/cmd/provider/lightsail/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/location/zz_main.go
+++ b/cmd/provider/location/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/macie2/zz_main.go
+++ b/cmd/provider/macie2/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/mediaconvert/zz_main.go
+++ b/cmd/provider/mediaconvert/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/medialive/zz_main.go
+++ b/cmd/provider/medialive/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/mediapackage/zz_main.go
+++ b/cmd/provider/mediapackage/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/mediastore/zz_main.go
+++ b/cmd/provider/mediastore/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/memorydb/zz_main.go
+++ b/cmd/provider/memorydb/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/monolith/zz_main.go
+++ b/cmd/provider/monolith/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/mq/zz_main.go
+++ b/cmd/provider/mq/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/mwaa/zz_main.go
+++ b/cmd/provider/mwaa/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/neptune/zz_main.go
+++ b/cmd/provider/neptune/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/networkfirewall/zz_main.go
+++ b/cmd/provider/networkfirewall/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/networkmanager/zz_main.go
+++ b/cmd/provider/networkmanager/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/opensearch/zz_main.go
+++ b/cmd/provider/opensearch/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/opensearchserverless/zz_main.go
+++ b/cmd/provider/opensearchserverless/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/opsworks/zz_main.go
+++ b/cmd/provider/opsworks/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/organizations/zz_main.go
+++ b/cmd/provider/organizations/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/osis/zz_main.go
+++ b/cmd/provider/osis/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/pinpoint/zz_main.go
+++ b/cmd/provider/pinpoint/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/pipes/zz_main.go
+++ b/cmd/provider/pipes/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/qldb/zz_main.go
+++ b/cmd/provider/qldb/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/quicksight/zz_main.go
+++ b/cmd/provider/quicksight/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/ram/zz_main.go
+++ b/cmd/provider/ram/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/rds/zz_main.go
+++ b/cmd/provider/rds/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/redshift/zz_main.go
+++ b/cmd/provider/redshift/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/redshiftserverless/zz_main.go
+++ b/cmd/provider/redshiftserverless/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/resourcegroups/zz_main.go
+++ b/cmd/provider/resourcegroups/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/rolesanywhere/zz_main.go
+++ b/cmd/provider/rolesanywhere/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/route53/zz_main.go
+++ b/cmd/provider/route53/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/route53recoverycontrolconfig/zz_main.go
+++ b/cmd/provider/route53recoverycontrolconfig/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/route53recoveryreadiness/zz_main.go
+++ b/cmd/provider/route53recoveryreadiness/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/route53resolver/zz_main.go
+++ b/cmd/provider/route53resolver/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/rum/zz_main.go
+++ b/cmd/provider/rum/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/s3/zz_main.go
+++ b/cmd/provider/s3/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/s3control/zz_main.go
+++ b/cmd/provider/s3control/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/sagemaker/zz_main.go
+++ b/cmd/provider/sagemaker/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/scheduler/zz_main.go
+++ b/cmd/provider/scheduler/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/schemas/zz_main.go
+++ b/cmd/provider/schemas/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/secretsmanager/zz_main.go
+++ b/cmd/provider/secretsmanager/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/securityhub/zz_main.go
+++ b/cmd/provider/securityhub/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/serverlessrepo/zz_main.go
+++ b/cmd/provider/serverlessrepo/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/servicecatalog/zz_main.go
+++ b/cmd/provider/servicecatalog/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/servicediscovery/zz_main.go
+++ b/cmd/provider/servicediscovery/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/servicequotas/zz_main.go
+++ b/cmd/provider/servicequotas/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/ses/zz_main.go
+++ b/cmd/provider/ses/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/sesv2/zz_main.go
+++ b/cmd/provider/sesv2/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/sfn/zz_main.go
+++ b/cmd/provider/sfn/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/signer/zz_main.go
+++ b/cmd/provider/signer/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/simpledb/zz_main.go
+++ b/cmd/provider/simpledb/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/sns/zz_main.go
+++ b/cmd/provider/sns/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/sqs/zz_main.go
+++ b/cmd/provider/sqs/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/ssm/zz_main.go
+++ b/cmd/provider/ssm/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/ssoadmin/zz_main.go
+++ b/cmd/provider/ssoadmin/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/swf/zz_main.go
+++ b/cmd/provider/swf/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/timestreamwrite/zz_main.go
+++ b/cmd/provider/timestreamwrite/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/transcribe/zz_main.go
+++ b/cmd/provider/transcribe/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/transfer/zz_main.go
+++ b/cmd/provider/transfer/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/vpc/zz_main.go
+++ b/cmd/provider/vpc/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/vpclattice/zz_main.go
+++ b/cmd/provider/vpclattice/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/waf/zz_main.go
+++ b/cmd/provider/waf/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/wafregional/zz_main.go
+++ b/cmd/provider/wafregional/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/wafv2/zz_main.go
+++ b/cmd/provider/wafv2/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/workspaces/zz_main.go
+++ b/cmd/provider/workspaces/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/cmd/provider/xray/zz_main.go
+++ b/cmd/provider/xray/zz_main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/hack/main.go.tmpl
+++ b/hack/main.go.tmpl
@@ -42,6 +42,7 @@ import (
 	"github.com/upbound/provider-aws/apis/v1alpha1"
 	"github.com/upbound/provider-aws/config"
 	resolverapis "github.com/upbound/provider-aws/internal/apis"
+	"github.com/upbound/provider-aws/internal/bootcheck"
 	"github.com/upbound/provider-aws/internal/clients"
 	"github.com/upbound/provider-aws/internal/controller"
 	"github.com/upbound/provider-aws/internal/features"
@@ -60,6 +61,13 @@ func deprecationAction(flagName string) kingpin.Action {
 		_, err := fmt.Fprintf(os.Stderr, "warning: Command-line flag %q is deprecated and no longer used. It will be removed in a future release. Please remove it from all of your configurations (ControllerConfigs, etc.).\n", flagName)
 		kingpin.FatalIfError(err, "Failed to print the deprecation notice.")
 		return nil
+	}
+}
+
+func init() {
+	err := bootcheck.CheckEnv()
+	if err != nil {
+		log.Fatalf("bootcheck failed. provider will not be started: %v", err)
 	}
 }
 

--- a/internal/bootcheck/default.go
+++ b/internal/bootcheck/default.go
@@ -1,0 +1,10 @@
+//go:build !custombootcheck
+// +build !custombootcheck
+
+package bootcheck
+
+func CheckEnv() error {
+	// No-op by default. Use build tags for build-time isolation of custom preflight checks.
+	// Ensure to update the build tags on L1-L2 so that they are mutually exclusive across implementations.
+	return nil
+}

--- a/internal/bootcheck/default.go
+++ b/internal/bootcheck/default.go
@@ -1,6 +1,10 @@
 //go:build !custombootcheck
 // +build !custombootcheck
 
+// SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package bootcheck
 
 func CheckEnv() error {


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

This PR proposes a simple approach to enable custom startup checks on the provider by updating the main.go.tmpl. As a concrete example, users may run their workloads in highly regulated environments where the provider should not start if the environment is not properly configured.

This implements the default path, which is a no-op. It uses a combination of an `init()` hook and [go build tags](https://pkg.go.dev/go/build#hdr-Build_Constraints) to:

- minimize code branching (build-time isolation)
- ensure critical checks run before anything else (fail fast)
- not require access to additional flags, env, or setup

A (simplified) example of an alternative implementation is building images with a compliance check (e.g. running in a FIPS-enabled host). What that would look like is:

- add `internal/bootcheck/fips.go`
   - add the build tags and adjust the default as needed.
    ```
         //go:build fips
         // +build fips
    ```
- build the images as before with `GO_TAGS=fips` to produce images targeting that specific compliance check.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [ ] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

Locally building and installing the xpkg.

[contribution process]: https://git.io/fj2m9
