### PR TITLE
fix EFS FileSystemPolicy update loop causing API throttling

### DIFF
--- a/config/cluster/efs/config.go
+++ b/config/cluster/efs/config.go
@@ -6,6 +6,9 @@ package efs
 
 import (
 	"github.com/crossplane/upjet/v2/pkg/config"
+	awspolicy "github.com/hashicorp/awspolicyequivalence"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/pkg/errors"
 
 	"github.com/upbound/provider-aws/v2/config/cluster/common"
 )
@@ -43,6 +46,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		r.References["file_system_id"] = config.Reference{
 			TerraformName: "aws_efs_file_system",
 		}
+		r.TerraformCustomDiff = fileSystemPolicyCustomDiff
 	})
 
 	p.AddResourceConfigurator("aws_efs_file_system", func(r *config.Resource) {
@@ -61,4 +65,34 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			return conn, nil
 		}
 	})
+}
+
+// fileSystemPolicyCustomDiff suppresses spurious "policy" diffs for
+// aws_efs_file_system_policy. AWS can return the policy document with a
+// different but semantically equivalent JSON representation (e.g. reordered
+// statements) than what was submitted. Without this, every observe sees a
+// diff, triggering an update on every reconcile and exhausting the EFS API
+// rate limit.
+func fileSystemPolicyCustomDiff(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+	if diff == nil || diff.Attributes["policy"] == nil || diff.Attributes["policy"].Old == "" || diff.Attributes["policy"].New == "" {
+		return diff, nil
+	}
+
+	vOld, err := common.RemovePolicyVersion(diff.Attributes["policy"].Old)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to remove Version from the old AWS policy document")
+	}
+	vNew, err := common.RemovePolicyVersion(diff.Attributes["policy"].New)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to remove Version from the new AWS policy document")
+	}
+
+	ok, err := awspolicy.PoliciesAreEquivalent(vOld, vNew)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to compare the old and the new AWS policy documents")
+	}
+	if ok {
+		delete(diff.Attributes, "policy")
+	}
+	return diff, nil
 }

