### PR TITLE
fix: suppress ApplyMethod-only diffs for DB parameter groups

### DIFF
--- a/config/cluster/docdb/config.go
+++ b/config/cluster/docdb/config.go
@@ -7,10 +7,12 @@ package docdb
 import (
 	"github.com/crossplane/upjet/v2/pkg/config"
 	"github.com/crossplane/upjet/v2/pkg/types/comments"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/upbound/provider-aws/v2/config/cluster/common"
+	"github.com/upbound/provider-aws/v2/config/diffutils"
 )
 
 // Configure adds configurations for the docdb group.
@@ -63,6 +65,12 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_docdb_subnet_group", func(r *config.Resource) {
 		r.References["subnet_ids"] = config.Reference{
 			TerraformName: "aws_subnet",
+		}
+	})
+
+	p.AddResourceConfigurator("aws_docdb_cluster_parameter_group", func(r *config.Resource) {
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, s *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			return diffutils.SuppressAWSParameterGroupDiff(r, diff, s)
 		}
 	})
 }

--- a/config/cluster/neptune/config.go
+++ b/config/cluster/neptune/config.go
@@ -6,6 +6,9 @@ package neptune
 
 import (
 	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/upbound/provider-aws/v2/config/diffutils"
 )
 
 // Configure adds configurations for the neptune group
@@ -46,6 +49,16 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		r.UseAsync = true
 		r.References["db_cluster_identifier"] = config.Reference{
 			TerraformName: "aws_neptune_cluster",
+		}
+	})
+	p.AddResourceConfigurator("aws_neptune_parameter_group", func(r *config.Resource) {
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, s *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			return diffutils.SuppressAWSParameterGroupDiff(r, diff, s)
+		}
+	})
+	p.AddResourceConfigurator("aws_neptune_cluster_parameter_group", func(r *config.Resource) {
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, s *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			return diffutils.SuppressAWSParameterGroupDiff(r, diff, s)
 		}
 	})
 }

--- a/config/cluster/rds/config.go
+++ b/config/cluster/rds/config.go
@@ -7,14 +7,14 @@ package rds
 import (
 	"fmt"
 
+	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/crossplane/upjet/v2/pkg/types/comments"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/crossplane/upjet/v2/pkg/config"
-	"github.com/crossplane/upjet/v2/pkg/types/comments"
-
 	"github.com/upbound/provider-aws/v2/config/cluster/common"
 	"github.com/upbound/provider-aws/v2/config/cluster/rds/utils"
+	"github.com/upbound/provider-aws/v2/config/diffutils"
 )
 
 // Configure adds configurations for the rds group.
@@ -262,5 +262,15 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 
 	p.AddResourceConfigurator("aws_db_cluster_snapshot", func(r *config.Resource) {
 		r.UseAsync = true
+	})
+	p.AddResourceConfigurator("aws_db_parameter_group", func(r *config.Resource) {
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, s *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			return diffutils.SuppressAWSParameterGroupDiff(r, diff, s)
+		}
+	})
+	p.AddResourceConfigurator("aws_rds_cluster_parameter_group", func(r *config.Resource) {
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, s *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			return diffutils.SuppressAWSParameterGroupDiff(r, diff, s)
+		}
 	})
 }

