### PR TITLE
fix(cloudfront): map origin request policy by id, not name

### DIFF
--- a/apis/cluster/cloudfront/v1beta2/zz_generated.deepcopy.go
+++ b/apis/cluster/cloudfront/v1beta2/zz_generated.deepcopy.go
@@ -6851,6 +6851,11 @@ func (in *OriginRequestPolicyInitParameters) DeepCopyInto(out *OriginRequestPoli
 		*out = new(OriginRequestPolicyHeadersConfigInitParameters)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
+	}
 	if in.QueryStringsConfig != nil {
 		in, out := &in.QueryStringsConfig, &out.QueryStringsConfig
 		*out = new(OriginRequestPolicyQueryStringsConfigInitParameters)
@@ -6933,6 +6938,11 @@ func (in *OriginRequestPolicyObservation) DeepCopyInto(out *OriginRequestPolicyO
 		*out = new(string)
 		**out = **in
 	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
+	}
 	if in.QueryStringsConfig != nil {
 		in, out := &in.QueryStringsConfig, &out.QueryStringsConfig
 		*out = new(OriginRequestPolicyQueryStringsConfigObservation)
@@ -6967,6 +6977,11 @@ func (in *OriginRequestPolicyParameters) DeepCopyInto(out *OriginRequestPolicyPa
 		in, out := &in.HeadersConfig, &out.HeadersConfig
 		*out = new(OriginRequestPolicyHeadersConfigParameters)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
 	}
 	if in.QueryStringsConfig != nil {
 		in, out := &in.QueryStringsConfig, &out.QueryStringsConfig

--- a/apis/cluster/cloudfront/v1beta2/zz_originrequestpolicy_types.go
+++ b/apis/cluster/cloudfront/v1beta2/zz_originrequestpolicy_types.go
@@ -104,6 +104,9 @@ type OriginRequestPolicyInitParameters struct {
 	// Object that determines whether any HTTP headers (and if so, which headers) are included in the origin request key and automatically included in requests that CloudFront sends to the origin. See Headers Config for more information.
 	HeadersConfig *OriginRequestPolicyHeadersConfigInitParameters `json:"headersConfig,omitempty" tf:"headers_config,omitempty"`
 
+	// Unique name to identify the origin request policy.
+	Name *string `json:"name,omitempty" tf:"name,omitempty"`
+
 	// Object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the origin request key and automatically included in requests that CloudFront sends to the origin. See Query String Config for more information.
 	QueryStringsConfig *OriginRequestPolicyQueryStringsConfigInitParameters `json:"queryStringsConfig,omitempty" tf:"query_strings_config,omitempty"`
 }
@@ -128,6 +131,9 @@ type OriginRequestPolicyObservation struct {
 	// The identifier for the origin request policy.
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
+	// Unique name to identify the origin request policy.
+	Name *string `json:"name,omitempty" tf:"name,omitempty"`
+
 	// Object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the origin request key and automatically included in requests that CloudFront sends to the origin. See Query String Config for more information.
 	QueryStringsConfig *OriginRequestPolicyQueryStringsConfigObservation `json:"queryStringsConfig,omitempty" tf:"query_strings_config,omitempty"`
 }
@@ -145,6 +151,10 @@ type OriginRequestPolicyParameters struct {
 	// Object that determines whether any HTTP headers (and if so, which headers) are included in the origin request key and automatically included in requests that CloudFront sends to the origin. See Headers Config for more information.
 	// +kubebuilder:validation:Optional
 	HeadersConfig *OriginRequestPolicyHeadersConfigParameters `json:"headersConfig,omitempty" tf:"headers_config,omitempty"`
+
+	// Unique name to identify the origin request policy.
+	// +kubebuilder:validation:Optional
+	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// Object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the origin request key and automatically included in requests that CloudFront sends to the origin. See Query String Config for more information.
 	// +kubebuilder:validation:Optional
@@ -229,6 +239,7 @@ type OriginRequestPolicy struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.cookiesConfig) || (has(self.initProvider) && has(self.initProvider.cookiesConfig))",message="spec.forProvider.cookiesConfig is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.headersConfig) || (has(self.initProvider) && has(self.initProvider.headersConfig))",message="spec.forProvider.headersConfig is a required parameter"
+	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.name) || (has(self.initProvider) && has(self.initProvider.name))",message="spec.forProvider.name is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.queryStringsConfig) || (has(self.initProvider) && has(self.initProvider.queryStringsConfig))",message="spec.forProvider.queryStringsConfig is a required parameter"
 	Spec   OriginRequestPolicySpec   `json:"spec"`
 	Status OriginRequestPolicyStatus `json:"status,omitempty"`

