### PR TITLE
fix(elbv2): suppress spurious access_logs diff for Gateway Load Balancers

### DIFF
--- a/config/cluster/elbv2/config.go
+++ b/config/cluster/elbv2/config.go
@@ -39,6 +39,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		}
 		r.UseAsync = true
 		r.LateInitializer.IgnoredFields = []string{"access_logs"}
+		r.TerraformCustomDiff = lbCustomDiff
 	})
 
 	p.AddResourceConfigurator("aws_lb_listener", func(r *config.Resource) {
@@ -165,6 +166,28 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		r.ShortGroup = "elbv2"
 		r.Kind = "LBTrustStore"
 	})
+}
+
+// lbCustomDiff drops diffs on the access_logs block for Gateway Load
+// Balancers. AWS does not support the access_logs.s3.* attributes for this
+// load balancer type: the upstream provider only guards against sending them
+// on create, not on update, so a Gateway LB observed with an empty
+// access_logs block (the API's own default) produces a perpetual diff whose
+// resulting update call is rejected by AWS with a ValidationException on
+// every reconcile.
+func lbCustomDiff(diff *terraform.InstanceDiff, state *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+	if diff == nil || diff.Empty() || diff.Destroy || diff.Attributes == nil {
+		return diff, nil
+	}
+	if state == nil || state.Attributes["load_balancer_type"] != "gateway" {
+		return diff, nil
+	}
+	for k := range diff.Attributes {
+		if strings.HasPrefix(k, "access_logs") {
+			delete(diff.Attributes, k)
+		}
+	}
+	return diff, nil
 }
 
 func lbListenerRuleCustomDiff(diff *terraform.InstanceDiff, state *terraform.InstanceState, cfg *terraform.ResourceConfig) (*terraform.InstanceDiff, error) { //nolint:gocyclo // easier to follow as a unit

--- a/config/cluster/elbv2/config_test.go
+++ b/config/cluster/elbv2/config_test.go
@@ -43,6 +43,113 @@ func configWithARNOnly() *terraform.ResourceConfig {
 	}
 }
 
+func TestLBCustomDiff(t *testing.T) {
+	cases := map[string]struct {
+		reason   string
+		diff     *terraform.InstanceDiff
+		state    *terraform.InstanceState
+		wantKeys []string
+		goneKeys []string
+	}{
+		"NilDiff": {
+			reason: "nil diff passes through unchanged",
+			diff:   nil,
+		},
+		"EmptyDiff": {
+			reason: "empty diff passes through unchanged",
+			diff:   &terraform.InstanceDiff{},
+		},
+		"DestroyDiff": {
+			reason: "destroy diff is never modified",
+			diff: &terraform.InstanceDiff{
+				Destroy: true,
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"access_logs.0.enabled": {Old: "false", New: "true"},
+				},
+			},
+			state: &terraform.InstanceState{
+				Attributes: map[string]string{"load_balancer_type": "gateway"},
+			},
+			wantKeys: []string{"access_logs.0.enabled"},
+		},
+		"NilState_Kept": {
+			reason: "diff is kept when state is nil, since the load balancer type cannot be determined",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"access_logs.0.enabled": {Old: "", New: "false"},
+				},
+			},
+			state:    nil,
+			wantKeys: []string{"access_logs.0.enabled"},
+		},
+		"ApplicationType_Kept": {
+			reason: "access_logs diffs are real and meaningful for application load balancers, so they are kept",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"access_logs.0.enabled": {Old: "", New: "true"},
+					"access_logs.0.bucket":  {Old: "", New: "my-bucket"},
+				},
+			},
+			state: &terraform.InstanceState{
+				Attributes: map[string]string{"load_balancer_type": "application"},
+			},
+			wantKeys: []string{"access_logs.0.enabled", "access_logs.0.bucket"},
+		},
+		"GatewayType_Suppressed": {
+			reason: "the spurious access_logs diff observed for a gateway load balancer is suppressed",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"access_logs.#":         {Old: "1", New: "0"},
+					"access_logs.0.enabled": {Old: "false", New: ""},
+				},
+			},
+			state: &terraform.InstanceState{
+				Attributes: map[string]string{"load_balancer_type": "gateway"},
+			},
+			goneKeys: []string{"access_logs.#", "access_logs.0.enabled"},
+		},
+		"GatewayType_UnrelatedKeysUntouched": {
+			reason: "keys that do not belong to access_logs are left untouched for a gateway load balancer",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"access_logs.0.enabled":      {Old: "false", New: ""},
+					"enable_deletion_protection": {Old: "false", New: "true"},
+				},
+			},
+			state: &terraform.InstanceState{
+				Attributes: map[string]string{"load_balancer_type": "gateway"},
+			},
+			wantKeys: []string{"enable_deletion_protection"},
+			goneKeys: []string{"access_logs.0.enabled"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := lbCustomDiff(tc.diff, tc.state, nil)
+			if err != nil {
+				t.Fatalf("%s: unexpected error: %v", tc.reason, err)
+			}
+			if tc.diff == nil {
+				if got != nil {
+					t.Errorf("%s: expected nil diff, got non-nil", tc.reason)
+				}
+				return
+			}
+			for _, k := range tc.wantKeys {
+				if _, ok := got.Attributes[k]; !ok {
+					t.Errorf("%s: key %q should be present but is missing", tc.reason, k)
+				}
+			}
+			for _, k := range tc.goneKeys {
+				if _, ok := got.Attributes[k]; ok {
+					t.Errorf("%s: key %q should have been suppressed but is still present", tc.reason, k)
+				}
+			}
+		})
+	}
+}
+
 func TestLBListenerRuleCustomDiff(t *testing.T) {
 	cases := map[string]struct {
 		reason   string

--- a/config/namespaced/elbv2/config.go
+++ b/config/namespaced/elbv2/config.go
@@ -39,6 +39,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		}
 		r.UseAsync = true
 		r.LateInitializer.IgnoredFields = []string{"access_logs"}
+		r.TerraformCustomDiff = lbCustomDiff
 	})
 
 	p.AddResourceConfigurator("aws_lb_listener", func(r *config.Resource) {
@@ -165,6 +166,28 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		r.ShortGroup = "elbv2"
 		r.Kind = "LBTrustStore"
 	})