--- a/config/diffutils/customdiff.go
+++ b/config/diffutils/customdiff.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: CC0-1.0
+
+package diffutils
+
+import (
+	"strings"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+type awsDBParameter struct {
+	Value       string
+	ApplyMethod string
+	Hash        string
+}
+
+func flattenDBParameterSet(tfList []any) map[string]awsDBParameter {
+	dbParams := make(map[string]awsDBParameter, len(tfList))
+	for _, tfMapRaw := range tfList {
+		tfMap, ok := tfMapRaw.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, ok := tfMap["name"].(string)
+		if !ok || name == "" {
+			continue
+		}
+		dbParam := awsDBParameter{}
+		// Parameter values are case-sensitive, hence stored verbatim.
+		if v, ok := tfMap["value"].(string); ok {
+			dbParam.Value = v
+		}
+		if v, ok := tfMap["apply_method"].(string); ok && v != "" {
+			dbParam.ApplyMethod = strings.ToLower(v)
+		}
+		dbParams[name] = dbParam
+	}
+
+	return dbParams
+}
+
+// SuppressAWSParameterGroupDiff suppresses diff for AWS DB parameter group diff when the diff is
+// only on `ApplyMethod` causing perpetual diff.
+// See https://github.com/hashicorp/terraform-provider-aws/blob/v6.55.0/website/docs/r/db_parameter_group.html.markdown#problematic-plan-changes
+func SuppressAWSParameterGroupDiff(r *config.Resource, diff *terraform.InstanceDiff, s *terraform.InstanceState) (*terraform.InstanceDiff, error) { //nolint:gocyclo // easier to follow as a unit
+	if isNonUpdateDiff(diff, s) {
+		return diff, nil
+	}
+	d, err := schema.InternalMap(r.TerraformResource.Schema).Data(s, diff)
+	if err != nil {
+		return nil, errors.Wrapf(err, "cannot construct diff data")
+	}
+
+	if d.HasChange("parameter") {
+		o, n := d.GetChange("parameter")
+		os, ns := o.(*schema.Set), n.(*schema.Set)
+
+		// no diff suppression when parameters are added or removed
+		if os.Len() != ns.Len() {
+			return diff, nil
+		}
+
+		oldParams := flattenDBParameterSet(os.List())
+		newParams := flattenDBParameterSet(ns.List())
+
+		// check if flattening changes the parameter count, meaning
+		// there are duplicate parameters with same name and different
+		// values/apply-methods. This can be considered as an invalid
+		// configuration.
+		if len(oldParams) != os.Len() || len(newParams) != ns.Len() {
+			// no diff suppression, let other layers reject if needed
+			return diff, nil
+		}
+		for name, newVal := range newParams {
+			oldVal, ok := oldParams[name]
+			if !ok || oldVal.Value != newVal.Value {
+				// Desired config introduced a new parameter,
+				// or value changed for an existing parameter
+				return diff, nil
+			}
+		}
+
+		// At this point, we validated that the diff for all parameters
+		// in `parameter` attribute is apply-method only.
+		// Suppress this diff.
+		for k := range diff.Attributes {
+			if strings.HasPrefix(k, "parameter.") {
+				delete(diff.Attributes, k)
+			}
+		}
+	}
+	return diff, nil
+}
+
+// isNonUpdateDiff is a utility for checking a TF diff & state pair is a non-update,
+// e.g. diff is empty OR is a destroy diff OR creation diff
+func isNonUpdateDiff(diff *terraform.InstanceDiff, s *terraform.InstanceState) bool {
+	return diff == nil || len(diff.Attributes) == 0 || diff.Destroy || s == nil || len(s.Attributes) == 0
+}

--- a/config/diffutils/customdiff_test.go
+++ b/config/diffutils/customdiff_test.go
@@ -1,0 +1,622 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: CC0-1.0
+
+package diffutils
+
+import (
+	"hash/crc32"
+	"strings"
+	"testing"
+
+	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// parameterHash mirrors terraform-provider-aws
+// internal/service/rds.parameterHash, the Set hash function of the
+// `parameter` attribute of aws_db_parameter_group and
+// aws_rds_cluster_parameter_group. It is replicated here because the
+// element identity of the set - and therefore the shape of the diff
+// this package operates on - depends on it: because `apply_method`
+// contributes to the hash, changing only the apply method of a
+// parameter shows up as a removal of one set element plus an addition
+// of another, rather than as an in-place attribute change.
+func parameterHash(v any) int {
+	var str strings.Builder
+	m := v.(map[string]any)
+
+	// Names are hashed lower case to match how the AWS provider stores
+	// them when flattening the API response.
+	str.WriteString(strings.ToLower(m["name"].(string)))
+	str.WriteRune('-')
+	str.WriteString(strings.ToLower(m["apply_method"].(string)))
+	str.WriteRune('-')
+	str.WriteString(m["value"].(string))
+	str.WriteRune('-')
+
+	h := int(crc32.ChecksumIEEE([]byte(str.String())))
+	if h < 0 {
+		h = -h
+	}
+	return h
+}
+
+// parameterGroupSchema mirrors the relevant subset of the
+// aws_db_parameter_group Terraform schema. aws_rds_cluster_parameter_group
+// declares the very same `parameter` attribute.
+func parameterGroupSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"arn": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"description": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+			Default:  "Managed by Terraform",
+		},
+		"family": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"name": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+			ForceNew: true,
+		},
+		"parameter": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"apply_method": {
+						Type:     schema.TypeString,
+						Optional: true,
+						Default:  "immediate",
+					},
+					"name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+					"value": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
+				},
+			},
+			Set: parameterHash,
+		},
+	}
+}
+
+func parameterGroupResource() *config.Resource {
+	return &config.Resource{
+		TerraformResource: &schema.Resource{
+			Schema: parameterGroupSchema(),
+		},
+	}
+}
+
+// param is a shorthand for a single element of the `parameter` set.
+func param(name, value, applyMethod string) map[string]any {
+	return map[string]any{
+		"name":         name,
+		"value":        value,
+		"apply_method": applyMethod,
+	}
+}
+
+// baseAttributes are the non-`parameter` attributes that are held
+// identical between state and config by the test helpers, so that the
+// generated diff only contains what a test case is about.
+func baseAttributes() map[string]any {
+	return map[string]any{
+		"arn":         "arn:aws:rds:us-east-1:123456789012:pg:example",
+		"description": "Managed by Terraform",
+		"family":      "postgres14",
+		"name":        "example",
+	}
+}
+
+// paramGroupState builds an InstanceState the way the Terraform plugin
+// SDK would flatten it, i.e. with `parameter` set elements keyed by
+// their set hash.
+func paramGroupState(t *testing.T, params []any, overrides map[string]any) *terraform.InstanceState {
+	t.Helper()
+	d, err := schema.InternalMap(parameterGroupSchema()).Data(&terraform.InstanceState{ID: "example"}, nil)
+	if err != nil {
+		t.Fatalf("cannot construct resource data for the state: %v", err)
+	}
+	attrs := baseAttributes()
+	for k, v := range overrides {
+		attrs[k] = v
+	}
+	for k, v := range attrs {
+		if err := d.Set(k, v); err != nil {
+			t.Fatalf("cannot set %q in the state: %v", k, err)
+		}
+	}
+	if err := d.Set("parameter", params); err != nil {
+		t.Fatalf("cannot set \"parameter\" in the state: %v", err)
+	}
+	return d.State()
+}
+
+// paramGroupDiff produces a diff between the given state and the given
+// desired configuration using the plugin SDK's own diff machinery, the
+// same way upjet's Terraform plugin SDK external client does before
+// handing the diff to a config.Resource's TerraformCustomDiff.
+func paramGroupDiff(t *testing.T, s *terraform.InstanceState, params []any, overrides map[string]any) *terraform.InstanceDiff {
+	t.Helper()
+	raw := baseAttributes()
+	for k, v := range overrides {
+		raw[k] = v
+	}
+	raw["parameter"] = params
+	diff, err := schema.InternalMap(parameterGroupSchema()).Diff(t.Context(), s, terraform.NewResourceConfigRaw(raw), nil, nil, false)
+	if err != nil {
+		t.Fatalf("cannot construct the instance diff: %v", err)
+	}
+	return diff
+}
+
+// snapshotAttributes dereferences a diff's attributes so that they can
+// be compared after SuppressAWSParameterGroupDiff has mutated the diff
+// in place.
+func snapshotAttributes(diff *terraform.InstanceDiff) map[string]terraform.ResourceAttrDiff {
+	if diff == nil {
+		return nil
+	}
+	snapshot := make(map[string]terraform.ResourceAttrDiff, len(diff.Attributes))
+	for k, v := range diff.Attributes {
+		snapshot[k] = *v
+	}
+	return snapshot
+}
+
+func filterAttributes(attrs map[string]terraform.ResourceAttrDiff, isParameter bool) map[string]terraform.ResourceAttrDiff {
+	filtered := make(map[string]terraform.ResourceAttrDiff, len(attrs))
+	for k, v := range attrs {
+		if strings.HasPrefix(k, "parameter.") == isParameter {
+			filtered[k] = v
+		}
+	}
+	return filtered
+}
+
+func TestSuppressAWSParameterGroupDiff(t *testing.T) {
+	type args struct {
+		// stateParams is the `parameter` set as observed in the
+		// external resource.
+		stateParams []any
+		// configParams is the desired `parameter` set.
+		configParams []any
+		// configOverrides are non-`parameter` attributes that differ
+		// from the state.
+		configOverrides map[string]any
+	}
+	type want struct {
+		// suppressed asserts that all `parameter.*` attributes have
+		// been dropped from the diff. When false, the `parameter.*`
+		// attributes must be left exactly as the plugin SDK
+		// calculated them.
+		suppressed bool
+		// nonParameterAttributes are the diff attribute names that
+		// must survive the call untouched.
+		nonParameterAttributes []string
+	}
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ApplyMethodOnlyChange": {
+			reason: "A diff that only changes the apply method of a parameter should be suppressed.",
+			args: args{
+				stateParams:  []any{param("max_connections", "100", "immediate")},
+				configParams: []any{param("max_connections", "100", "pending-reboot")},
+			},
+			want: want{suppressed: true},
+		},
+		"ApplyMethodOnlyChangeAmongMultipleParameters": {
+			reason: "A diff that only changes the apply method of a subset of the parameters should be suppressed.",
+			args: args{
+				stateParams: []any{
+					param("max_connections", "100", "immediate"),
+					param("log_min_duration_statement", "500", "immediate"),
+					param("work_mem", "4096", "pending-reboot"),
+				},
+				configParams: []any{
+					param("max_connections", "100", "pending-reboot"),
+					param("log_min_duration_statement", "500", "immediate"),
+					param("work_mem", "4096", "immediate"),
+				},
+			},
+			want: want{suppressed: true},
+		},
+		"ApplyMethodOnlyChangeWithOtherAttributeChange": {
+			reason: "Only the parameter diff should be suppressed, the diff of the other attributes should be preserved.",
+			args: args{
+				stateParams:     []any{param("max_connections", "100", "immediate")},
+				configParams:    []any{param("max_connections", "100", "pending-reboot")},
+				configOverrides: map[string]any{"description": "Managed by Crossplane"},
+			},
+			want: want{
+				suppressed:             true,
+				nonParameterAttributes: []string{"description"},
+			},
+		},
+		"ValueChange": {
+			reason: "A parameter value change must not be suppressed, otherwise the update is never applied.",
+			args: args{
+				stateParams:  []any{param("max_connections", "100", "immediate")},
+				configParams: []any{param("max_connections", "200", "immediate")},
+			},
+			want: want{suppressed: false},
+		},
+		"ValueAndApplyMethodChange": {
+			reason: "A parameter value change must not be suppressed even when its apply method changes as well.",
+			args: args{
+				stateParams:  []any{param("max_connections", "100", "immediate")},
+				configParams: []any{param("max_connections", "200", "pending-reboot")},
+			},
+			want: want{suppressed: false},
+		},
+		"ValueChangeOfOneOfManyParameters": {
+			reason: "A single parameter value change must not be suppressed together with the apply method only changes.",
+			args: args{
+				stateParams: []any{
+					param("max_connections", "100", "immediate"),
+					param("work_mem", "4096", "immediate"),
+				},
+				configParams: []any{
+					param("max_connections", "100", "pending-reboot"),
+					param("work_mem", "8192", "immediate"),
+				},
+			},
+			want: want{suppressed: false},
+		},
+		"ParameterAdded": {
+			reason: "Adding a parameter must not be suppressed.",
+			args: args{
+				stateParams: []any{param("max_connections", "100", "immediate")},
+				configParams: []any{
+					param("max_connections", "100", "pending-reboot"),
+					param("work_mem", "4096", "immediate"),
+				},
+			},
+			want: want{suppressed: false},
+		},
+		"ParameterRemoved": {
+			reason: "Removing a parameter must not be suppressed.",
+			args: args{
+				stateParams: []any{
+					param("max_connections", "100", "immediate"),
+					param("work_mem", "4096", "immediate"),
+				},
+				configParams: []any{param("max_connections", "100", "pending-reboot")},
+			},
+			want: want{suppressed: false},
+		},
+		"ParameterReplaced": {
+			reason: "Replacing a parameter with another one must not be suppressed although the parameter count is unchanged.",
+			args: args{
+				stateParams:  []any{param("max_connections", "100", "immediate")},
+				configParams: []any{param("work_mem", "100", "immediate")},
+			},
+			want: want{suppressed: false},
+		},
+		"DuplicateParameterNamesInConfig": {
+			reason: "Duplicate parameter names collapse when flattened, so their apply methods cannot be correlated and the diff must not be suppressed.",
+			args: args{
+				stateParams: []any{
+					param("max_connections", "100", "immediate"),
+					param("max_connections", "200", "immediate"),
+				},
+				configParams: []any{
+					param("max_connections", "100", "pending-reboot"),
+					param("max_connections", "200", "pending-reboot"),
+				},
+			},
+			want: want{suppressed: false},
+		},
+		"DuplicateParameterNamesInState": {
+			reason: "A duplicate parameter name on only one side of the diff must not be suppressed either.",
+			args: args{
+				stateParams: []any{
+					param("max_connections", "100", "immediate"),
+					param("max_connections", "200", "immediate"),
+				},
+				configParams: []any{
+					param("max_connections", "100", "pending-reboot"),
+					param("work_mem", "4096", "pending-reboot"),
+				},
+			},
+			want: want{suppressed: false},
+		},
+		"OnlyOtherAttributeChanged": {
+			reason: "A diff without any parameter change should be returned as is.",
+			args: args{
+				stateParams:     []any{param("max_connections", "100", "immediate")},
+				configParams:    []any{param("max_connections", "100", "immediate")},
+				configOverrides: map[string]any{"description": "Managed by Crossplane"},
+			},
+			want: want{
+				suppressed:             false,
+				nonParameterAttributes: []string{"description"},
+			},
+		},
+		"NoParametersAtAll": {
+			reason: "A diff of a parameter group without any parameter should be returned as is.",
+			args: args{
+				stateParams:     []any{},
+				configParams:    []any{},
+				configOverrides: map[string]any{"description": "Managed by Crossplane"},
+			},
+			want: want{
+				suppressed:             false,
+				nonParameterAttributes: []string{"description"},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			s := paramGroupState(t, tc.args.stateParams, nil)
+			diff := paramGroupDiff(t, s, tc.args.configParams, tc.args.configOverrides)
+			before := snapshotAttributes(diff)
+
+			got, err := SuppressAWSParameterGroupDiff(parameterGroupResource(), diff, s)
+			if err != nil {
+				t.Fatalf("SuppressAWSParameterGroupDiff(...): unexpected error: %v\nReason: %s", err, tc.reason)
+			}
+			if got == nil {
+				t.Fatalf("SuppressAWSParameterGroupDiff(...): unexpected nil diff\nReason: %s", tc.reason)
+			}
+			after := snapshotAttributes(got)
+
+			// The parameter attributes are either all gone, or all
+			// exactly as the plugin SDK calculated them.
+			wantParameters := filterAttributes(before, true)
+			if tc.want.suppressed {
+				if len(wantParameters) == 0 {
+					t.Fatalf("test case is not exercising diff suppression: the calculated diff has no \"parameter.*\" attributes\nReason: %s", tc.reason)
+				}
+				wantParameters = map[string]terraform.ResourceAttrDiff{}
+			}
+			if d := cmp.Diff(wantParameters, filterAttributes(after, true)); d != "" {
+				t.Errorf("SuppressAWSParameterGroupDiff(...): -want \"parameter.*\" diff attributes, +got:\n%s\nReason: %s", d, tc.reason)
+			}
+
+			// Attributes other than the parameter set are never touched.
+			if d := cmp.Diff(filterAttributes(before, false), filterAttributes(after, false)); d != "" {
+				t.Errorf("SuppressAWSParameterGroupDiff(...): -want non-\"parameter.*\" diff attributes, +got:\n%s\nReason: %s", d, tc.reason)
+			}
+			for _, a := range tc.want.nonParameterAttributes {
+				if _, ok := got.Attributes[a]; !ok {
+					t.Errorf("SuppressAWSParameterGroupDiff(...): expected attribute %q to be present in the returned diff\nReason: %s", a, tc.reason)
+				}
+			}
+		})
+	}
+}
+
+func TestSuppressAWSParameterGroupDiffNonUpdateDiff(t *testing.T) {
+	// A diff that would be suppressed if it were an update diff, so
+	// that the non-update short circuits are what is actually under
+	// test.
+	applyMethodOnlyDiff := func(t *testing.T) (*terraform.InstanceState, *terraform.InstanceDiff) {
+		t.Helper()
+		s := paramGroupState(t, []any{param("max_connections", "100", "immediate")}, nil)
+		return s, paramGroupDiff(t, s, []any{param("max_connections", "100", "pending-reboot")}, nil)
+	}
+
+	cases := map[string]struct {
+		reason string
+		mutate func(t *testing.T, s *terraform.InstanceState, diff *terraform.InstanceDiff) (*terraform.InstanceState, *terraform.InstanceDiff)
+	}{
+		"NilDiff": {
+			reason: "A nil diff should be returned as is.",
+			mutate: func(_ *testing.T, s *terraform.InstanceState, _ *terraform.InstanceDiff) (*terraform.InstanceState, *terraform.InstanceDiff) {
+				return s, nil
+			},
+		},
+		"EmptyDiff": {
+			reason: "A diff without any attribute should be returned as is.",
+			mutate: func(_ *testing.T, s *terraform.InstanceState, _ *terraform.InstanceDiff) (*terraform.InstanceState, *terraform.InstanceDiff) {
+				return s, terraform.NewInstanceDiff()
+			},
+		},
+		"DestroyDiff": {
+			reason: "A destroy diff should be returned as is.",
+			mutate: func(_ *testing.T, s *terraform.InstanceState, diff *terraform.InstanceDiff) (*terraform.InstanceState, *terraform.InstanceDiff) {
+				diff.Destroy = true
+				return s, diff
+			},
+		},
+		"NilState": {
+			reason: "A diff with no state, i.e. a creation diff, should be returned as is.",
+			mutate: func(_ *testing.T, _ *terraform.InstanceState, diff *terraform.InstanceDiff) (*terraform.InstanceState, *terraform.InstanceDiff) {
+				return nil, diff
+			},
+		},
+		"EmptyState": {
+			reason: "A diff with an empty state, i.e. a creation diff, should be returned as is.",
+			mutate: func(_ *testing.T, _ *terraform.InstanceState, diff *terraform.InstanceDiff) (*terraform.InstanceState, *terraform.InstanceDiff) {
+				return &terraform.InstanceState{}, diff
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			s, diff := applyMethodOnlyDiff(t)
+			s, diff = tc.mutate(t, s, diff)
+			before := snapshotAttributes(diff)
+
+			got, err := SuppressAWSParameterGroupDiff(parameterGroupResource(), diff, s)
+			if err != nil {
+				t.Fatalf("SuppressAWSParameterGroupDiff(...): unexpected error: %v\nReason: %s", err, tc.reason)
+			}
+			if got != diff {
+				t.Fatalf("SuppressAWSParameterGroupDiff(...): expected the input diff to be returned as is\nReason: %s", tc.reason)
+			}
+			if d := cmp.Diff(before, snapshotAttributes(got)); d != "" {
+				t.Errorf("SuppressAWSParameterGroupDiff(...): -want diff attributes, +got:\n%s\nReason: %s", d, tc.reason)
+			}
+		})
+	}
+}
+
+func TestFlattenDBParameterSet(t *testing.T) {
+	cases := map[string]struct {
+		reason string
+		tfList []any
+		want   map[string]awsDBParameter
+	}{
+		"Empty": {
+			reason: "An empty list should flatten into an empty map.",
+			tfList: []any{},
+			want:   map[string]awsDBParameter{},
+		},
+		"Parameters": {
+			reason: "Every parameter should be keyed by its name.",
+			tfList: []any{
+				param("max_connections", "100", "immediate"),
+				param("work_mem", "4096", "pending-reboot"),
+			},
+			want: map[string]awsDBParameter{
+				"max_connections": {Value: "100", ApplyMethod: "immediate"},
+				"work_mem":        {Value: "4096", ApplyMethod: "pending-reboot"},
+			},
+		},
+		"ApplyMethodLowerCased": {
+			reason: "Apply methods should be normalized to lower case so that they compare case insensitively.",
+			tfList: []any{param("max_connections", "100", "Pending-Reboot")},
+			want: map[string]awsDBParameter{
+				"max_connections": {Value: "100", ApplyMethod: "pending-reboot"},
+			},
+		},
+		"ValueCasePreserved": {
+			reason: "Parameter values are case sensitive, hence they should be preserved verbatim.",
+			tfList: []any{param("log_statement", "DDL", "immediate")},
+			want: map[string]awsDBParameter{
+				"log_statement": {Value: "DDL", ApplyMethod: "immediate"},
+			},
+		},
+		"EmptyApplyMethod": {
+			reason: "An unset apply method should be left empty rather than defaulted, so that it compares equal to another unset one.",
+			tfList: []any{param("max_connections", "100", "")},
+			want: map[string]awsDBParameter{
+				"max_connections": {Value: "100"},
+			},
+		},
+		"NonMapEntrySkipped": {
+			reason: "An entry that is not a map should be skipped instead of panicking.",
+			tfList: []any{"max_connections", param("work_mem", "4096", "immediate")},
+			want: map[string]awsDBParameter{
+				"work_mem": {Value: "4096", ApplyMethod: "immediate"},
+			},
+		},
+		"EmptyNameSkipped": {
+			reason: "An entry without a name cannot be correlated, hence it should be skipped.",
+			tfList: []any{param("", "100", "immediate"), param("work_mem", "4096", "immediate")},
+			want: map[string]awsDBParameter{
+				"work_mem": {Value: "4096", ApplyMethod: "immediate"},
+			},
+		},
+		"MissingNameSkipped": {
+			reason: "An entry with a non-string name should be skipped instead of panicking.",
+			tfList: []any{map[string]any{"value": "100", "apply_method": "immediate"}},
+			want:   map[string]awsDBParameter{},
+		},
+		"MissingValue": {
+			reason: "An entry without a value should be flattened with an empty value instead of panicking.",
+			tfList: []any{map[string]any{"name": "max_connections", "apply_method": "immediate"}},
+			want: map[string]awsDBParameter{
+				"max_connections": {ApplyMethod: "immediate"},
+			},
+		},
+		"DuplicateNamesCollapse": {
+			reason: "Duplicate parameter names collapse into a single entry, which is what lets the caller detect them by comparing the flattened count with the set length.",
+			tfList: []any{
+				param("max_connections", "100", "immediate"),
+				param("max_connections", "200", "immediate"),
+			},
+			want: map[string]awsDBParameter{
+				"max_connections": {Value: "200", ApplyMethod: "immediate"},
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if d := cmp.Diff(tc.want, flattenDBParameterSet(tc.tfList)); d != "" {
+				t.Errorf("flattenDBParameterSet(...): -want, +got:\n%s\nReason: %s", d, tc.reason)
+			}
+		})
+	}
+}
+
+func TestIsNonUpdateDiff(t *testing.T) {
+	attrs := map[string]*terraform.ResourceAttrDiff{"description": {Old: "a", New: "b"}}
+	stateAttrs := map[string]string{"description": "a"}
+
+	cases := map[string]struct {
+		reason string
+		diff   *terraform.InstanceDiff
+		state  *terraform.InstanceState
+		want   bool
+	}{
+		"UpdateDiff": {
+			reason: "A non-empty diff on a non-empty state is an update diff.",
+			diff:   &terraform.InstanceDiff{Attributes: attrs},
+			state:  &terraform.InstanceState{ID: "example", Attributes: stateAttrs},
+			want:   false,
+		},
+		"NilDiff": {
+			reason: "A nil diff is not an update diff.",
+			diff:   nil,
+			state:  &terraform.InstanceState{ID: "example", Attributes: stateAttrs},
+			want:   true,
+		},
+		"EmptyDiff": {
+			reason: "A diff without attributes is not an update diff.",
+			diff:   terraform.NewInstanceDiff(),
+			state:  &terraform.InstanceState{ID: "example", Attributes: stateAttrs},
+			want:   true,
+		},
+		"DestroyDiff": {
+			reason: "A destroy diff is not an update diff.",
+			diff:   &terraform.InstanceDiff{Attributes: attrs, Destroy: true},
+			state:  &terraform.InstanceState{ID: "example", Attributes: stateAttrs},
+			want:   true,
+		},
+		"NilState": {
+			reason: "A diff without a state is a creation diff, not an update diff.",
+			diff:   &terraform.InstanceDiff{Attributes: attrs},
+			state:  nil,
+			want:   true,
+		},
+		"EmptyState": {
+			reason: "A diff on a state without attributes is a creation diff, not an update diff.",
+			diff:   &terraform.InstanceDiff{Attributes: attrs},
+			state:  &terraform.InstanceState{},
+			want:   true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := isNonUpdateDiff(tc.diff, tc.state); got != tc.want {
+				t.Errorf("isNonUpdateDiff(...): want %t, got %t\nReason: %s", tc.want, got, tc.reason)
+			}
+		})
+	}
+}