--- a/apis/namespaced/cloudfront/v1beta1/zz_generated.deepcopy.go
+++ b/apis/namespaced/cloudfront/v1beta1/zz_generated.deepcopy.go
@@ -7813,6 +7813,11 @@ func (in *OriginRequestPolicyInitParameters) DeepCopyInto(out *OriginRequestPoli
 		*out = new(OriginRequestPolicyHeadersConfigInitParameters)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
+	}
 	if in.QueryStringsConfig != nil {
 		in, out := &in.QueryStringsConfig, &out.QueryStringsConfig
 		*out = new(OriginRequestPolicyQueryStringsConfigInitParameters)
@@ -7895,6 +7900,11 @@ func (in *OriginRequestPolicyObservation) DeepCopyInto(out *OriginRequestPolicyO
 		*out = new(string)
 		**out = **in
 	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
+	}
 	if in.QueryStringsConfig != nil {
 		in, out := &in.QueryStringsConfig, &out.QueryStringsConfig
 		*out = new(OriginRequestPolicyQueryStringsConfigObservation)
@@ -7929,6 +7939,11 @@ func (in *OriginRequestPolicyParameters) DeepCopyInto(out *OriginRequestPolicyPa
 		in, out := &in.HeadersConfig, &out.HeadersConfig
 		*out = new(OriginRequestPolicyHeadersConfigParameters)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.Name != nil {
+		in, out := &in.Name, &out.Name
+		*out = new(string)
+		**out = **in
 	}
 	if in.QueryStringsConfig != nil {
 		in, out := &in.QueryStringsConfig, &out.QueryStringsConfig

--- a/apis/namespaced/cloudfront/v1beta1/zz_originrequestpolicy_types.go
+++ b/apis/namespaced/cloudfront/v1beta1/zz_originrequestpolicy_types.go
@@ -104,6 +104,9 @@ type OriginRequestPolicyInitParameters struct {
 	// Object that determines whether any HTTP headers (and if so, which headers) are included in the origin request key and automatically included in requests that CloudFront sends to the origin. See Headers Config for more information.
 	HeadersConfig *OriginRequestPolicyHeadersConfigInitParameters `json:"headersConfig,omitempty" tf:"headers_config,omitempty"`
 
+	// Unique name to identify the origin request policy.
+	Name *string `json:"name,omitempty" tf:"name,omitempty"`
+
 	// Object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the origin request key and automatically included in requests that CloudFront sends to the origin. See Query String Config for more information.
 	QueryStringsConfig *OriginRequestPolicyQueryStringsConfigInitParameters `json:"queryStringsConfig,omitempty" tf:"query_strings_config,omitempty"`
 }
@@ -128,6 +131,9 @@ type OriginRequestPolicyObservation struct {
 	// The identifier for the origin request policy.
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
+	// Unique name to identify the origin request policy.
+	Name *string `json:"name,omitempty" tf:"name,omitempty"`
+
 	// Object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the origin request key and automatically included in requests that CloudFront sends to the origin. See Query String Config for more information.
 	QueryStringsConfig *OriginRequestPolicyQueryStringsConfigObservation `json:"queryStringsConfig,omitempty" tf:"query_strings_config,omitempty"`
 }
@@ -145,6 +151,10 @@ type OriginRequestPolicyParameters struct {
 	// Object that determines whether any HTTP headers (and if so, which headers) are included in the origin request key and automatically included in requests that CloudFront sends to the origin. See Headers Config for more information.
 	// +kubebuilder:validation:Optional
 	HeadersConfig *OriginRequestPolicyHeadersConfigParameters `json:"headersConfig,omitempty" tf:"headers_config,omitempty"`
+
+	// Unique name to identify the origin request policy.
+	// +kubebuilder:validation:Optional
+	Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
 	// Object that determines whether any URL query strings in viewer requests (and if so, which query strings) are included in the origin request key and automatically included in requests that CloudFront sends to the origin. See Query String Config for more information.
 	// +kubebuilder:validation:Optional
@@ -229,6 +239,7 @@ type OriginRequestPolicy struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.cookiesConfig) || (has(self.initProvider) && has(self.initProvider.cookiesConfig))",message="spec.forProvider.cookiesConfig is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.headersConfig) || (has(self.initProvider) && has(self.initProvider.headersConfig))",message="spec.forProvider.headersConfig is a required parameter"
+	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.name) || (has(self.initProvider) && has(self.initProvider.name))",message="spec.forProvider.name is a required parameter"
 	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.queryStringsConfig) || (has(self.initProvider) && has(self.initProvider.queryStringsConfig))",message="spec.forProvider.queryStringsConfig is a required parameter"
 	Spec   OriginRequestPolicySpec   `json:"spec"`
 	Status OriginRequestPolicyStatus `json:"status,omitempty"`

--- a/config/externalname.go
+++ b/config/externalname.go
@@ -641,8 +641,8 @@ var TerraformPluginSDKExternalNameConfigs = map[string]config.ExternalName{
 	"aws_cloudfront_origin_access_control": config.IdentifierFromProvider,
 	// Cloudfront Origin Access Identities can be imported using the id
 	"aws_cloudfront_origin_access_identity": config.IdentifierFromProvider,
-	// No import documented, but https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudfront_origin_request_policy#name
-	"aws_cloudfront_origin_request_policy": config.NameAsIdentifier,
+	// Cloudfront Origin Request Policies can be imported using the id
+	"aws_cloudfront_origin_request_policy": config.IdentifierFromProvider,
 	// CloudFront Public Key can be imported using the id
 	"aws_cloudfront_public_key": config.IdentifierFromProvider,
 	// CloudFront real-time log configurations can be imported using the ARN,

--- a/examples-generated/cluster/cloudfront/v1beta2/originrequestpolicy.yaml
+++ b/examples-generated/cluster/cloudfront/v1beta2/originrequestpolicy.yaml
@@ -24,6 +24,7 @@ spec:
       headers:
         items:
         - example
+    name: example-policy
     queryStringsConfig:
       queryStringBehavior: whitelist
       queryStrings:

--- a/examples-generated/namespaced/cloudfront/v1beta1/originrequestpolicy.yaml
+++ b/examples-generated/namespaced/cloudfront/v1beta1/originrequestpolicy.yaml
@@ -25,6 +25,7 @@ spec:
       headers:
         items:
         - example
+    name: example-policy
     queryStringsConfig:
       queryStringBehavior: whitelist
       queryStrings:

--- a/internal/controller/cluster/cloudfront/originrequestpolicy/zz_controller.go
+++ b/internal/controller/cluster/cloudfront/originrequestpolicy/zz_controller.go
@@ -50,7 +50,6 @@ func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	name := managed.ControllerName(v1beta2.OriginRequestPolicy_GroupVersionKind.String())
 	var initializers managed.InitializerChain
-	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	rl := reconciliationpolicy.NewExponentialFailureRateLimiter(time.Second, 60*time.Second)
 	eventHandler := handler.NewEventHandler(handler.WithDefaultRateLimiter(rl), handler.WithLogger(o.Logger.WithValues("gvk", v1beta2.OriginRequestPolicy_GroupVersionKind)))
 	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind(v1beta2.OriginRequestPolicy_GroupVersionKind), tjcontroller.WithEventHandler(eventHandler), tjcontroller.WithStatusUpdates(false))

--- a/internal/controller/namespaced/cloudfront/originrequestpolicy/zz_controller.go
+++ b/internal/controller/namespaced/cloudfront/originrequestpolicy/zz_controller.go
@@ -50,7 +50,6 @@ func SetupGated(mgr ctrl.Manager, o tjcontroller.Options) error {
 func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	name := managed.ControllerName(v1beta1.OriginRequestPolicy_GroupVersionKind.String())
 	var initializers managed.InitializerChain
-	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	rl := reconciliationpolicy.NewExponentialFailureRateLimiter(time.Second, 60*time.Second)
 	eventHandler := handler.NewEventHandler(handler.WithDefaultRateLimiter(rl), handler.WithLogger(o.Logger.WithValues("gvk", v1beta1.OriginRequestPolicy_GroupVersionKind)))
 	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind(v1beta1.OriginRequestPolicy_GroupVersionKind), tjcontroller.WithEventHandler(eventHandler), tjcontroller.WithStatusUpdates(false))

--- a/package/crds/cloudfront.aws.m.upbound.io_originrequestpolicies.yaml
+++ b/package/crds/cloudfront.aws.m.upbound.io_originrequestpolicies.yaml
@@ -97,6 +97,9 @@ spec:
                             x-kubernetes-list-type: set
                         type: object
                     type: object
+                  name:
+                    description: Unique name to identify the origin request policy.
+                    type: string
                   queryStringsConfig:
                     description: Object that determines whether any URL query strings
                       in viewer requests (and if so, which query strings) are included
@@ -166,6 +169,9 @@ spec:
                             x-kubernetes-list-type: set
                         type: object
                     type: object
+                  name:
+                    description: Unique name to identify the origin request policy.
+                    type: string
                   queryStringsConfig:
                     description: Object that determines whether any URL query strings
                       in viewer requests (and if so, which query strings) are included
@@ -252,6 +258,10 @@ spec:
               rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                 || ''Update'' in self.managementPolicies) || has(self.forProvider.headersConfig)
                 || (has(self.initProvider) && has(self.initProvider.headersConfig))'