+}
+
+// lbCustomDiff drops diffs on the access_logs block for Gateway Load
+// Balancers. AWS does not support the access_logs.s3.* attributes for this
+// load balancer type: the upstream provider only guards against sending them
+// on create, not on update, so a Gateway LB observed with an empty
+// access_logs block (the API's own default) produces a perpetual diff whose
+// resulting update call is rejected by AWS with a ValidationException on
+// every reconcile.
+func lbCustomDiff(diff *terraform.InstanceDiff, state *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+	if diff == nil || diff.Empty() || diff.Destroy || diff.Attributes == nil {
+		return diff, nil
+	}
+	if state == nil || state.Attributes["load_balancer_type"] != "gateway" {
+		return diff, nil
+	}
+	for k := range diff.Attributes {
+		if strings.HasPrefix(k, "access_logs") {
+			delete(diff.Attributes, k)
+		}
+	}
+	return diff, nil
 }
 
 func lbListenerRuleCustomDiff(diff *terraform.InstanceDiff, state *terraform.InstanceState, cfg *terraform.ResourceConfig) (*terraform.InstanceDiff, error) { //nolint:gocyclo // easier to follow as a unit

--- a/config/namespaced/elbv2/config_test.go
+++ b/config/namespaced/elbv2/config_test.go
@@ -43,6 +43,113 @@ func configWithARNOnly() *terraform.ResourceConfig {
 	}
 }
 