--- a/config/namespaced/docdb/config.go
+++ b/config/namespaced/docdb/config.go
@@ -7,9 +7,11 @@ package docdb
 import (
 	"github.com/crossplane/upjet/v2/pkg/config"
 	"github.com/crossplane/upjet/v2/pkg/types/comments"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
+	"github.com/upbound/provider-aws/v2/config/diffutils"
 	"github.com/upbound/provider-aws/v2/config/namespaced/common"
 )
 
@@ -63,6 +65,12 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 	p.AddResourceConfigurator("aws_docdb_subnet_group", func(r *config.Resource) {
 		r.References["subnet_ids"] = config.Reference{
 			TerraformName: "aws_subnet",
+		}
+	})
+
+	p.AddResourceConfigurator("aws_docdb_cluster_parameter_group", func(r *config.Resource) {
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, s *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			return diffutils.SuppressAWSParameterGroupDiff(r, diff, s)
 		}
 	})
 }

--- a/config/namespaced/neptune/config.go
+++ b/config/namespaced/neptune/config.go
@@ -6,6 +6,9 @@ package neptune
 
 import (
 	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/upbound/provider-aws/v2/config/diffutils"
 )
 
 // Configure adds configurations for the neptune group
@@ -46,6 +49,16 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		r.UseAsync = true
 		r.References["db_cluster_identifier"] = config.Reference{
 			TerraformName: "aws_neptune_cluster",
+		}
+	})
+	p.AddResourceConfigurator("aws_neptune_parameter_group", func(r *config.Resource) {
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, s *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			return diffutils.SuppressAWSParameterGroupDiff(r, diff, s)
+		}
+	})
+	p.AddResourceConfigurator("aws_neptune_cluster_parameter_group", func(r *config.Resource) {
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, s *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			return diffutils.SuppressAWSParameterGroupDiff(r, diff, s)
 		}
 	})
 }

