### PR TITLE
Add support for ClusterAuth managementPolicies always with Observe present

### DIFF
--- a/internal/controller/cluster/eks/clusterauth/controller.go
+++ b/internal/controller/cluster/eks/clusterauth/controller.go
@@ -18,6 +18,7 @@ import (
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -26,6 +27,7 @@ import (
 
 	"github.com/upbound/provider-aws/v2/apis/cluster/eks/v1beta1"
 	"github.com/upbound/provider-aws/v2/internal/clients"
+	"github.com/upbound/provider-aws/v2/internal/features"
 )
 
 const (
@@ -46,9 +48,43 @@ func SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return nil
 }
 
+// supportedManagementPolicies lists the management policy sets ClusterAuth
+// can honour. The resource mints a short-lived token in Create and can only
+// refresh it in Update, so every explicit set must include both actions.
+// LateInitialize and Delete are no-ops for this resource.
+func supportedManagementPolicies() []sets.Set[xpv2.ManagementAction] {
+	return []sets.Set[xpv2.ManagementAction]{
+		sets.New(xpv2.ManagementActionAll),
+		sets.New[xpv2.ManagementAction](),
+		sets.New(xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate),
+		sets.New(xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate, xpv2.ManagementActionLateInitialize),
+		sets.New(xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate, xpv2.ManagementActionDelete),
+		sets.New(xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate, xpv2.ManagementActionLateInitialize, xpv2.ManagementActionDelete),
+	}
+}
+
 // Setup adds a controller that reconciles ClusterAuth.
 func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	name := managed.ControllerName(v1beta1.ClusterAuth_GroupKind)
+
+	opts := []managed.ReconcilerOption{
+		managed.WithExternalConnector(&connector{
+			kube:               mgr.GetClient(),
+			newEKSClientFn:     eks.NewFromConfig,
+			newPresignClientFn: newPresignClient,
+		}),
+		// We use a constant poll interval here to make sure we get a chance
+		// to refresh the token before it expires.
+		managed.WithPollInterval(time.Minute * 1),
+		managed.WithLogger(o.Logger.WithValues("controller", name)),
+		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
+	}
+	if o.Features.Enabled(features.EnableBetaManagementPolicies) {
+		opts = append(opts,
+			managed.WithManagementPolicies(),
+			managed.WithReconcilerSupportedManagementPolicies(supportedManagementPolicies()),
+		)
+	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -56,16 +92,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		For(&v1beta1.ClusterAuth{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.ClusterAuth_GroupVersionKind),
-			managed.WithExternalConnector(&connector{
-				kube:               mgr.GetClient(),
-				newEKSClientFn:     eks.NewFromConfig,
-				newPresignClientFn: newPresignClient,
-			}),
-			// We use a constant poll interval here to make sure we get a chance
-			// to refresh the token before it expires.
-			managed.WithPollInterval(time.Minute*1),
-			managed.WithLogger(o.Logger.WithValues("controller", name)),
-			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
+			opts...))
 }
 
 // SetupGated adds a controller that reconciles ClusterAuth.