+func TestLBCustomDiff(t *testing.T) {
+	cases := map[string]struct {
+		reason   string
+		diff     *terraform.InstanceDiff
+		state    *terraform.InstanceState
+		wantKeys []string
+		goneKeys []string
+	}{
+		"NilDiff": {
+			reason: "nil diff passes through unchanged",
+			diff:   nil,
+		},
+		"EmptyDiff": {
+			reason: "empty diff passes through unchanged",
+			diff:   &terraform.InstanceDiff{},
+		},
+		"DestroyDiff": {
+			reason: "destroy diff is never modified",
+			diff: &terraform.InstanceDiff{
+				Destroy: true,
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"access_logs.0.enabled": {Old: "false", New: "true"},
+				},
+			},
+			state: &terraform.InstanceState{
+				Attributes: map[string]string{"load_balancer_type": "gateway"},
+			},
+			wantKeys: []string{"access_logs.0.enabled"},
+		},
+		"NilState_Kept": {
+			reason: "diff is kept when state is nil, since the load balancer type cannot be determined",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"access_logs.0.enabled": {Old: "", New: "false"},
+				},
+			},
+			state:    nil,
+			wantKeys: []string{"access_logs.0.enabled"},
+		},
+		"ApplicationType_Kept": {
+			reason: "access_logs diffs are real and meaningful for application load balancers, so they are kept",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"access_logs.0.enabled": {Old: "", New: "true"},
+					"access_logs.0.bucket":  {Old: "", New: "my-bucket"},
+				},
+			},
+			state: &terraform.InstanceState{
+				Attributes: map[string]string{"load_balancer_type": "application"},
+			},
+			wantKeys: []string{"access_logs.0.enabled", "access_logs.0.bucket"},
+		},
+		"GatewayType_Suppressed": {
+			reason: "the spurious access_logs diff observed for a gateway load balancer is suppressed",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"access_logs.#":         {Old: "1", New: "0"},
+					"access_logs.0.enabled": {Old: "false", New: ""},
+				},
+			},
+			state: &terraform.InstanceState{
+				Attributes: map[string]string{"load_balancer_type": "gateway"},
+			},
+			goneKeys: []string{"access_logs.#", "access_logs.0.enabled"},
+		},
+		"GatewayType_UnrelatedKeysUntouched": {
+			reason: "keys that do not belong to access_logs are left untouched for a gateway load balancer",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"access_logs.0.enabled":      {Old: "false", New: ""},
+					"enable_deletion_protection": {Old: "false", New: "true"},
+				},
+			},
+			state: &terraform.InstanceState{
+				Attributes: map[string]string{"load_balancer_type": "gateway"},
+			},
+			wantKeys: []string{"enable_deletion_protection"},
+			goneKeys: []string{"access_logs.0.enabled"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := lbCustomDiff(tc.diff, tc.state, nil)
+			if err != nil {
+				t.Fatalf("%s: unexpected error: %v", tc.reason, err)
+			}
+			if tc.diff == nil {
+				if got != nil {
+					t.Errorf("%s: expected nil diff, got non-nil", tc.reason)
+				}
+				return
+			}
+			for _, k := range tc.wantKeys {
+				if _, ok := got.Attributes[k]; !ok {
+					t.Errorf("%s: key %q should be present but is missing", tc.reason, k)
+				}
+			}
+			for _, k := range tc.goneKeys {
+				if _, ok := got.Attributes[k]; ok {
+					t.Errorf("%s: key %q should have been suppressed but is still present", tc.reason, k)
+				}
+			}
+		})
+	}
+}
+
 func TestLBListenerRuleCustomDiff(t *testing.T) {
 	cases := map[string]struct {
 		reason   string


### PR DESCRIPTION
### Description of your changes

For an `aws_lb` resource with `load_balancer_type=gateway`, the vendored terraform-provider-aws Read path always populates the `access_logs` Terraform state block, even though AWS never returns `access_logs.s3.*` attributes for Gateway Load Balancers. Because the `access_logs` schema field's `DiffSuppressFunc` only suppresses a missing block (not an empty one), this manufactures a permanent diff. Unlike Create, the vendored Update path does not gate `access_logs` on `load_balancer_type`, so every reconcile that observes this diff calls Update, which sends `access_logs.s3.enabled=false` to AWS and is rejected with `ValidationException: Load balancer attribute key 'access_logs.s3.enabled' is not recognized`. Since Observe also reports the resource as not up to date on every cycle, this flips the resource's `Synced` condition to `False` with a `ReconcileError` on every reconcile, even though the load balancer itself is created and otherwise healthy.

This PR adds a `TerraformCustomDiff` for `aws_lb` (`config/cluster/elbv2/config.go` and `config/namespaced/elbv2/config.go`, kept identical as with the rest of this package) that drops any `access_logs.*` diff keys when the observed state's `load_balancer_type` is `"gateway"`. This follows the same pattern already used in this file for `aws_lb_listener` and `aws_lb_listener_rule`: suppress a diff known to be spurious rather than patching the vendored provider. With no `access_logs` diff left, upjet never calls Update for this field on Gateway Load Balancers, so the erroring API call is never made.

This change only adds a runtime diff customization consumed exclusively by upjet's controller (`pkg/controller/external_tfpluginsdk.go`); it is not referenced anywhere in upjet's code-generation packages, so it does not affect generated CRD schemas or `zz_` files, which is why `make generate` was not run for this change.

Fixes #2075

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [ ] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

Ran `go build ./config/...` and `go test ./config/cluster/elbv2/... ./config/namespaced/elbv2/... -v`; both packages build and all tests pass, including the new `TestLBCustomDiff` cases covering nil/empty/destroy diffs, a nil state, a real `access_logs` change on an Application load balancer (kept), and the spurious `access_logs` diff on a Gateway load balancer (suppressed). `go vet` is clean on both packages. No live AWS reproduction was performed (no AWS credentials or cluster available in this environment); the fix is validated against hand-built `terraform.InstanceDiff`/`InstanceState` fixtures, at the same rigor as the pre-existing `lbListenerRuleCustomDiff` tests in this file.

[contribution process]: https://git.io/fj2m9

---
AI assistance: this change was drafted with Claude Code.