### PR TITLE
Fix ReplicationGroup.elasticache example manifests

### DIFF
--- a/examples/elasticache/cluster/v1beta1/globalreplicationgroup.yaml
+++ b/examples/elasticache/cluster/v1beta1/globalreplicationgroup.yaml
@@ -28,7 +28,7 @@ metadata:
 spec:
   forProvider:
     description: primary replication group
-    atRestEncryptionEnabled: true
+    atRestEncryptionEnabled: "true"
     # Uncomment lines below if you set 'numCacheClusters' > 1
     #
     # automaticFailoverEnabled: true

--- a/examples/elasticache/cluster/v1beta2/replicationgroup.yaml
+++ b/examples/elasticache/cluster/v1beta2/replicationgroup.yaml
@@ -76,7 +76,7 @@ metadata:
 spec:
   forProvider:
     automaticFailoverEnabled: true
-    atRestEncryptionEnabled: true
+    atRestEncryptionEnabled: "true"
     autoGenerateAuthToken: true
     authTokenSecretRef:
       name: redis-auth-token

--- a/examples/elasticache/namespaced/v1beta1/globalreplicationgroup.yaml
+++ b/examples/elasticache/namespaced/v1beta1/globalreplicationgroup.yaml
@@ -29,7 +29,7 @@ metadata:
 spec:
   forProvider:
     description: primary replication group
-    atRestEncryptionEnabled: true
+    atRestEncryptionEnabled: "true"
     # Uncomment lines below if you set 'numCacheClusters' > 1
     #
     # automaticFailoverEnabled: true

--- a/examples/elasticache/namespaced/v1beta1/replicationgroup.yaml
+++ b/examples/elasticache/namespaced/v1beta1/replicationgroup.yaml
@@ -81,7 +81,7 @@ metadata:
 spec:
   forProvider:
     automaticFailoverEnabled: true
-    atRestEncryptionEnabled: true
+    atRestEncryptionEnabled: "true"
     autoGenerateAuthToken: true
     authTokenSecretRef:
       name: redis-auth-token


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fix the example manifests for `ReplicationGroup.elasticache`. `spec.forProvider.atRestEncryptionEnabled` is a string since v1.19.0.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