+            - message: spec.forProvider.name is a required parameter
+              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
+                || ''Update'' in self.managementPolicies) || has(self.forProvider.name)
+                || (has(self.initProvider) && has(self.initProvider.name))'
             - message: spec.forProvider.queryStringsConfig is a required parameter
               rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                 || ''Update'' in self.managementPolicies) || has(self.forProvider.queryStringsConfig)
@@ -306,6 +316,9 @@ spec:
                     type: object
                   id:
                     description: The identifier for the origin request policy.
+                    type: string
+                  name:
+                    description: Unique name to identify the origin request policy.
                     type: string
                   queryStringsConfig:
                     description: Object that determines whether any URL query strings

--- a/package/crds/cloudfront.aws.upbound.io_originrequestpolicies.yaml
+++ b/package/crds/cloudfront.aws.upbound.io_originrequestpolicies.yaml
@@ -567,6 +567,9 @@ spec:
                             x-kubernetes-list-type: set
                         type: object
                     type: object
+                  name:
+                    description: Unique name to identify the origin request policy.
+                    type: string
                   queryStringsConfig:
                     description: Object that determines whether any URL query strings
                       in viewer requests (and if so, which query strings) are included
@@ -636,6 +639,9 @@ spec:
                             x-kubernetes-list-type: set
                         type: object
                     type: object