--- a/config/namespaced/rds/config.go
+++ b/config/namespaced/rds/config.go
@@ -7,12 +7,12 @@ package rds
 import (
 	"fmt"
 
+	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/crossplane/upjet/v2/pkg/types/comments"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
-	"github.com/crossplane/upjet/v2/pkg/config"
-	"github.com/crossplane/upjet/v2/pkg/types/comments"
-
+	"github.com/upbound/provider-aws/v2/config/diffutils"
 	"github.com/upbound/provider-aws/v2/config/namespaced/common"
 	"github.com/upbound/provider-aws/v2/config/namespaced/rds/utils"
 )
@@ -254,5 +254,15 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 
 	p.AddResourceConfigurator("aws_db_cluster_snapshot", func(r *config.Resource) {
 		r.UseAsync = true
+	})
+	p.AddResourceConfigurator("aws_db_parameter_group", func(r *config.Resource) {
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, s *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			return diffutils.SuppressAWSParameterGroupDiff(r, diff, s)
+		}
+	})
+	p.AddResourceConfigurator("aws_rds_cluster_parameter_group", func(r *config.Resource) {
+		r.TerraformCustomDiff = func(diff *terraform.InstanceDiff, s *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+			return diffutils.SuppressAWSParameterGroupDiff(r, diff, s)
+		}
 	})
 }

