### PR TITLE
fix(fsx): ignore DiskIopsConfiguration in late initialization to prevent conflicts

### DIFF
--- a/apis/cluster/fsx/v1beta1/zz_ontapfilesystem_terraformed.go
+++ b/apis/cluster/fsx/v1beta1/zz_ontapfilesystem_terraformed.go
@@ -118,6 +118,9 @@ func (tr *OntapFileSystem) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	// This is a manual change as adding the ignore in config.go only affects the latest version
+	// and using the newer version will have a performance impact
+	opts = append(opts, resource.WithNameFilter("DiskIopsConfiguration"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/cluster/fsx/v1beta2/zz_ontapfilesystem_terraformed.go
+++ b/apis/cluster/fsx/v1beta2/zz_ontapfilesystem_terraformed.go
@@ -118,6 +118,7 @@ func (tr *OntapFileSystem) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("DiskIopsConfiguration"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/fsx/v1beta1/zz_ontapfilesystem_terraformed.go
+++ b/apis/namespaced/fsx/v1beta1/zz_ontapfilesystem_terraformed.go
@@ -118,6 +118,7 @@ func (tr *OntapFileSystem) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("DiskIopsConfiguration"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/cluster/fsx/config.go
+++ b/config/cluster/fsx/config.go
@@ -18,4 +18,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			Extractor:     common.PathARNExtractor,
 		}
 	})
+	p.AddResourceConfigurator("aws_fsx_ontap_file_system", func(r *config.Resource) {
+		r.LateInitializer.IgnoredFields = []string{"disk_iops_configuration"}
+	})
 }

--- a/config/namespaced/fsx/config.go
+++ b/config/namespaced/fsx/config.go
@@ -18,4 +18,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			Extractor:     common.PathARNExtractor,
 		}
 	})
+	p.AddResourceConfigurator("aws_fsx_ontap_file_system", func(r *config.Resource) {
+		r.LateInitializer.IgnoredFields = []string{"disk_iops_configuration"}
+	})
 }


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

## Summary

  Fix FSX ONTAP filesystem update failures caused by IOPS configuration conflicts during storage capacity updates.

## Problem

  When attempting to increase storage capacity on FSX ONTAP filesystems using Crossplane, operations were failing with the error:
  Warning CannotUpdateExternalResource: async update failed: failed to update the resource: BadRequest: Invalid DiskIopsConfiguration provided. IOPS cannot be set with AUTOMATIC mode.

  This occurred because the late initialization process was including DiskIopsConfiguration fields that conflict with AWS FSX's AUTOMATIC IOPS mode during updates.

##  Solution

  - Added DiskIopsConfiguration to the ignored fields list in late initialization for both v1beta1 and v1beta2 API versions
  - Updated the FSX resource configurator to explicitly ignore disk_iops_configuration during late initialization
  - Applied manual fixes to both API versions to ensure backward compatibility without requiring version upgrades

Fixes #1823

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [ ] Not made any manual changes to generated files, and verified this with `make check-diff`.
`make check-diff` was fine but i communicated with @ulucinar which confirmed that there was no other way than to add a manual line to a previously generated file

### How has this code been tested

Applied this resource
```
apiVersion: fsx.aws.upbound.io/v1beta2
kind: OntapFileSystem
metadata:
  name: test
spec:
  deletionPolicy: Delete
  forProvider:
    automaticBackupRetentionDays: 0
    deploymentType: SINGLE_AZ_1
    preferredSubnetId: subnet-09824ef9e60e4d73e
    subnetIds:
     - subnet-09824ef9e60e4d73e
    region: us-west-2
    storageCapacity: 1024
    storageType: SSD
    throughputCapacity: 128
    throughputCapacityPerHaPair: 128
```

then changed its `storageCapacity` to `2048`, observed healthy resource