+                  name:
+                    description: Unique name to identify the origin request policy.
+                    type: string
                   queryStringsConfig:
                     description: Object that determines whether any URL query strings
                       in viewer requests (and if so, which query strings) are included
@@ -750,6 +756,10 @@ spec:
               rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                 || ''Update'' in self.managementPolicies) || has(self.forProvider.headersConfig)
                 || (has(self.initProvider) && has(self.initProvider.headersConfig))'
+            - message: spec.forProvider.name is a required parameter
+              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
+                || ''Update'' in self.managementPolicies) || has(self.forProvider.name)
+                || (has(self.initProvider) && has(self.initProvider.name))'
             - message: spec.forProvider.queryStringsConfig is a required parameter
               rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
                 || ''Update'' in self.managementPolicies) || has(self.forProvider.queryStringsConfig)
@@ -804,6 +814,9 @@ spec:
                     type: object
                   id:
                     description: The identifier for the origin request policy.
+                    type: string
+                  name:
+                    description: Unique name to identify the origin request policy.
                     type: string
                   queryStringsConfig:
                     description: Object that determines whether any URL query strings


### PR DESCRIPTION
### Description of your changes

`aws_cloudfront_origin_request_policy` is mapped as `NameAsIdentifier`, but Terraform imports this resource by id. `NameAsIdentifier` drops `name` from the CRD and uses the external name as the Terraform id, so the policy can only ever be addressed by a name that the CloudFront API cannot look up. The resource is therefore never observed: every reconcile tries to create it, which 409s once the name exists and otherwise leaves a stray policy behind.

Switching it to `IdentifierFromProvider` matches `aws_cloudfront_cache_policy`, `aws_cloudfront_response_headers_policy` and `aws_cloudfront_origin_access_control`, which all already work this way.

Full analysis, reproduction and error output are in the issue.

Fixes #2226

Two commits: the config change, then `make generate`. The generated diff is small and entirely confined to this resource — `name` and `name_prefix` return to `spec.forProvider`, the CRDs gain a CEL rule requiring `name` when Create or Update is in `managementPolicies`, and `managed.NewNameAsExternalName` drops out of both controllers.

### One thing I would like input on

This changes external-name semantics for existing users. The external name becomes the policy id rather than its name, so existing resources need theirs updated or they will be seen as absent and recreated. I am glad to add a migration note wherever you would like it, or to approach the transition differently if you would prefer.

### How has this code been tested

`make generate` and `make check-diff` both run clean locally (`branch is clean`).

The bug was reproduced on provider-aws-cloudfront v2.5.3 with Crossplane v2.1.4: an `OriginRequestPolicy` whose policy already existed in the account never reached `Ready`, retrying `CreateOriginRequestPolicy` and getting `OriginRequestPolicyAlreadyExists` each time. Setting the external name to the policy id made it reconcile immediately, which is the behaviour this change makes the default.

Not yet exercised through uptest.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit).
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

[contribution process]: https://git.io/fj2m9