--- a/examples/docdb/cluster/v1beta1/clusterparametergroup-loopfix.yaml
+++ b/examples/docdb/cluster/v1beta1/clusterparametergroup-loopfix.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+apiVersion: docdb.aws.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: h-docdb50-ttlmonitor-immediate
+spec:
+  forProvider:
+    region: us-west-2
+    family: docdb5.0
+    description: "case H - DocDB cluster param group, default value + immediate"
+    parameter:
+      - name: ttl_monitor
+        value: enabled
+        applyMethod: immediate
+    tags:
+      Test: Uptest

--- a/examples/docdb/namespaced/v1beta1/clusterparametergroup-loopfix.yaml
+++ b/examples/docdb/namespaced/v1beta1/clusterparametergroup-loopfix.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+apiVersion: docdb.aws.m.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: h-docdb50-ttlmonitor-immediate
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: docdb5.0
+    description: "case H - DocDB cluster param group, default value + immediate"
+    parameter:
+      - name: ttl_monitor
+        value: enabled
+        applyMethod: immediate
+    tags:
+      Test: Uptest

--- a/examples/neptune/cluster/v1beta1/cluster-parameter-group-loopfix.yaml
+++ b/examples/neptune/cluster/v1beta1/cluster-parameter-group-loopfix.yaml
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Neptune cluster-level (DB cluster parameter group) cases.
+# Parameter defaults and apply types are from
+# https://docs.aws.amazon.com/neptune/latest/userguide/parameters.html
+# Cluster-level parameters come in both flavors, so both a static and a dynamic
+# parameter are covered here. A changed value on a STATIC parameter has to be
+# requested with pending-reboot, whereas a DYNAMIC one accepts immediate.
+# Note that, unlike aws_rds_cluster_parameter_group, the Neptune cluster
+# parameter group schema defaults applyMethod to pending-reboot, so the loop is
+# triggered by explicitly asking for immediate on a parameter whose value AWS
+# does not have to touch.
+
+# Case O - neptune_enable_audit_log is static and defaults to 0, so the value is a
+# no-op at AWS. AWS ignores the apply method change alone and keeps reporting
+# pending-reboot, which is the perpetual diff.
+apiVersion: neptune.aws.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: o-neptune13-auditlog-immediate
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case O - Neptune cluster param group, static default value + immediate"
+    parameter:
+      - name: neptune_enable_audit_log
+        value: "0"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case P - same churn on a DYNAMIC parameter.
+# neptune_enable_slow_query_log defaults to disabled.
+apiVersion: neptune.aws.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: p-neptune13-slowquerylog-immediate
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case P - Neptune cluster param group, dynamic default value + immediate"
+    parameter:
+      - name: neptune_enable_slow_query_log
+        value: disabled
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case Q - NON-default value on a DYNAMIC parameter, requested with immediate,
+# which AWS accepts for dynamic parameters. The diff must not be suppressed.
+# neptune_slow_query_log_threshold defaults to 5000 ms.
+apiVersion: neptune.aws.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: q-neptune13-slowquerythreshold-immediate
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case Q - Neptune cluster param group, dynamic non-default value + immediate"
+    parameter:
+      - name: neptune_slow_query_log_threshold
+        value: "10000"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case R - NON-default value on a STATIC parameter, requested with pending-reboot.
+# AWS really applies the change, so the diff must not be suppressed.
+apiVersion: neptune.aws.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: r-neptune13-auditlog-pendingreboot
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case R - Neptune cluster param group, static non-default value + pending-reboot"
+    parameter:
+      - name: neptune_enable_audit_log
+        value: "1"
+        applyMethod: pending-reboot
+    tags:
+      Test: Uptest
+---
+# Case S - a loop-triggering parameter and a genuinely changing parameter in the
+# same set. Suppression is all-or-nothing per parameter group, so this asserts
+# that neptune_slow_query_log_threshold is still updated instead of being
+# swallowed together with the neptune_streams apply method churn.
+# neptune_streams is static and defaults to 0.
+apiVersion: neptune.aws.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: s-neptune13-mixed
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case S - Neptune cluster param group, apply method churn + real change"
+    parameter:
+      - name: neptune_streams
+        value: "0"
+        applyMethod: immediate
+      - name: neptune_slow_query_log_threshold
+        value: "10000"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case T - default value, applyMethod omitted. Defaults to pending-reboot for
+# Neptune, which is what AWS reports back, so desired == observed and no diff.
+# neptune_lookup_cache is static and defaults to 0.
+apiVersion: neptune.aws.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: t-neptune13-lookupcache-unset
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case T - Neptune cluster param group, default value, applyMethod omitted"
+    parameter:
+      - name: neptune_lookup_cache
+        value: "0"
+    tags:
+      Test: Uptest