```
apiVersion: fsx.aws.upbound.io/v1beta2
kind: OntapFileSystem
metadata:
  annotations:
    crossplane.io/external-create-pending: "2025-07-27T20:45:36+02:00"
    crossplane.io/external-create-succeeded: "2025-07-27T20:46:35+02:00"
    crossplane.io/external-name: fs-01f98c9b513c69fb4
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"fsx.aws.upbound.io/v1beta2","kind":"OntapFileSystem","metadata":{"annotations":{},"name":"test"},"spec":{"deletionPolicy":"Delete","forProvider":{"automaticBackupRetentionDays":0,"deploymentType":"SINGLE_AZ_1","preferredSubnetId":"subnet-09824ef9e60e4d73e","region":"us-west-2","storageCapacity":1024,"storageType":"SSD","subnetIds":["subnet-09824ef9e60e4d73e"],"throughputCapacity":128,"throughputCapacityPerHaPair":128}}}
    test: Sun Jul 27 08:52:10 PM CEST 2025
  creationTimestamp: "2025-07-27T18:43:05Z"
  finalizers:
  - finalizer.managedresource.crossplane.io
  generation: 16
  name: test
  resourceVersion: "111649"
  uid: 44a643da-c3b5-4b8e-b1cb-2ad65222d86f
spec:
  deletionPolicy: Delete
  forProvider:
    automaticBackupRetentionDays: 0
    deploymentType: SINGLE_AZ_1
    haPairs: 1
    kmsKeyId: arn:aws:kms:us-west-2:609897127049:key/dc89f1c2-3a25-40be-b61f-04142453e193
    preferredSubnetId: subnet-09824ef9e60e4d73e
    region: us-west-2
    storageCapacity: 4096
    storageType: SSD
    subnetIds:
    - subnet-09824ef9e60e4d73e
    tags:
      crossplane-kind: ontapfilesystem.fsx.aws.upbound.io
      crossplane-name: test
      crossplane-providerconfig: default
    throughputCapacity: 128
    throughputCapacityPerHaPair: 128
    weeklyMaintenanceStartTime: "4:07:30"
  initProvider: {}
  managementPolicies:
  - '*'
  providerConfigRef:
    name: default
status:
  atProvider:
    arn: arn:aws:fsx:us-west-2:609897127049:file-system/fs-01f98c9b513c69fb4
    automaticBackupRetentionDays: 0
    dailyAutomaticBackupStartTime: ""
    deploymentType: SINGLE_AZ_1
    diskIopsConfiguration:
      iops: 12288
      mode: AUTOMATIC
    dnsName: ""
    endpointIpAddressRange: ""
    endpoints:
    - intercluster:
      - dnsName: intercluster.fs-01f98c9b513c69fb4.fsx.us-west-2.amazonaws.com
        ipAddresses:
        - 192.168.135.95
        - 192.168.181.166
      management:
      - dnsName: management.fs-01f98c9b513c69fb4.fsx.us-west-2.amazonaws.com
        ipAddresses:
        - 192.168.146.176
    haPairs: 1
    id: fs-01f98c9b513c69fb4
    kmsKeyId: arn:aws:kms:us-west-2:609897127049:key/dc89f1c2-3a25-40be-b61f-04142453e193
    networkInterfaceIds:
    - eni-036e2bcb02173c0a1
    - eni-0917ddd960cd98e7d
    ownerId: "609897127049"
    preferredSubnetId: subnet-09824ef9e60e4d73e
    storageCapacity: 4096
    storageType: SSD
    subnetIds:
    - subnet-09824ef9e60e4d73e
    tags:
      crossplane-kind: ontapfilesystem.fsx.aws.upbound.io
      crossplane-name: test
      crossplane-providerconfig: default
    tagsAll:
      crossplane-kind: ontapfilesystem.fsx.aws.upbound.io
      crossplane-name: test
      crossplane-providerconfig: default
    throughputCapacity: 128
    throughputCapacityPerHaPair: 128
    vpcId: vpc-04fc046edd23d0b79
    weeklyMaintenanceStartTime: "4:07:30"
  conditions:
  - lastTransitionTime: "2025-07-27T19:35:19Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2025-07-28T13:53:10Z"
    observedGeneration: 16
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  - lastTransitionTime: "2025-07-27T19:04:13Z"
    reason: Success
    status: "True"
    type: LastAsyncOperation
```

Applied this resource with explicit iops configuration:
```
apiVersion: fsx.aws.upbound.io/v1beta2
kind: OntapFileSystem
metadata:
  name: test-old
spec:
  deletionPolicy: Delete
  forProvider:
    diskIopsConfiguration:
      iops: 20000
      mode: USER_PROVISIONED
    automaticBackupRetentionDays: 0
    deploymentType: SINGLE_AZ_1
    preferredSubnetId: subnet-09824ef9e60e4d73e
    subnetIds:
     - subnet-09824ef9e60e4d73e
    region: us-west-2
    storageCapacity: 1024
    storageType: SSD
    throughputCapacity: 128
    throughputCapacityPerHaPair: 128
```

