### PR TITLE
fix(sfn): correct aws_sfn_activity ARN identifier format

### DIFF
--- a/config/externalname.go
+++ b/config/externalname.go
@@ -2671,7 +2671,7 @@ var TerraformPluginSDKExternalNameConfigs = map[string]config.ExternalName{
 
 	// sfn
 	//
-	"aws_sfn_activity": config.TemplatedStringAsIdentifier("name", fullARNTemplate("states", "activity/{{ .external_name }}")),
+	"aws_sfn_activity": config.TemplatedStringAsIdentifier("name", fullARNTemplate("states", "activity:{{ .external_name }}")),
 	//
 	"aws_sfn_state_machine": config.TemplatedStringAsIdentifier("name", fullARNTemplate("states", "stateMachine:{{ .external_name }}")),
 


### PR DESCRIPTION
## What problem does this PR solve?

`aws_sfn_activity`'s external-name template built its ARN with a `/`
before the activity name: `activity/{{ .external_name }}`. AWS Step
Functions activity ARNs use a colon separator instead:
`arn:aws:states:<region>:<account-id>:activity:<name>`. This matches
the pattern already used a few lines below for
`aws_sfn_state_machine` (`stateMachine:{{ .external_name }}`).

With the slash, generated/imported external names for existing
`aws_sfn_activity` resources would not match the real resource ARN.

## How has this code been tested?

- Compared against the state-machine sibling entry in the same file,
  which already uses the colon-separated form.
- Verified against the documented AWS ARN format for Step Functions
  activities.