--- a/examples/neptune/cluster/v1beta1/parameter-group-loopfix.yaml
+++ b/examples/neptune/cluster/v1beta1/parameter-group-loopfix.yaml
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Neptune instance-level (DB parameter group) cases.
+# Parameter defaults and apply types are from
+# https://docs.aws.amazon.com/neptune/latest/userguide/parameters.html
+# Every documented instance-level parameter is STATIC, so a changed value has to
+# be requested with pending-reboot - AWS rejects immediate for a static
+# parameter whose value actually changes.
+# Note that, unlike aws_db_parameter_group, the Neptune parameter group schema
+# defaults applyMethod to pending-reboot, so the loop is triggered by explicitly
+# asking for immediate on a parameter whose value AWS does not have to touch.
+
+# Case J - neptune_query_timeout defaults to 120000 ms, so the value is a no-op at
+# AWS. AWS ignores the apply method change alone and keeps reporting
+# pending-reboot, which is the perpetual diff.
+apiVersion: neptune.aws.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: j-neptune13-querytimeout-immediate
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case J - Neptune param group, default value + immediate"
+    parameter:
+      - name: neptune_query_timeout
+        value: "120000"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case K - same as case J with a non-numeric default value.
+# neptune_dfe_query_engine defaults to viaQueryHint.
+apiVersion: neptune.aws.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: k-neptune13-dfequeryengine-immediate
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case K - Neptune param group, default string value + immediate"
+    parameter:
+      - name: neptune_dfe_query_engine
+        value: viaQueryHint
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case L - NON-default value on a static parameter, requested with pending-reboot.
+# AWS really applies the change, so the diff must not be suppressed.
+# neptune_result_cache defaults to 0.
+apiVersion: neptune.aws.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: l-neptune13-resultcache-pendingreboot
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case L - Neptune param group, non-default value + pending-reboot"
+    parameter:
+      - name: neptune_result_cache
+        value: "1"
+        applyMethod: pending-reboot
+    tags:
+      Test: Uptest
+---
+# Case M - default value, applyMethod omitted. Defaults to pending-reboot for
+# Neptune, which is what AWS reports back, so desired == observed and no diff.
+apiVersion: neptune.aws.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: m-neptune13-querytimeout-unset
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case M - Neptune param group, default value, applyMethod omitted"
+    parameter:
+      - name: neptune_query_timeout
+        value: "120000"
+    tags:
+      Test: Uptest
+---
+# Case N - a loop-triggering parameter and a genuinely changing parameter in the
+# same set. Suppression is all-or-nothing per parameter group, so this asserts
+# that neptune_result_cache is still updated instead of being swallowed together
+# with the neptune_query_timeout apply method churn.
+apiVersion: neptune.aws.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: n-neptune13-mixed
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case N - Neptune param group, apply method churn + real change"
+    parameter:
+      - name: neptune_query_timeout
+        value: "120000"
+        applyMethod: immediate
+      - name: neptune_result_cache
+        value: "1"
+        applyMethod: pending-reboot
+    tags:
+      Test: Uptest