--- a/internal/controller/cluster/eks/clusterauth/controller_test.go
+++ b/internal/controller/cluster/eks/clusterauth/controller_test.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterauth
+
+import (
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSupportedManagementPolicies(t *testing.T) {
+	type args struct {
+		policies xpv2.ManagementPolicies
+	}
+	type want struct {
+		supported bool
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"Wildcard": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionAll}},
+			want: want{supported: true},
+		},
+		"Paused": {
+			args: args{policies: xpv2.ManagementPolicies{}},
+			want: want{supported: true},
+		},
+		"ObserveCreateUpdate": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate}},
+			want: want{supported: true},
+		},
+		"ObserveCreateUpdateLateInitialize": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate, xpv2.ManagementActionLateInitialize}},
+			want: want{supported: true},
+		},
+		"ObserveCreateUpdateDelete": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate, xpv2.ManagementActionDelete}},
+			want: want{supported: true},
+		},
+		"AllActionsExplicit": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate, xpv2.ManagementActionLateInitialize, xpv2.ManagementActionDelete}},
+			want: want{supported: true},
+		},
+		"ObserveOnlyCannotMintToken": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve}},
+			want: want{supported: false},
+		},
+		"ObserveCreateCannotRefreshToken": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionCreate}},
+			want: want{supported: false},
+		},
+		"ObserveCreateLateInitializeCannotRefreshToken": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionLateInitialize}},
+			want: want{supported: false},
+		},
+		"ObserveCreateDeleteCannotRefreshToken": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionDelete}},
+			want: want{supported: false},
+		},
+		"ObserveUpdateCannotMintToken": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionUpdate}},
+			want: want{supported: false},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			resolver := managed.NewManagementPoliciesResolver(true, tc.args.policies, managed.WithSupportedManagementPolicies(supportedManagementPolicies()))
+			got := resolver.Validate() == nil
+			if diff := cmp.Diff(tc.want.supported, got); diff != "" {
+				t.Errorf("Validate() supported: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/internal/controller/namespaced/eks/clusterauth/controller.go
+++ b/internal/controller/namespaced/eks/clusterauth/controller.go
@@ -18,6 +18,7 @@ import (
 	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -26,6 +27,7 @@ import (
 
 	"github.com/upbound/provider-aws/v2/apis/namespaced/eks/v1beta1"
 	"github.com/upbound/provider-aws/v2/internal/clients"
+	"github.com/upbound/provider-aws/v2/internal/features"
 )
 
 const (
@@ -46,9 +48,43 @@ func SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return nil
 }
 
+// supportedManagementPolicies lists the management policy sets ClusterAuth
+// can honour. The resource mints a short-lived token in Create and can only
+// refresh it in Update, so every explicit set must include both actions.
+// LateInitialize and Delete are no-ops for this resource.
+func supportedManagementPolicies() []sets.Set[xpv2.ManagementAction] {
+	return []sets.Set[xpv2.ManagementAction]{
+		sets.New(xpv2.ManagementActionAll),
+		sets.New[xpv2.ManagementAction](),
+		sets.New(xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate),
+		sets.New(xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate, xpv2.ManagementActionLateInitialize),
+		sets.New(xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate, xpv2.ManagementActionDelete),
+		sets.New(xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate, xpv2.ManagementActionLateInitialize, xpv2.ManagementActionDelete),
+	}
+}
+
 // Setup adds a controller that reconciles ClusterAuth.
 func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	name := managed.ControllerName(v1beta1.ClusterAuth_GroupKind)
+
+	opts := []managed.ReconcilerOption{
+		managed.WithExternalConnector(&connector{
+			kube:               mgr.GetClient(),
+			newEKSClientFn:     eks.NewFromConfig,
+			newPresignClientFn: newPresignClient,
+		}),
+		// We use a constant poll interval here to make sure we get a chance
+		// to refresh the token before it expires.
+		managed.WithPollInterval(time.Minute * 1),
+		managed.WithLogger(o.Logger.WithValues("controller", name)),
+		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
+	}
+	if o.Features.Enabled(features.EnableBetaManagementPolicies) {
+		opts = append(opts,
+			managed.WithManagementPolicies(),
+			managed.WithReconcilerSupportedManagementPolicies(supportedManagementPolicies()),
+		)
+	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(name).
@@ -56,16 +92,7 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 		For(&v1beta1.ClusterAuth{}).
 		Complete(managed.NewReconciler(mgr,
 			resource.ManagedKind(v1beta1.ClusterAuth_GroupVersionKind),
-			managed.WithExternalConnector(&connector{
-				kube:               mgr.GetClient(),
-				newEKSClientFn:     eks.NewFromConfig,
-				newPresignClientFn: newPresignClient,
-			}),
-			// We use a constant poll interval here to make sure we get a chance
-			// to refresh the token before it expires.
-			managed.WithPollInterval(time.Minute*1),
-			managed.WithLogger(o.Logger.WithValues("controller", name)),
-			managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name)))))
+			opts...))
 }
 
 // SetupGated adds a controller that reconciles ClusterAuth.

--- a/internal/controller/namespaced/eks/clusterauth/controller_test.go
+++ b/internal/controller/namespaced/eks/clusterauth/controller_test.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterauth
+
+import (
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
+	xpv2 "github.com/crossplane/crossplane/apis/v2/core/v2"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSupportedManagementPolicies(t *testing.T) {
+	type args struct {
+		policies xpv2.ManagementPolicies
+	}
+	type want struct {
+		supported bool
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"Wildcard": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionAll}},
+			want: want{supported: true},
+		},
+		"Paused": {
+			args: args{policies: xpv2.ManagementPolicies{}},
+			want: want{supported: true},
+		},
+		"ObserveCreateUpdate": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate}},
+			want: want{supported: true},
+		},
+		"ObserveCreateUpdateLateInitialize": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate, xpv2.ManagementActionLateInitialize}},
+			want: want{supported: true},
+		},
+		"ObserveCreateUpdateDelete": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate, xpv2.ManagementActionDelete}},
+			want: want{supported: true},
+		},
+		"AllActionsExplicit": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionUpdate, xpv2.ManagementActionLateInitialize, xpv2.ManagementActionDelete}},
+			want: want{supported: true},
+		},
+		"ObserveOnlyCannotMintToken": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve}},
+			want: want{supported: false},
+		},
+		"ObserveCreateCannotRefreshToken": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionCreate}},
+			want: want{supported: false},
+		},
+		"ObserveCreateLateInitializeCannotRefreshToken": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionLateInitialize}},
+			want: want{supported: false},
+		},
+		"ObserveCreateDeleteCannotRefreshToken": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionCreate, xpv2.ManagementActionDelete}},
+			want: want{supported: false},
+		},
+		"ObserveUpdateCannotMintToken": {
+			args: args{policies: xpv2.ManagementPolicies{xpv2.ManagementActionObserve, xpv2.ManagementActionUpdate}},
+			want: want{supported: false},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			resolver := managed.NewManagementPoliciesResolver(true, tc.args.policies, managed.WithSupportedManagementPolicies(supportedManagementPolicies()))
+			got := resolver.Validate() == nil
+			if diff := cmp.Diff(tc.want.supported, got); diff != "" {
+				t.Errorf("Validate() supported: -want, +got:\n%s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description of your changes
Adds support in ClusterAuth for all managementPolicies sets that contain Create, Update and Observe which are required for  the controller to work. LateInitialize and Delete are now optional

Fixes #1908

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [X] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested
Added unit tests

[contribution process]: https://git.io/fj2m9