--- a/config/cluster/efs/config_test.go
+++ b/config/cluster/efs/config_test.go
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: CC0-1.0
+
+package efs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const (
+	oldPolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Principal":{"AWS":"*"},"Action":"*","Condition":{"Bool":{"aws:SecureTransport":"false"}}}]}`
+	// Same policy as oldPolicy, but with keys reordered the way AWS echoes
+	// the document back from DescribeFileSystemPolicy.
+	equivalentPolicy = `{"Statement":[{"Condition":{"Bool":{"aws:SecureTransport":"false"}},"Action":"*","Principal":{"AWS":"*"},"Effect":"Deny"}],"Version":"2012-10-17"}`
+	differentPolicy  = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"*"}]}`
+)
+
+func TestFileSystemPolicyCustomDiff(t *testing.T) {
+	cases := map[string]struct {
+		reason   string
+		diff     *terraform.InstanceDiff
+		wantErr  bool
+		goneKeys []string
+		wantKeys []string
+	}{
+		"NilDiff": {
+			reason: "nil diff passes through unchanged",
+			diff:   nil,
+		},
+		"NoPolicyAttribute": {
+			reason: "a diff without a policy attribute is left untouched",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"file_system_id": {Old: "", New: "fs-123"},
+				},
+			},
+			wantKeys: []string{"file_system_id"},
+		},
+		"CreateDiff_NoOld": {
+			reason: "a create diff (no old value) is left untouched",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"policy": {Old: "", New: oldPolicy},
+				},
+			},
+			wantKeys: []string{"policy"},
+		},
+		"EquivalentPolicies_Suppressed": {
+			reason: "a semantically equivalent but differently ordered policy is suppressed",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"policy": {Old: oldPolicy, New: equivalentPolicy},
+				},
+			},
+			goneKeys: []string{"policy"},
+		},
+		"DifferentPolicies_NotSuppressed": {
+			reason: "a real policy change is kept in the diff",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"policy": {Old: oldPolicy, New: differentPolicy},
+				},
+			},
+			wantKeys: []string{"policy"},
+		},
+		"InvalidJSON_Errors": {
+			reason: "an unparseable policy document returns an error instead of panicking",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"policy": {Old: oldPolicy, New: "not-json"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := fileSystemPolicyCustomDiff(tc.diff, nil, nil)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("%s: expected an error, got none", tc.reason)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("%s: unexpected error: %v", tc.reason, err)
+			}
+			if tc.diff == nil {
+				if got != nil {
+					t.Errorf("%s: expected nil diff, got non-nil", tc.reason)
+				}
+				return
+			}
+			for _, k := range tc.wantKeys {
+				if _, ok := got.Attributes[k]; !ok {
+					t.Errorf("%s: key %q should be present but is missing", tc.reason, k)
+				}
+			}
+			for _, k := range tc.goneKeys {
+				if _, ok := got.Attributes[k]; ok {
+					t.Errorf("%s: key %q should have been suppressed but is still present", tc.reason, k)
+				}
+			}
+		})
+	}
+}

--- a/config/namespaced/efs/config.go
+++ b/config/namespaced/efs/config.go
@@ -6,6 +6,9 @@ package efs
 
 import (
 	"github.com/crossplane/upjet/v2/pkg/config"
+	awspolicy "github.com/hashicorp/awspolicyequivalence"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/pkg/errors"
 
 	"github.com/upbound/provider-aws/v2/config/namespaced/common"
 )
@@ -43,6 +46,7 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 		r.References["file_system_id"] = config.Reference{
 			TerraformName: "aws_efs_file_system",
 		}
+		r.TerraformCustomDiff = fileSystemPolicyCustomDiff
 	})
 
 	p.AddResourceConfigurator("aws_efs_file_system", func(r *config.Resource) {
@@ -51,4 +55,34 @@ func Configure(p *config.Provider) { //nolint:gocyclo
 			Extractor:     common.PathARNExtractor,
 		}
 	})
+}
+
+// fileSystemPolicyCustomDiff suppresses spurious "policy" diffs for
+// aws_efs_file_system_policy. AWS can return the policy document with a
+// different but semantically equivalent JSON representation (e.g. reordered
+// statements) than what was submitted. Without this, every observe sees a
+// diff, triggering an update on every reconcile and exhausting the EFS API
+// rate limit.
+func fileSystemPolicyCustomDiff(diff *terraform.InstanceDiff, _ *terraform.InstanceState, _ *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+	if diff == nil || diff.Attributes["policy"] == nil || diff.Attributes["policy"].Old == "" || diff.Attributes["policy"].New == "" {
+		return diff, nil
+	}
+
+	vOld, err := common.RemovePolicyVersion(diff.Attributes["policy"].Old)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to remove Version from the old AWS policy document")
+	}
+	vNew, err := common.RemovePolicyVersion(diff.Attributes["policy"].New)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to remove Version from the new AWS policy document")
+	}
+
+	ok, err := awspolicy.PoliciesAreEquivalent(vOld, vNew)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to compare the old and the new AWS policy documents")
+	}
+	if ok {
+		delete(diff.Attributes, "policy")
+	}
+	return diff, nil
 }

--- a/config/namespaced/efs/config_test.go
+++ b/config/namespaced/efs/config_test.go
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: CC0-1.0
+
+package efs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const (
+	oldPolicy = `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Principal":{"AWS":"*"},"Action":"*","Condition":{"Bool":{"aws:SecureTransport":"false"}}}]}`
+	// Same policy as oldPolicy, but with keys reordered the way AWS echoes
+	// the document back from DescribeFileSystemPolicy.
+	equivalentPolicy = `{"Statement":[{"Condition":{"Bool":{"aws:SecureTransport":"false"}},"Action":"*","Principal":{"AWS":"*"},"Effect":"Deny"}],"Version":"2012-10-17"}`
+	differentPolicy  = `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"*"}]}`
+)
+
+func TestFileSystemPolicyCustomDiff(t *testing.T) {
+	cases := map[string]struct {
+		reason   string
+		diff     *terraform.InstanceDiff
+		wantErr  bool
+		goneKeys []string
+		wantKeys []string
+	}{
+		"NilDiff": {
+			reason: "nil diff passes through unchanged",
+			diff:   nil,
+		},
+		"NoPolicyAttribute": {
+			reason: "a diff without a policy attribute is left untouched",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"file_system_id": {Old: "", New: "fs-123"},
+				},
+			},
+			wantKeys: []string{"file_system_id"},
+		},
+		"CreateDiff_NoOld": {
+			reason: "a create diff (no old value) is left untouched",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"policy": {Old: "", New: oldPolicy},
+				},
+			},
+			wantKeys: []string{"policy"},
+		},
+		"EquivalentPolicies_Suppressed": {
+			reason: "a semantically equivalent but differently ordered policy is suppressed",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"policy": {Old: oldPolicy, New: equivalentPolicy},
+				},
+			},
+			goneKeys: []string{"policy"},
+		},
+		"DifferentPolicies_NotSuppressed": {
+			reason: "a real policy change is kept in the diff",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"policy": {Old: oldPolicy, New: differentPolicy},
+				},
+			},
+			wantKeys: []string{"policy"},
+		},
+		"InvalidJSON_Errors": {
+			reason: "an unparseable policy document returns an error instead of panicking",
+			diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"policy": {Old: oldPolicy, New: "not-json"},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := fileSystemPolicyCustomDiff(tc.diff, nil, nil)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("%s: expected an error, got none", tc.reason)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("%s: unexpected error: %v", tc.reason, err)
+			}
+			if tc.diff == nil {
+				if got != nil {
+					t.Errorf("%s: expected nil diff, got non-nil", tc.reason)
+				}
+				return
+			}
+			for _, k := range tc.wantKeys {
+				if _, ok := got.Attributes[k]; !ok {
+					t.Errorf("%s: key %q should be present but is missing", tc.reason, k)
+				}
+			}
+			for _, k := range tc.goneKeys {
+				if _, ok := got.Attributes[k]; ok {
+					t.Errorf("%s: key %q should have been suppressed but is still present", tc.reason, k)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #2175

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make generate` and committed the results (ideally in a separate commit).
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### Description of your changes

`aws_efs_file_system_policy` re-reads its `policy` attribute from AWS after every create/update. AWS can echo the JSON policy document back with reordered statements/keys, which Terraform's plain string diff treats as a real change on every reconcile. This drives the controller to keep issuing `Update` calls indefinitely, which in turn causes extra `DescribeFileSystemPolicy` calls that exhaust the EFS API's throttling limit, producing repeated `CannotObserveExternalResource` / `CannotUpdateExternalResource` Warning events.

This PR adds a `TerraformCustomDiff` for `aws_efs_file_system_policy` that performs a semantic (structural) comparison of the old and new `policy` JSON via `github.com/hashicorp/awspolicyequivalence`, dropping the `policy` key from the diff when the two documents are equivalent. A genuine policy change (e.g. a different `Effect` or `Principal`) is still detected and kept in the diff. This mirrors the existing pattern already used in this repo for `aws_sns_topic` and `aws_sqs_queue_policy` (`config/cluster/sns/config.go`, `config/cluster/sqs/config.go`), applied here to both the cluster-scoped and namespaced EFS configs. No CRD schema or generated code is touched by this change.

Fixes #2175

### How has this code been tested

```
go build ./config/cluster/efs/... ./config/namespaced/efs/...
go test ./config/cluster/efs/... ./config/namespaced/efs/... -v
go vet ./config/cluster/efs/... ./config/namespaced/efs/...
```

All pass, including a test case that reproduces the reordered-JSON shape AWS returns for the policy document from the report's reproduction manifest, and a case confirming a genuine policy change is not suppressed. This was not validated against a live AWS account or a real `terraform apply`/reconcile loop, only via Go unit tests against the custom-diff function in isolation.

[contribution process]: https://git.io/fj2m9

---
AI assistance: this change was drafted with Claude Code.