--- a/examples/neptune/namespaced/v1beta1/cluster-parameter-group-loopfix.yaml
+++ b/examples/neptune/namespaced/v1beta1/cluster-parameter-group-loopfix.yaml
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Neptune cluster-level (DB cluster parameter group) cases.
+# Parameter defaults and apply types are from
+# https://docs.aws.amazon.com/neptune/latest/userguide/parameters.html
+# Cluster-level parameters come in both flavors, so both a static and a dynamic
+# parameter are covered here. A changed value on a STATIC parameter has to be
+# requested with pending-reboot, whereas a DYNAMIC one accepts immediate.
+# Note that, unlike aws_rds_cluster_parameter_group, the Neptune cluster
+# parameter group schema defaults applyMethod to pending-reboot, so the loop is
+# triggered by explicitly asking for immediate on a parameter whose value AWS
+# does not have to touch.
+
+# Case O - neptune_enable_audit_log is static and defaults to 0, so the value is a
+# no-op at AWS. AWS ignores the apply method change alone and keeps reporting
+# pending-reboot, which is the perpetual diff.
+apiVersion: neptune.aws.m.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: o-neptune13-auditlog-immediate
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case O - Neptune cluster param group, static default value + immediate"
+    parameter:
+      - name: neptune_enable_audit_log
+        value: "0"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case P - same churn on a DYNAMIC parameter.
+# neptune_enable_slow_query_log defaults to disabled.
+apiVersion: neptune.aws.m.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: p-neptune13-slowquerylog-immediate
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case P - Neptune cluster param group, dynamic default value + immediate"
+    parameter:
+      - name: neptune_enable_slow_query_log
+        value: disabled
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case Q - NON-default value on a DYNAMIC parameter, requested with immediate,
+# which AWS accepts for dynamic parameters. The diff must not be suppressed.
+# neptune_slow_query_log_threshold defaults to 5000 ms.
+apiVersion: neptune.aws.m.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: q-neptune13-slowquerythreshold-immediate
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case Q - Neptune cluster param group, dynamic non-default value + immediate"
+    parameter:
+      - name: neptune_slow_query_log_threshold
+        value: "10000"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case R - NON-default value on a STATIC parameter, requested with pending-reboot.
+# AWS really applies the change, so the diff must not be suppressed.
+apiVersion: neptune.aws.m.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: r-neptune13-auditlog-pendingreboot
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case R - Neptune cluster param group, static non-default value + pending-reboot"
+    parameter:
+      - name: neptune_enable_audit_log
+        value: "1"
+        applyMethod: pending-reboot
+    tags:
+      Test: Uptest
+---
+# Case S - a loop-triggering parameter and a genuinely changing parameter in the
+# same set. Suppression is all-or-nothing per parameter group, so this asserts
+# that neptune_slow_query_log_threshold is still updated instead of being
+# swallowed together with the neptune_streams apply method churn.
+# neptune_streams is static and defaults to 0.
+apiVersion: neptune.aws.m.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: s-neptune13-mixed
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case S - Neptune cluster param group, apply method churn + real change"
+    parameter:
+      - name: neptune_streams
+        value: "0"
+        applyMethod: immediate
+      - name: neptune_slow_query_log_threshold
+        value: "10000"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case T - default value, applyMethod omitted. Defaults to pending-reboot for
+# Neptune, which is what AWS reports back, so desired == observed and no diff.
+# neptune_lookup_cache is static and defaults to 0.
+apiVersion: neptune.aws.m.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: t-neptune13-lookupcache-unset
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case T - Neptune cluster param group, default value, applyMethod omitted"
+    parameter:
+      - name: neptune_lookup_cache
+        value: "0"
+    tags:
+      Test: Uptest

--- a/examples/neptune/namespaced/v1beta1/parameter-group-loopfix.yaml
+++ b/examples/neptune/namespaced/v1beta1/parameter-group-loopfix.yaml
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# Neptune instance-level (DB parameter group) cases.
+# Parameter defaults and apply types are from
+# https://docs.aws.amazon.com/neptune/latest/userguide/parameters.html
+# Every documented instance-level parameter is STATIC, so a changed value has to
+# be requested with pending-reboot - AWS rejects immediate for a static
+# parameter whose value actually changes.
+# Note that, unlike aws_db_parameter_group, the Neptune parameter group schema
+# defaults applyMethod to pending-reboot, so the loop is triggered by explicitly
+# asking for immediate on a parameter whose value AWS does not have to touch.
+
+# Case J - neptune_query_timeout defaults to 120000 ms, so the value is a no-op at
+# AWS. AWS ignores the apply method change alone and keeps reporting
+# pending-reboot, which is the perpetual diff.
+apiVersion: neptune.aws.m.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: j-neptune13-querytimeout-immediate
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case J - Neptune param group, default value + immediate"
+    parameter:
+      - name: neptune_query_timeout
+        value: "120000"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case K - same as case J with a non-numeric default value.
+# neptune_dfe_query_engine defaults to viaQueryHint.
+apiVersion: neptune.aws.m.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: k-neptune13-dfequeryengine-immediate
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case K - Neptune param group, default string value + immediate"
+    parameter:
+      - name: neptune_dfe_query_engine
+        value: viaQueryHint
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case L - NON-default value on a static parameter, requested with pending-reboot.
+# AWS really applies the change, so the diff must not be suppressed.
+# neptune_result_cache defaults to 0.
+apiVersion: neptune.aws.m.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: l-neptune13-resultcache-pendingreboot
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case L - Neptune param group, non-default value + pending-reboot"
+    parameter:
+      - name: neptune_result_cache
+        value: "1"
+        applyMethod: pending-reboot
+    tags:
+      Test: Uptest
+---
+# Case M - default value, applyMethod omitted. Defaults to pending-reboot for
+# Neptune, which is what AWS reports back, so desired == observed and no diff.
+apiVersion: neptune.aws.m.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: m-neptune13-querytimeout-unset
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case M - Neptune param group, default value, applyMethod omitted"
+    parameter:
+      - name: neptune_query_timeout
+        value: "120000"
+    tags:
+      Test: Uptest
+---
+# Case N - a loop-triggering parameter and a genuinely changing parameter in the
+# same set. Suppression is all-or-nothing per parameter group, so this asserts
+# that neptune_result_cache is still updated instead of being swallowed together
+# with the neptune_query_timeout apply method churn.
+apiVersion: neptune.aws.m.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: n-neptune13-mixed
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: neptune1.3
+    description: "case N - Neptune param group, apply method churn + real change"
+    parameter:
+      - name: neptune_query_timeout
+        value: "120000"
+        applyMethod: immediate
+      - name: neptune_result_cache
+        value: "1"
+        applyMethod: pending-reboot
+    tags:
+      Test: Uptest

--- a/examples/rds/cluster/v1beta1/clusterparametergroup-loopfix.yaml
+++ b/examples/rds/cluster/v1beta1/clusterparametergroup-loopfix.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: g-aurorapg16-forcessl-immediate
+spec:
+  forProvider:
+    region: us-west-2
+    family: aurora-postgresql16
+    description: "case G - RDS cluster param group, default value + immediate"
+    parameter:
+      - name: rds.force_ssl
+        value: "1"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: i-aurorapg16-forcessl-default
+spec:
+  forProvider:
+    region: us-west-2
+    family: aurora-postgresql16
+    description: "case I - RDS cluster param group, Aurora default value + immediate"
+    parameter:
+      - name: rds.force_ssl
+        value: "0"
+        applyMethod: immediate
+    tags:
+      Test: Uptest

