### PR TITLE
fix: make ProviderConfig respect secretRef namespace

### DIFF
--- a/internal/clients/pc_resolver.go
+++ b/internal/clients/pc_resolver.go
@@ -49,9 +49,9 @@ func enrichLocalSecretRefs(pc *namespacedv1beta1.ProviderConfig, mg xpresource.M
 	if pc == nil {
 		return
 	}
-	if pc.Spec.Credentials.SecretRef != nil {
-		pc.Spec.Credentials.SecretRef.Namespace = mg.GetNamespace()
-	}
+	if pc.Spec.Credentials.SecretRef != nil && pc.Spec.Credentials.SecretRef.Namespace == "" {                        
+        pc.Spec.Credentials.SecretRef.Namespace = mg.GetNamespace()
+    }
 	if pc.Spec.Credentials.Upbound != nil &&
 		pc.Spec.Credentials.Upbound.WebIdentity != nil &&
 		pc.Spec.Credentials.Upbound.WebIdentity.TokenConfig != nil &&


### PR DESCRIPTION
### Description of your changes

This PR attempts to make the Provider respect namespaces set in the secretRef field of the ProviderConfig. 

Currently, if a namespace scoped `ProviderConfig` has a reference to a secret in a different namespace, the `secretRef.namespace` field will be changed to the managed resources's namespace by the provider during reconciliation. 

Below is an example of a `ProviderConfig` in namespace `foo`, but references a secret in namespace `bar`. If the secret exists in namespace bar, the MR will still fail reconciliation with an error that the secret could not be found. Moving the secret from `bar` to `foo` resolves the issue.

```yaml
apiVersion: aws.m.upbound.io/v1beta1
kind: ProviderConfig
metadata:
  name: some-provider-config
  namespace: foo
spec:
  credentials:
    source: Secret
    secretRef:
      key: some-key
      name: secret-name
      namespace: bar
```

It is unclear if this is intended behavior, and I would love if someone had any insight. 
This PR only changes one line which I think is responsible for the issue I am experiencing, but there are a couple of other branches below which do something similar. They should probably also be changed. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.