Observed resource becoming ready and synced
```
apiVersion: fsx.aws.upbound.io/v1beta2
kind: OntapFileSystem
metadata:
  annotations:
    crossplane.io/external-create-pending: "2025-07-28T14:52:20Z"
    crossplane.io/external-create-succeeded: "2025-07-28T14:52:20Z"
    crossplane.io/external-name: fs-0f9b4074476108013
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"fsx.aws.upbound.io/v1beta2","kind":"OntapFileSystem","metadata":{"annotations":{},"name":"test-old"},"spec":{"deletionPolicy":"Delete","forProvider":{"automaticBackupRetentionDays":0,"deploymentType":"SINGLE_AZ_1","diskIopsConfiguration":{"iops":20000,"mode":"USER_PROVISIONED"},"preferredSubnetId":"subnet-09824ef9e60e4d73e","region":"us-west-2","storageCapacity":1024,"storageType":"SSD","subnetIds":["subnet-09824ef9e60e4d73e"],"throughputCapacity":128,"throughputCapacityPerHaPair":128}}}
  creationTimestamp: "2025-07-28T14:52:20Z"
  finalizers:
  - finalizer.managedresource.crossplane.io
  generation: 3
  name: test-old
  resourceVersion: "263303"
  uid: 35a75e06-94f1-442b-a1ea-94ca6c53bae4
spec:
  deletionPolicy: Delete
  forProvider:
    automaticBackupRetentionDays: 0
    deploymentType: SINGLE_AZ_1
    diskIopsConfiguration:
      iops: 20000
      mode: USER_PROVISIONED
    haPairs: 1
    kmsKeyId: arn:aws:kms:us-west-2:609897127049:key/dc89f1c2-3a25-40be-b61f-04142453e193
    preferredSubnetId: subnet-09824ef9e60e4d73e
    region: us-west-2
    storageCapacity: 1024
    storageType: SSD
    subnetIds:
    - subnet-09824ef9e60e4d73e
    tags:
      crossplane-kind: ontapfilesystem.fsx.aws.upbound.io
      crossplane-name: test-old
      crossplane-providerconfig: default
    throughputCapacity: 128
    throughputCapacityPerHaPair: 128
    weeklyMaintenanceStartTime: "2:12:30"
  initProvider: {}
  managementPolicies:
  - '*'
  providerConfigRef:
    name: default
status:
  atProvider:
    arn: arn:aws:fsx:us-west-2:609897127049:file-system/fs-0f9b4074476108013
    automaticBackupRetentionDays: 0
    dailyAutomaticBackupStartTime: ""
    deploymentType: SINGLE_AZ_1
    diskIopsConfiguration:
      iops: 20000
      mode: USER_PROVISIONED
    dnsName: ""
    endpointIpAddressRange: ""
    endpoints:
    - intercluster:
      - dnsName: intercluster.fs-0f9b4074476108013.fsx.us-west-2.amazonaws.com
        ipAddresses:
        - 192.168.131.153
        - 192.168.186.0
      management:
      - dnsName: management.fs-0f9b4074476108013.fsx.us-west-2.amazonaws.com
        ipAddresses:
        - 192.168.186.127
    haPairs: 1
    id: fs-0f9b4074476108013
    kmsKeyId: arn:aws:kms:us-west-2:609897127049:key/dc89f1c2-3a25-40be-b61f-04142453e193
    networkInterfaceIds:
    - eni-095984150dc7f153e
    - eni-02032ea7582ef13c7
    ownerId: "609897127049"
    preferredSubnetId: subnet-09824ef9e60e4d73e
    storageCapacity: 1024
    storageType: SSD
    subnetIds:
    - subnet-09824ef9e60e4d73e
    tags:
      crossplane-kind: ontapfilesystem.fsx.aws.upbound.io
      crossplane-name: test-old
      crossplane-providerconfig: default
    tagsAll:
      crossplane-kind: ontapfilesystem.fsx.aws.upbound.io
      crossplane-name: test-old
      crossplane-providerconfig: default
    throughputCapacity: 128
    throughputCapacityPerHaPair: 128
    vpcId: vpc-04fc046edd23d0b79
    weeklyMaintenanceStartTime: "2:12:30"
  conditions:
  - lastTransitionTime: "2025-07-28T15:07:47Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2025-07-29T07:48:40Z"
    observedGeneration: 3
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  - lastTransitionTime: "2025-07-28T15:07:44Z"
    reason: Success
    status: "True"
    type: LastAsyncOperation
```

However what i observed is that when i switch from 
```
    diskIopsConfiguration:
      iops: 20000
      mode: USER_PROVISIONED
```
to
```
    diskIopsConfiguration:
      mode: AUTOMATIC
```

I observed 
```
  - lastTransitionTime: "2025-07-30T08:34:39Z"
    message: 'update failed: async update failed: failed to update the resource: [{0
      updating FSx for NetApp ONTAP File System (fs-0f9b4074476108013): operation
      error FSx: UpdateFileSystem, https response error StatusCode: 400, RequestID:
      15fa5003-3f3f-4e74-a182-f87253d7ec28, BadRequest: Invalid DiskIopsConfiguration
      provided. IOPS cannot be set with AUTOMATIC mode.  []}]'
```
However, i see the same behavior on the main branch.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