--- a/examples/rds/cluster/v1beta1/parametergroup-loopfix.yaml
+++ b/examples/rds/cluster/v1beta1/parametergroup-loopfix.yaml
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# rds.force_ssl defaults to 1 on RDS PostgreSQL 15+, so value "1" is a no-op at AWS.
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: a-pg16-forcessl-immediate
+spec:
+  forProvider:
+    region: us-west-2
+    family: postgres16
+    description: "Case A - default value + applyMethod immediate"
+    parameter:
+      - name: rds.force_ssl
+        value: "1"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case B — provider-upjet-aws#1444. log_checkpoints defaults to 1 on postgres15.
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: b-pg15-logcheckpoints-immediate
+spec:
+  forProvider:
+    region: us-west-2
+    family: postgres15
+    description: "case B - provider-upjet-aws#1444 reproducer"
+    parameter:
+      - name: log_checkpoints
+        value: "1"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+
+---
+# Case C — provider-upjet-aws#1286. innodb_file_per_table defaults to 1 on mysql8.0.
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: c-mysql80-innodbfpt-immediate
+spec:
+  forProvider:
+    region: us-west-2
+    family: mysql8.0
+    description: "case C - provider-upjet-aws#1286 reproducer"
+    parameter:
+      - name: innodb_file_per_table
+        value: "1"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case D — same parameter, NON-default value. AWS really applies the change, records
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: d-pg16-forcessl-nondefault
+spec:
+  forProvider:
+    region: us-west-2
+    family: postgres16
+    description: "case D - non-default value + immediate"
+    parameter:
+      - name: rds.force_ssl
+        value: "0"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+  providerConfigRef:
+    name: default
+---
+# Case E — default value but applyMethod pending-reboot, which is what AWS reports back.
+# Desired == observed, so no diff.
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: e-pg16-forcessl-pendingreboot
+spec:
+  forProvider:
+    region: us-west-2
+    family: postgres16
+    description: "case E - default value + pending-reboot"
+    parameter:
+      - name: rds.force_ssl
+        value: "1"
+        applyMethod: pending-reboot
+    tags:
+      Test: Uptest
+---
+apiVersion: rds.aws.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: f-pg16-forcessl-unset
+spec:
+  forProvider:
+    region: us-west-2
+    family: postgres16
+    description: "case F - default value, applyMethod omitted"
+    parameter:
+      - name: rds.force_ssl
+        value: "1"
+    tags:
+      Test: Uptest

--- a/examples/rds/namespaced/v1beta1/clusterparametergroup-loopfix.yaml
+++ b/examples/rds/namespaced/v1beta1/clusterparametergroup-loopfix.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+apiVersion: rds.aws.m.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: g-aurorapg16-forcessl-immediate
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: aurora-postgresql16
+    description: "case G - RDS cluster param group, default value + immediate"
+    parameter:
+      - name: rds.force_ssl
+        value: "1"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+apiVersion: rds.aws.m.upbound.io/v1beta1
+kind: ClusterParameterGroup
+metadata:
+  name: i-aurorapg16-forcessl-default
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: aurora-postgresql16
+    description: "case I - RDS cluster param group, Aurora default value + immediate"
+    parameter:
+      - name: rds.force_ssl
+        value: "0"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---

--- a/examples/rds/namespaced/v1beta1/parametergroup-loopfix.yaml
+++ b/examples/rds/namespaced/v1beta1/parametergroup-loopfix.yaml
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+# rds.force_ssl defaults to 1 on RDS PostgreSQL 15+, so value "1" is a no-op at AWS.
+apiVersion: rds.aws.m.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: a-pg16-forcessl-immediate
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: postgres16
+    description: "Case A - default value + applyMethod immediate"
+    parameter:
+      - name: rds.force_ssl
+        value: "1"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case B — provider-upjet-aws#1444. log_checkpoints defaults to 1 on postgres15.
+apiVersion: rds.aws.m.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: b-pg15-logcheckpoints-immediate
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: postgres15
+    description: "case B - provider-upjet-aws#1444 reproducer"
+    parameter:
+      - name: log_checkpoints
+        value: "1"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+
+---
+# Case C — provider-upjet-aws#1286. innodb_file_per_table defaults to 1 on mysql8.0.
+apiVersion: rds.aws.m.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: c-mysql80-innodbfpt-immediate
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: mysql8.0
+    description: "case C - provider-upjet-aws#1286 reproducer"
+    parameter:
+      - name: innodb_file_per_table
+        value: "1"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+---
+# Case D — same parameter, NON-default value. AWS really applies the change, records
+apiVersion: rds.aws.m.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: d-pg16-forcessl-nondefault
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: postgres16
+    description: "case D - non-default value + immediate"
+    parameter:
+      - name: rds.force_ssl
+        value: "0"
+        applyMethod: immediate
+    tags:
+      Test: Uptest
+  providerConfigRef:
+    kind: ProviderConfig
+    name: default
+---
+# Case E — default value but applyMethod pending-reboot, which is what AWS reports back.
+# Desired == observed, so no diff.
+apiVersion: rds.aws.m.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: e-pg16-forcessl-pendingreboot
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: postgres16
+    description: "case E - default value + pending-reboot"
+    parameter:
+      - name: rds.force_ssl
+        value: "1"
+        applyMethod: pending-reboot
+    tags:
+      Test: Uptest
+---
+apiVersion: rds.aws.m.upbound.io/v1beta1
+kind: ParameterGroup
+metadata:
+  name: f-pg16-forcessl-unset
+  namespace: upbound-system
+spec:
+  forProvider:
+    region: us-west-2
+    family: postgres16
+    description: "case F - default value, applyMethod omitted"
+    parameter:
+      - name: rds.force_ssl
+        value: "1"
+    tags:
+      Test: Uptest


### PR DESCRIPTION
### Description of your changes

Fixes perpetual diff with `ClusterParameterGroup` and `ParameterGroup` resources in `rds` , `docdb` and `neptune` API groups when the parameter values matches the AWS default, but only the `ApplyMethod` differs.

### Root cause

It comes from how AWS treats the `apply_method` of a parameter:

1. For a parameter it has not been asked to modify, AWS reports
   `ApplyMethod: pending-reboot`.
2. AWS refuses to change a parameter's apply method *unless its value also changes*, however the request is accepted and silently ignored, so the `apply_method` does not properly roundtrip after updating.

Also see upstream TF docs on RDS [Problematic Plan Changes](https://github.com/hashicorp/terraform-provider-aws/blob/v6.55.0/website/docs/r/db_parameter_group.html.markdown#problematic-plan-changes) section.

### Fix

Added a custom diff such that it inspects the `parameter` set diff and drops every `parameter.*` attribute **only** when all the parameters diffs are `ApplyMethod` only.

Non-update diffs (empty diff, resource creation, destroy diffs), parameter additions/deletions diffs, parameter value change diffs are kept as is.


Fixes #1286, #1444

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

- New manifests added for reproducers
- Validated that update loop occurs before this PR with these new example manifests

Uptest: 

[Uptest-f5937a58a7096309113ba1e771525c2b](https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/30925394534)

```
/test-examples="examples/docdb/cluster/v1beta1/clusterparametergroup-loopfix.yaml,
examples/neptune/cluster/v1beta1/cluster-parameter-group-loopfix.yaml,
examples/neptune/cluster/v1beta1/parameter-group-loopfix.yaml,
examples/rds/cluster/v1beta1/clusterparametergroup-loopfix.yaml,
examples/rds/cluster/v1beta1/parametergroup-loopfix.yaml"
```
After review addressing:
https://github.com/crossplane-contrib/provider-upjet-aws/actions/runs/30998555722 -- Passed

[contribution process]: https://git.io/fj2m9
