### PR TITLE
Update go version to 1.24.6 [Security]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 
 module github.com/upbound/provider-aws
 
-go 1.24.4
+go 1.24.6
 
 require (
 	dario.cat/mergo v1.0.2


### PR DESCRIPTION
### Description of your changes

Update go version to 1.24.6

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
